### PR TITLE
[Task] Add initialIndex Parameter to HomeScreen (#107)

### DIFF
--- a/fittrack/lib/screens/home/home_screen.dart
+++ b/fittrack/lib/screens/home/home_screen.dart
@@ -6,20 +6,34 @@ import '../analytics/analytics_screen.dart';
 import '../profile/profile_screen.dart';
 
 class HomeScreen extends StatefulWidget {
-  const HomeScreen({super.key});
+  /// The initial tab index to display when the screen is first shown.
+  ///
+  /// Defaults to 0 (Programs screen). Used by GlobalBottomNavBar to navigate
+  /// to specific sections.
+  ///
+  /// Valid values: 0 (Programs), 1 (Analytics), 2 (Profile)
+  final int initialIndex;
+
+  const HomeScreen({
+    super.key,
+    this.initialIndex = 0,
+  });
 
   @override
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  int _currentIndex = 0;
-  
+  late int _currentIndex;
+
   late final List<Widget> _screens;
-  
+
   @override
   void initState() {
     super.initState();
+    // Use initialIndex from widget, defaulting to 0 if not provided
+    _currentIndex = widget.initialIndex;
+
     _screens = [
       const ProgramsScreen(),
       const AnalyticsScreen(),

--- a/fittrack/test/screens/home/home_screen_test.dart
+++ b/fittrack/test/screens/home/home_screen_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:fittrack/screens/home/home_screen.dart';
+import 'package:fittrack/screens/programs/programs_screen.dart';
+import 'package:fittrack/screens/analytics/analytics_screen.dart';
+import 'package:fittrack/screens/profile/profile_screen.dart';
+import 'package:fittrack/providers/auth_provider.dart';
+import 'package:fittrack/providers/program_provider.dart';
+
+void main() {
+  group('HomeScreen', () {
+    late MockFirebaseAuth mockAuth;
+    late FakeFirebaseFirestore mockFirestore;
+    late MockUser mockUser;
+
+    setUp(() {
+      mockUser = MockUser(
+        isAnonymous: false,
+        uid: 'test-user-id',
+        email: 'test@example.com',
+        displayName: 'Test User',
+      );
+      mockAuth = MockFirebaseAuth(mockUser: mockUser, signedIn: true);
+      mockFirestore = FakeFirebaseFirestore();
+    });
+
+    Widget createTestWidget({int? initialIndex}) {
+      return MultiProvider(
+        providers: [
+          ChangeNotifierProvider(
+            create: (_) => AuthProvider(mockAuth),
+          ),
+          ChangeNotifierProvider(
+            create: (_) => ProgramProvider(mockFirestore, 'test-user-id'),
+          ),
+        ],
+        child: MaterialApp(
+          home: HomeScreen(
+            initialIndex: initialIndex ?? 0,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('displays Programs screen by default (initialIndex = 0)', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Assert - Programs screen should be visible
+      expect(find.byType(ProgramsScreen), findsOneWidget);
+      expect(find.byType(AnalyticsScreen), findsNothing);
+      expect(find.byType(ProfileScreen), findsNothing);
+    });
+
+    testWidgets('displays Programs screen when initialIndex is 0', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget(initialIndex: 0));
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.byType(ProgramsScreen), findsOneWidget);
+
+      // Verify bottom nav highlights Programs
+      final bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 0);
+    });
+
+    testWidgets('displays Analytics screen when initialIndex is 1', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget(initialIndex: 1));
+      await tester.pumpAndSettle();
+
+      // Assert - AnalyticsScreen should be visible (via IndexedStack)
+      // Note: IndexedStack keeps all children in widget tree, so we check the index
+      final bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 1);
+    });
+
+    testWidgets('displays Profile screen when initialIndex is 2', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget(initialIndex: 2));
+      await tester.pumpAndSettle();
+
+      // Assert - ProfileScreen should be visible (via IndexedStack)
+      final bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 2);
+    });
+
+    testWidgets('has all three bottom navigation items', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Assert
+      expect(find.text('Programs'), findsOneWidget);
+      expect(find.text('Analytics'), findsOneWidget);
+      expect(find.text('Profile'), findsOneWidget);
+      expect(find.byIcon(Icons.fitness_center), findsOneWidget);
+      expect(find.byIcon(Icons.analytics), findsOneWidget);
+      expect(find.byIcon(Icons.person), findsOneWidget);
+    });
+
+    testWidgets('can switch between tabs using bottom navigation', (tester) async {
+      // Arrange
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Initial state - Programs
+      var bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 0);
+
+      // Act - Tap Analytics
+      await tester.tap(find.text('Analytics'));
+      await tester.pumpAndSettle();
+
+      // Assert - Analytics selected
+      bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 1);
+
+      // Act - Tap Profile
+      await tester.tap(find.text('Profile'));
+      await tester.pumpAndSettle();
+
+      // Assert - Profile selected
+      bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 2);
+    });
+
+    testWidgets('uses IndexedStack to maintain state across tab switches', (tester) async {
+      // Act
+      await tester.pumpWidget(createTestWidget());
+      await tester.pumpAndSettle();
+
+      // Assert - IndexedStack should be present
+      expect(find.byType(IndexedStack), findsOneWidget);
+
+      // Verify all three screens are children of IndexedStack
+      final indexedStack = tester.widget<IndexedStack>(
+        find.byType(IndexedStack),
+      );
+      expect(indexedStack.children.length, 3);
+    });
+
+    testWidgets('backward compatible when initialIndex is not provided', (tester) async {
+      // Act - Create HomeScreen without initialIndex parameter
+      await tester.pumpWidget(
+        MultiProvider(
+          providers: [
+            ChangeNotifierProvider(
+              create: (_) => AuthProvider(mockAuth),
+            ),
+            ChangeNotifierProvider(
+              create: (_) => ProgramProvider(mockFirestore, 'test-user-id'),
+            ),
+          ],
+          child: MaterialApp(
+            home: HomeScreen(), // No initialIndex parameter
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Assert - Should default to Programs screen (index 0)
+      final bottomNav = tester.widget<BottomNavigationBar>(
+        find.byType(BottomNavigationBar),
+      );
+      expect(bottomNav.currentIndex, 0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds `initialIndex` parameter to HomeScreen to support navigation from GlobalBottomNavBar. This enables the global bottom navigation to open HomeScreen with a specific tab selected.

## Changes

### Modified Files
- `lib/screens/home/home_screen.dart` - Added initialIndex parameter
  - New optional `initialIndex` parameter (defaults to 0 for backward compatibility)
  - Updated `_currentIndex` from hardcoded `int` to `late int`
  - Set `_currentIndex = widget.initialIndex` in `initState()`
  - Added comprehensive documentation

### New Files Created
- `test/screens/home/home_screen_test.dart` - Comprehensive tests for HomeScreen
  - Tests for all three initial index values (0, 1, 2)
  - Backward compatibility test (no parameter provided)
  - Tab switching functionality tests
  - IndexedStack state preservation tests

### Features Implemented
✅ Optional `initialIndex` parameter with default value of 0
✅ Proper initialization of `_currentIndex` from `widget.initialIndex`
✅ Backward compatible - existing code continues to work
✅ Comprehensive test coverage (8 tests)
✅ Documentation explaining valid values and usage

### Technical Details

**Backward Compatibility:**
```dart
// Old code - still works
HomeScreen()

// New code - with initial index
HomeScreen(initialIndex: 1) // Opens Analytics tab
```

**Valid Index Values:**
- 0 = Programs screen (default)
- 1 = Analytics screen
- 2 = Profile screen

**Usage by GlobalBottomNavBar:**
```dart
Navigator.pushAndRemoveUntil(
  context,
  MaterialPageRoute(
    builder: (_) => HomeScreen(initialIndex: section.index),
  ),
  (route) => false,
);
```

## Testing

All tests passing locally:
- ✅ Default initialIndex (0) test
- ✅ Programs screen (index 0) test
- ✅ Analytics screen (index 1) test
- ✅ Profile screen (index 2) test
- ✅ Bottom navigation items test
- ✅ Tab switching test
- ✅ IndexedStack state preservation test
- ✅ Backward compatibility test

## Related Issues

Closes #107
Part of #52

## Dependencies

- This PR must merge BEFORE Task #106 (GlobalBottomNavBar) can work properly
- GlobalBottomNavBar depends on HomeScreen having the initialIndex parameter

## Next Steps

After this PR merges:
1. Merge Task #106 PR (GlobalBottomNavBar widget)
2. Proceed with Task #108 (Add bottom nav to Programs hierarchy)