### PR TITLE
[Task #13 & #14] Create Settings Screen UI and Wire Navigation

### DIFF
--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
+import 'settings_screen.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -85,7 +86,12 @@ class ProfileScreen extends StatelessWidget {
                 icon: Icons.settings_outlined,
                 title: 'Settings',
                 onTap: () {
-                  // TODO: Navigate to settings
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const SettingsScreen(),
+                    ),
+                  );
                 },
               ),
               _MenuItem(

--- a/fittrack/lib/screens/profile/settings_screen.dart
+++ b/fittrack/lib/screens/profile/settings_screen.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/theme_provider.dart';
+
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+        elevation: 0,
+      ),
+      body: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return ListView(
+            children: [
+              // Appearance Section
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Text(
+                  'Appearance',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              // ignore: deprecated_member_use
+              RadioListTile<ThemeMode>(
+                title: const Text('Light'),
+                subtitle: const Text('Always use light theme'),
+                value: ThemeMode.light,
+                // ignore: deprecated_member_use
+                groupValue: themeProvider.currentThemeMode,
+                // ignore: deprecated_member_use
+                onChanged: (ThemeMode? value) {
+                  if (value != null) {
+                    themeProvider.setThemeMode(value);
+                  }
+                },
+              ),
+              // ignore: deprecated_member_use
+              RadioListTile<ThemeMode>(
+                title: const Text('Dark'),
+                subtitle: const Text('Always use dark theme'),
+                value: ThemeMode.dark,
+                // ignore: deprecated_member_use
+                groupValue: themeProvider.currentThemeMode,
+                // ignore: deprecated_member_use
+                onChanged: (ThemeMode? value) {
+                  if (value != null) {
+                    themeProvider.setThemeMode(value);
+                  }
+                },
+              ),
+              // ignore: deprecated_member_use
+              RadioListTile<ThemeMode>(
+                title: const Text('System Default'),
+                subtitle: const Text('Use system theme setting'),
+                value: ThemeMode.system,
+                // ignore: deprecated_member_use
+                groupValue: themeProvider.currentThemeMode,
+                // ignore: deprecated_member_use
+                onChanged: (ThemeMode? value) {
+                  if (value != null) {
+                    themeProvider.setThemeMode(value);
+                  }
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Created SettingsScreen with theme mode selector
- Added navigation from ProfileScreen to SettingsScreen
- Immediate visual feedback on theme selection
- Follows existing UI patterns

## Implementation Details
**SettingsScreen:**
- Three RadioListTile options (Light, Dark, System Default)
- Consumer<ThemeProvider> for reactive updates
- Calls themeProvider.setThemeMode() on selection
- Current selection reflects provider state

**ProfileScreen:**
- Added import for SettingsScreen
- Wired Settings menu item to navigate to SettingsScreen
- Uses Navigator.push() with MaterialPageRoute

## Test Plan
- ✓ Settings screen renders with all options
- ✓ Navigation from Profile works correctly
- ✓ Theme updates immediately on selection
- ⏳ Widget tests in next PR (#17)
- ⏳ All tests pass (verified by GitHub Actions)

## Related Issues
Closes #13
Closes #14
Part of #1 (Dark Mode Support)
Depends on #10, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)