### PR TITLE
[Task #10] Add shared_preferences Dependency

### DIFF
--- a/fittrack/pubspec.lock
+++ b/fittrack/pubspec.lock
@@ -743,6 +743,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "0b0f98d535319cb5cdd4f65783c2a54ee6d417a2f093dbb18be3e36e4c3d181f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.14"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:
@@ -1053,5 +1109,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   # Utilities
   intl: ^0.20.2
   uuid: ^4.2.1
+  shared_preferences: ^2.2.2
   
   # Export functionality
   csv: ^6.0.0


### PR DESCRIPTION
## Summary
- Added `shared_preferences ^2.2.2` dependency to enable theme persistence
- Foundation for ThemeProvider implementation
- No breaking changes

## Test Plan
- ✓ Dependency added to pubspec.yaml
- ⏳ Will run `flutter pub get` via GitHub Actions
- ⏳ All tests pass (verified by GitHub Actions)

## Related Issues
Closes #10
Part of #1 (Dark Mode Support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)