### PR TITLE
[Task #11] Create ThemeProvider

### DIFF
--- a/fittrack/lib/providers/theme_provider.dart
+++ b/fittrack/lib/providers/theme_provider.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  static const String _themeModeKey = 'theme_mode';
+
+  final SharedPreferences _prefs;
+  ThemeMode _currentThemeMode = ThemeMode.system;
+
+  ThemeProvider(this._prefs) {
+    _loadThemeMode();
+  }
+
+  ThemeMode get currentThemeMode => _currentThemeMode;
+
+  Future<void> setThemeMode(ThemeMode mode) async {
+    if (_currentThemeMode == mode) return;
+
+    _currentThemeMode = mode;
+    await _prefs.setString(_themeModeKey, mode.name);
+    notifyListeners();
+  }
+
+  Future<void> _loadThemeMode() async {
+    final String? savedMode = _prefs.getString(_themeModeKey);
+
+    if (savedMode != null) {
+      switch (savedMode) {
+        case 'light':
+          _currentThemeMode = ThemeMode.light;
+          break;
+        case 'dark':
+          _currentThemeMode = ThemeMode.dark;
+          break;
+        case 'system':
+        default:
+          _currentThemeMode = ThemeMode.system;
+          break;
+      }
+    } else {
+      _currentThemeMode = ThemeMode.system;
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> loadThemeMode() async {
+    await _loadThemeMode();
+  }
+}


### PR DESCRIPTION
## Summary
- Created ThemeProvider using ChangeNotifier pattern
- Manages theme mode state (light, dark, system)
- Persists preferences with SharedPreferences
- Defaults to ThemeMode.system
- Follows AuthProvider pattern for consistency

## Implementation Details
- `currentThemeMode` getter exposes current theme
- `setThemeMode()` updates and persists theme preference
- `loadThemeMode()` loads saved preference on init
- Notifies listeners on theme changes for reactive UI

## Test Plan
- ⏳ Unit tests in next PR (#16)
- ⏳ All tests pass (verified by GitHub Actions)

## Related Issues
Closes #11
Part of #1 (Dark Mode Support)
Depends on #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)