### PR TITLE
[Task #12] Integrate ThemeProvider in main.dart

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -4,28 +4,30 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'firebase_options.dart';
 import 'providers/auth_provider.dart' as app_auth;
 import 'providers/program_provider.dart';
+import 'providers/theme_provider.dart';
 import 'screens/auth/auth_wrapper.dart';
 import 'services/firestore_service.dart';
 import 'services/notification_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  
+
   // Initialize Firebase
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  
+
   // Configure emulators in debug mode
   if (kDebugMode) {
     FirebaseAuth.instance.useAuthEmulator('127.0.0.1', 9099);
     FirebaseFirestore.instance.useFirestoreEmulator('127.0.0.1', 8080);
   }
-  
+
   // Enable Firestore offline persistence (spec requirement from Section 11)
   try {
     await FirestoreService.enableOfflinePersistence();
@@ -33,20 +35,26 @@ void main() async {
     // Offline persistence may fail if already enabled
     debugPrint('Firestore offline persistence: $e');
   }
-  
+
   // Initialize notifications
   await NotificationService.instance.initialize();
-  
-  runApp(const FitTrackApp());
+
+  // Initialize SharedPreferences
+  final prefs = await SharedPreferences.getInstance();
+
+  runApp(FitTrackApp(prefs: prefs));
 }
 
 class FitTrackApp extends StatelessWidget {
-  const FitTrackApp({super.key});
+  final SharedPreferences prefs;
+
+  const FitTrackApp({super.key, required this.prefs});
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (_) => ThemeProvider(prefs)),
         ChangeNotifierProvider(create: (_) => app_auth.AuthProvider()),
         ChangeNotifierProxyProvider<app_auth.AuthProvider, ProgramProvider>(
           create: (_) => ProgramProvider(null),
@@ -54,32 +62,37 @@ class FitTrackApp extends StatelessWidget {
               ProgramProvider(authProvider.user?.uid),
         ),
       ],
-      child: MaterialApp(
-        title: 'FitTrack',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFF2196F3),
-            brightness: Brightness.light,
-          ),
-          useMaterial3: true,
-          appBarTheme: const AppBarTheme(
-            centerTitle: true,
-            elevation: 0,
-          ),
-        ),
-        darkTheme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: const Color(0xFF2196F3),
-            brightness: Brightness.dark,
-          ),
-          useMaterial3: true,
-          appBarTheme: const AppBarTheme(
-            centerTitle: true,
-            elevation: 0,
-          ),
-        ),
-        home: const AuthWrapper(),
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return MaterialApp(
+            title: 'FitTrack',
+            debugShowCheckedModeBanner: false,
+            themeMode: themeProvider.currentThemeMode,
+            theme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFF2196F3),
+                brightness: Brightness.light,
+              ),
+              useMaterial3: true,
+              appBarTheme: const AppBarTheme(
+                centerTitle: true,
+                elevation: 0,
+              ),
+            ),
+            darkTheme: ThemeData(
+              colorScheme: ColorScheme.fromSeed(
+                seedColor: const Color(0xFF2196F3),
+                brightness: Brightness.dark,
+              ),
+              useMaterial3: true,
+              appBarTheme: const AppBarTheme(
+                centerTitle: true,
+                elevation: 0,
+              ),
+            ),
+            home: const AuthWrapper(),
+          );
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Initialized SharedPreferences before runApp()
- Added ThemeProvider to MultiProvider
- Wrapped MaterialApp in Consumer<ThemeProvider>
- Bound themeMode to provider state
- Theme now persists across app restarts

## Implementation Details
**Changes to main.dart:**
- Import shared_preferences and theme_provider
- Initialize SharedPreferences in main() before runApp()
- Pass prefs instance to FitTrackApp
- Add ThemeProvider as first provider in MultiProvider
- Consumer<ThemeProvider> wraps MaterialApp
- MaterialApp.themeMode bound to currentThemeMode

## Test Plan
- ✓ App builds without errors
- ✓ Theme persists across restarts (tested manually)
- ⏳ All tests pass (verified by GitHub Actions)

## Related Issues
Closes #12
Part of #1 (Dark Mode Support)
Depends on #10, #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)