### PR TITLE
Task #116: Add Set Count Stepper to Exercise Creation

### DIFF
--- a/fittrack/lib/providers/program_provider.dart
+++ b/fittrack/lib/providers/program_provider.dart
@@ -734,6 +734,7 @@ class ProgramProvider extends ChangeNotifier {
     required String name,
     required ExerciseType exerciseType,
     String? notes,
+    int setCount = 1, // Default to 1 set if not specified
   }) async {
     if (_userId == null) return null;
 
@@ -742,8 +743,8 @@ class ProgramProvider extends ChangeNotifier {
       notifyListeners();
 
       // Calculate next order index
-      final nextOrderIndex = _exercises.isEmpty 
-          ? 0 
+      final nextOrderIndex = _exercises.isEmpty
+          ? 0
           : _exercises.map((e) => e.orderIndex).reduce((a, b) => a > b ? a : b) + 1;
 
       final exercise = Exercise(
@@ -760,7 +761,11 @@ class ProgramProvider extends ChangeNotifier {
         programId: programId,
       );
 
-      final exerciseId = await _firestoreService.createExercise(exercise);
+      // Create exercise and sets in a batched write
+      final exerciseId = await _firestoreService.createExerciseWithSets(
+        exercise,
+        setCount,
+      );
       return exerciseId;
     } catch (e) {
       _error = 'Failed to create exercise: $e';


### PR DESCRIPTION
## Summary
Implements Task #116: Set count stepper in create exercise flow

Closes #116

## Changes
- ✅ Added set count stepper UI to CreateExerciseScreen
- ✅ Stepper allows selection of 1-10 sets (default: 1)
- ✅ Stepper only shown when creating new exercises (not when editing)
- ✅ Updated `createExercise()` in ProgramProvider to accept `setCount` parameter
- ✅ Created `createExerciseWithSets()` in FirestoreService for batched writes
- ✅ Exercise and all sets created atomically in single Firestore batch
- ✅ Updated tips text to mention set count feature

## UI Features
- Stepper with +/- icon buttons (remove_circle_outline / add_circle_outline)
- Large numeric display showing current count
- Visual styling with primary color theme
- Buttons disabled at min (1) and max (10) limits
- Helper text: "Choose how many sets to create (1-10)"

## Technical Implementation

### Batched Write
```dart
Future<String> createExerciseWithSets(Exercise exercise, int setCount) async {
  final batch = _firestore.batch();
  
  // Create exercise document
  final exerciseRef = ...doc();
  batch.set(exerciseRef, exerciseData);
  
  // Create N sets
  for (int i = 0; i < setCount; i++) {
    final setRef = exerciseRef.collection('sets').doc();
    batch.set(setRef, setData);
  }
  
  await batch.commit();
  return exerciseRef.id;
}
```

### Default Set Values
All sets created with:
- `setNumber`: 1 to N (properly indexed)
- `checked`: false
- `weight`, `reps`, `duration`, `distance`: null (user fills during workout)
- `notes`, `restTime`: null
- All required IDs and timestamps populated

### Backward Compatibility
- `setCount` parameter defaults to 1 if not provided
- Existing code that doesn't specify setCount still works
- Edit mode unaffected (no stepper shown when editing)

## User Flow
1. User opens Create Exercise screen
2. Fills exercise name and selects type
3. Adjusts set count stepper (1-10)
4. Optionally adds notes
5. Taps "CREATE"
6. Exercise + all sets created in Firestore atomically
7. Returns to ConsolidatedWorkoutScreen
8. New exercise visible with all sets displayed

## Testing
- Manual testing required (Windows development environment)
- Verify stepper min/max limits enforced
- Verify batched write creates exercise + N sets
- Verify sets have correct setNumber values (1 to N)
- Verify all sets display in ConsolidatedWorkoutScreen
- Verify edit mode doesn't show stepper
- Test error handling if batch write fails

## Related Issues
- Parent: #53 (Feature: Consolidated Workout Screen)
- Task: #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)