### PR TITLE
[Task #58] Update Program Detail Screen - Week Delete

### DIFF
--- a/fittrack/lib/screens/programs/program_detail_screen.dart
+++ b/fittrack/lib/screens/programs/program_detail_screen.dart
@@ -471,19 +471,27 @@ class _WeekCard extends StatelessWidget {
     final programProvider = Provider.of<ProgramProvider>(context, listen: false);
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     final errorColor = Theme.of(context).colorScheme.error;
-    
+
+    // Fetch cascade counts before showing dialog
+    final cascadeCounts = await programProvider.getCascadeDeleteCounts(
+      weekId: week.id,
+    );
+
+    if (!context.mounted) return;
+
     final confirmed = await DeleteConfirmationDialog.show(
       context: context,
       title: 'Delete Week',
-      content: 'This will permanently delete "${week.name}" and all its workouts, '
-               'exercises, and sets. This action cannot be undone.',
+      content: 'Are you sure you want to delete this week?',
+      itemName: week.name,
       deleteButtonText: 'Delete Week',
+      cascadeCounts: cascadeCounts,
     );
 
     if (confirmed == true) {
       try {
         await programProvider.deleteWeekById(week.id);
-        
+
         if (context.mounted) {
           scaffoldMessenger.showSnackBar(
             SnackBar(


### PR DESCRIPTION
## Summary
Integrates cascade delete count functionality into the Program Detail Screen's week delete flow.

## Changes Made
Updated `_deleteWeek()` method in `program_detail_screen.dart` (lines 470-515):
- ✅ Fetch cascade counts before showing dialog using `programProvider.getCascadeDeleteCounts(weekId: week.id)`
- ✅ Add `context.mounted` check after async cascade count fetch
- ✅ Pass `cascadeCounts` and `itemName` parameters to enhanced `DeleteConfirmationDialog`
- ✅ Simplify content message (detailed counts now shown in dialog itself)
- ✅ Keep existing try-catch error handling and success messaging

## Testing

### Automated Tests
- GitHub Actions will run all existing tests (unit, widget, integration)
- Enhanced `DeleteConfirmationDialog` widget tests already cover cascade count display scenarios (13 tests in `test/widgets/delete_confirmation_dialog_test.dart`)

### Manual Testing Notes
Manual testing will be performed after PR approval to verify:
- Cascade counts display correctly in dialog for weeks with various content
- Week name highlighted in dialog
- Success message shows after deletion
- Week disappears from UI after deletion
- Error handling works correctly
- Testing on both Android and iOS (if available)

**Note:** Per CLAUDE.local.md, Flutter has permission issues on Windows development environment, so manual testing will be performed via emulator after merge or by QA team.

## Related Issues
- Closes #58
- Part of #49 (Delete Functionality Feature)

## Dependencies
Requires completed tasks:
- ✅ #54: Cascade Count Model & Service Methods
- ✅ #55: Cascade Count Aggregation in FirestoreService
- ✅ #56: Cascade Count Method in ProgramProvider
- ✅ #57: Enhanced DeleteConfirmationDialog Widget

## Technical Design
[Delete Functionality Fix - Technical Design](../Docs/Technical_Designs/Delete_Functionality_Fix_Technical_Design.md#51-program-detail-screen---week-delete)

## Acceptance Criteria
- ✅ `_deleteWeek()` fetches cascade counts before dialog
- ✅ Enhanced dialog receives `cascadeCounts` and `itemName` parameters
- ✅ Content message simplified
- ✅ Success/error messaging unchanged
- ⏳ All GitHub Actions tests pass (awaiting CI run)
- ⏳ Manual testing passes on both platforms (after approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>