### PR TITLE
[Task] Add GlobalBottomNavBar to Analytics and Profile Screens (#109)

### DIFF
--- a/fittrack/lib/screens/analytics/analytics_screen.dart
+++ b/fittrack/lib/screens/analytics/analytics_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/analytics.dart';
+import '../../models/navigation_section.dart';
 import '../../providers/program_provider.dart';
 import '../../widgets/error_display.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import 'components/activity_heatmap_section.dart';
 import 'components/key_statistics_section.dart';
 import 'components/charts_section.dart';
@@ -158,6 +160,9 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
             ),
           );
         },
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.analytics,
       ),
     );
   }

--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../models/navigation_section.dart';
+import '../../widgets/global_bottom_nav_bar.dart';
 import 'settings_screen.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -124,6 +126,9 @@ class ProfileScreen extends StatelessWidget {
             ],
           );
         },
+      ),
+      bottomNavigationBar: const GlobalBottomNavBar(
+        currentSection: NavigationSection.profile,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Completes UI integration by adding GlobalBottomNavBar to Analytics and Profile screens. All full-page screens now have persistent bottom navigation.

## Changes

### Modified Files
- `lib/screens/analytics/analytics_screen.dart` - Added GlobalBottomNavBar with NavigationSection.analytics
- `lib/screens/profile/profile_screen.dart` - Added GlobalBottomNavBar with NavigationSection.profile

### Implementation Details

**AnalyticsScreen:**
```dart
bottomNavigationBar: const GlobalBottomNavBar(
  currentSection: NavigationSection.analytics,
),
```

**ProfileScreen:**
```dart
bottomNavigationBar: const GlobalBottomNavBar(
  currentSection: NavigationSection.profile,
),
```

### Complete Coverage

✅ **All Full-Page Screens Now Have Bottom Nav:**
- Programs hierarchy (5 screens) - highlight "Programs"
- AnalyticsScreen - highlight "Analytics"  
- ProfileScreen - highlight "Profile"

✅ **Modal Screens Correctly Excluded:**
- Create* screens remain without bottom nav

## User Experience

Complete global navigation now available:
- Users on Analytics can tap "Programs" or "Profile" to switch sections instantly
- Users on Profile can tap "Programs" or "Analytics" without back navigation
- Consistent bottom nav experience across entire app

## Related Issues

Closes #109
Part of #52

## Next Steps

After this PR merges:
- Task #110: Content padding adjustments (manual testing)
- Task #111: Additional integration tests
- Task #112: Documentation updates
- Final PR to main