### PR TITLE
Task #77: Improve loading states and feedback for week duplication

### DIFF
--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -296,38 +296,67 @@ class _WeeksScreenState extends State<WeeksScreen> {
 
   void _handleMenuAction(BuildContext context, String action) async {
     final programProvider = Provider.of<ProgramProvider>(context, listen: false);
-    
+
     switch (action) {
       case 'duplicate':
-        final result = await programProvider.duplicateWeek(
-          programId: widget.program.id,
-          weekId: widget.week.id,
+        final scaffoldMessenger = ScaffoldMessenger.of(context);
+        final errorColor = Theme.of(context).colorScheme.error;
+
+        // Show loading dialog
+        showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (context) => const Center(
+            child: CircularProgressIndicator(),
+          ),
         );
-        
-        if (context.mounted) {
-          if (result != null && result['success'] == true) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Week duplicated successfully!'),
-                behavior: SnackBarBehavior.floating,
-              ),
-            );
-          } else {
-            ScaffoldMessenger.of(context).showSnackBar(
+
+        try {
+          final result = await programProvider.duplicateWeek(
+            programId: widget.program.id,
+            weekId: widget.week.id,
+          );
+
+          if (context.mounted) {
+            Navigator.of(context).pop(); // Dismiss loading dialog
+
+            if (result != null && result['success'] == true) {
+              scaffoldMessenger.showSnackBar(
+                const SnackBar(
+                  content: Text('Week duplicated successfully!'),
+                  behavior: SnackBarBehavior.floating,
+                ),
+              );
+              // Navigate back to program detail screen to see the duplicated week
+              Navigator.of(context).pop();
+            } else {
+              scaffoldMessenger.showSnackBar(
+                SnackBar(
+                  content: Text(programProvider.error ?? 'Failed to duplicate week'),
+                  backgroundColor: errorColor,
+                  behavior: SnackBarBehavior.floating,
+                ),
+              );
+            }
+          }
+        } catch (e) {
+          if (context.mounted) {
+            Navigator.of(context).pop(); // Dismiss loading dialog
+            scaffoldMessenger.showSnackBar(
               SnackBar(
-                content: Text(programProvider.error ?? 'Failed to duplicate week'),
-                backgroundColor: Theme.of(context).colorScheme.error,
+                content: Text('Error duplicating week: $e'),
+                backgroundColor: errorColor,
                 behavior: SnackBarBehavior.floating,
               ),
             );
           }
         }
         break;
-      
+
       case 'edit':
         // TODO: Navigate to edit week screen
         break;
-        
+
       case 'delete':
         _showDeleteDialog(context);
         break;


### PR DESCRIPTION
## Task #77: Improve loading states and feedback for week duplication

**Parent Issue:** #50 (Enhanced Week Duplication with Smart Naming)
**Implementation Task:** #77

### Changes

#### 1. Added Loading Dialog to WeeksScreen
- Show modal loading dialog during duplication operation
- Prevents user interaction with `barrierDismissible: false`
- Displays CircularProgressIndicator centered on screen
- Dismissed automatically when duplication completes

#### 2. Enhanced Error Handling
- Wrapped duplication call in try-catch block
- Catch generic errors and display user-friendly message
- Show error SnackBar with specific error details
- Preserve error color for error messages

#### 3. Improved Navigation Flow
- After successful duplication, navigate back to program detail screen
- User can immediately see the duplicated week in the list
- Better UX than staying on current week detail page
- Success SnackBar shown before navigation

#### 4. Consistent UX Across Screens
- Matches loading/feedback pattern from `program_detail_screen.dart` (Task #76)
- Both week card duplication and AppBar menu duplication have same UX
- Consistent error messaging across all duplication entry points

### Files Modified
- `lib/screens/weeks/weeks_screen.dart`
  - Enhanced `_handleMenuAction()` duplicate case (lines 297-364)
  - Added loading dialog before duplication call
  - Added try-catch error handling
  - Added navigation back to program detail after success

### User Experience Improvements
- Clear visual feedback during long-running operations
- No more "is something happening?" confusion
- Error messages displayed clearly to user
- Immediate visibility of duplicated week in list

### Testing
- Manual testing of duplication from WeeksScreen AppBar menu
- Integration with Tasks #73-76 (smart naming, timestamps, week card menu)
- [ ] Tests will be verified by Testing Agent (no local CI quota)

**Ready for review and merge to feature branch.**