### PR TITLE
[Task] Add GlobalBottomNavBar to Programs Hierarchy Screens (#108)

### DIFF
--- a/fittrack/lib/screens/programs/program_detail_screen.dart
+++ b/fittrack/lib/screens/programs/program_detail_screen.dart
@@ -3,7 +3,9 @@ import 'package:provider/provider.dart';
 import '../../providers/program_provider.dart';
 import '../../models/program.dart';
 import '../../models/week.dart';
+import '../../models/navigation_section.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import '../weeks/weeks_screen.dart';
 import '../weeks/create_week_screen.dart';
 
@@ -244,6 +246,9 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
       floatingActionButton: FloatingActionButton(
         onPressed: () => _navigateToCreateWeek(context),
         child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.programs,
       ),
     );
   }

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/program_provider.dart';
 import '../../models/program.dart';
+import '../../models/navigation_section.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
 import '../../widgets/error_display.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import 'program_detail_screen.dart';
 import 'create_program_screen.dart';
 
@@ -102,6 +104,9 @@ class ProgramsScreen extends StatelessWidget {
       floatingActionButton: FloatingActionButton(
         onPressed: () => _navigateToCreateProgram(context),
         child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.programs,
       ),
     );
   }

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -4,7 +4,9 @@ import '../../providers/program_provider.dart';
 import '../../models/program.dart';
 import '../../models/week.dart';
 import '../../models/workout.dart';
+import '../../models/navigation_section.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import '../workouts/create_workout_screen.dart';
 import '../workouts/workout_detail_screen.dart';
 
@@ -259,6 +261,9 @@ class _WeeksScreenState extends State<WeeksScreen> {
       floatingActionButton: FloatingActionButton(
         onPressed: () => _navigateToCreateWorkout(context),
         child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.programs,
       ),
     );
   }

--- a/fittrack/lib/screens/workouts/workout_detail_screen.dart
+++ b/fittrack/lib/screens/workouts/workout_detail_screen.dart
@@ -5,7 +5,9 @@ import '../../models/program.dart';
 import '../../models/week.dart';
 import '../../models/workout.dart';
 import '../../models/exercise.dart';
+import '../../models/navigation_section.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import '../exercises/create_exercise_screen.dart';
 import '../exercises/exercise_detail_screen.dart';
 
@@ -140,6 +142,9 @@ class _WorkoutDetailScreenState extends State<WorkoutDetailScreen> {
         onPressed: () => _addExercise(context),
         tooltip: 'Add Exercise',
         child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.programs,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Adds GlobalBottomNavBar to all screens in the Programs navigation hierarchy, providing persistent bottom navigation access from deep within the app.

## Changes

### Modified Files
- `lib/screens/programs/programs_screen.dart` - Added GlobalBottomNavBar
- `lib/screens/programs/program_detail_screen.dart` - Added GlobalBottomNavBar
- `lib/screens/weeks/weeks_screen.dart` - Added GlobalBottomNavBar
- `lib/screens/workouts/workout_detail_screen.dart` - Added GlobalBottomNavBar

### Implementation Details

All screens updated with:
```dart
bottomNavigationBar: const GlobalBottomNavBar(
  currentSection: NavigationSection.programs,
),
```

**Navigation Section:** All screens use `NavigationSection.programs` because they are all part of the Programs navigation hierarchy. This ensures the "Programs" tab is highlighted on the bottom nav bar when users are on any of these screens.

**Screens Covered:**
- ✅ ProgramsScreen (Programs list)
- ✅ ProgramDetailScreen (Weeks within a program)
- ✅ WeeksScreen (Workouts within a week)
- ✅ WorkoutDetailScreen (Exercises within a workout)

**Modal Screens Excluded (as designed):**
- ❌ CreateProgramScreen
- ❌ CreateWeekScreen
- ❌ CreateWorkoutScreen
- ❌ Create ExerciseScreen

## User Experience

Users can now:
- Tap "Analytics" from within a workout to instantly view analytics (clears nav stack)
- Tap "Profile" from program details to access settings
- Tap "Programs" (Home) to return to programs list from anywhere
- Navigate freely without using back button multiple times

## Related Issues

Closes #108
Part of #52

## Next Steps

After this PR merges:
- Task #109: Add GlobalBottomNavBar to Analytics and Profile screens
- Task #110: Adjust content padding if needed