### PR TITLE
fix: Disable localhost emulator config to support physical devices

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -22,11 +19,13 @@ void main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
 
-  // Configure emulators in debug mode
-  if (kDebugMode) {
-    FirebaseAuth.instance.useAuthEmulator('127.0.0.1', 9099);
-    FirebaseFirestore.instance.useFirestoreEmulator('127.0.0.1', 8080);
-  }
+  // Configure emulators ONLY for local development
+  // Note: This should be commented out for physical device testing
+  // Uncomment ONLY when running against local Firebase emulators
+  // if (kDebugMode) {
+  //   FirebaseAuth.instance.useAuthEmulator('127.0.0.1', 9099);
+  //   FirebaseFirestore.instance.useFirestoreEmulator('127.0.0.1', 8080);
+  // }
 
   // Enable Firestore offline persistence (spec requirement from Section 11)
   try {


### PR DESCRIPTION
## Summary
Fixes #30 - App hangs on physical devices due to localhost configuration

This PR disables the Firebase emulator configuration that was causing the app to hang on physical devices. The app was attempting to connect to `127.0.0.1` for Firebase Auth and Firestore, which only works on emulators/simulators but fails on physical devices.

## Changes Made
- ✅ Commented out Firebase emulator configuration in `lib/main.dart`
- ✅ Removed unused imports (`firebase_auth`, `cloud_firestore`, `foundation`)
- ✅ Added clear documentation for when to enable emulator config

## Root Cause
The app was configured with:
```dart
if (kDebugMode) {
  FirebaseAuth.instance.useAuthEmulator('127.0.0.1', 9099);
  FirebaseFirestore.instance.useFirestoreEmulator('127.0.0.1', 8080);
}
```

On physical devices, `127.0.0.1` refers to the device itself, not the development machine, causing connection failures and app hangs.

## Solution
Commented out the emulator configuration. Developers can manually uncomment it when working with local Firebase emulators. For physical device testing, CI/CD, and production, the app now connects to the actual Firebase project.

## Testing Checklist
- [ ] App launches successfully on physical Android device
- [ ] App launches successfully on physical iOS device
- [ ] Firebase Auth works on physical devices
- [ ] Firestore reads/writes work on physical devices
- [ ] No localhost connection attempts in logs
- [ ] Automated tests pass (GitHub Actions)

## Deployment Impact
- **Severity:** Critical bug fix
- **Breaking Changes:** None
- **Migration Required:** None

## Related Issues
- Fixes #30 (Critical bug)
- Parent Feature: #1 (Dark Mode Support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)