### PR TITLE
[Task #173] Remove unit test from enhanced integration tests job

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -422,7 +422,7 @@ jobs:
       run: |
         cd fittrack
         # Run simplified integration tests
-        flutter test test/screens/enhanced_create_program_screen_test.dart test/models/program_model_validation_test.dart \
+        flutter test test/screens/enhanced_create_program_screen_test.dart \
           --timeout=120s \
           --reporter=github
           


### PR DESCRIPTION
## Summary
Removes `program_model_validation_test.dart` from the enhanced integration tests job since it's already covered by the unit-tests job's glob pattern `test/models/`.

## Why This Matters
- `program_model_validation_test.dart` is a **pure unit test** that only validates model properties
- It has NO Firebase integration or emulator connection
- Running it in "integration tests" job is misleading
- It's already executed correctly in the unit-tests job (line 74)

## Changes
- Removed `test/models/program_model_validation_test.dart` from enhanced integration tests job (line 425)
- Test will now run only in unit-tests job where it belongs

## Impact
- ✅ Correct test classification (unit test runs in unit-tests job)
- ✅ No duplicate test execution
- ✅ Clearer separation between unit and integration tests

## Testing
**Note:** No CI quota available for testing. Changes verified via:
- ✅ Manual code review
- ✅ Confirmed test is covered by `test/models/` glob pattern in unit-tests job
- ✅ Syntax validation

## Related Issues
- Part of #123 (False Pass Integration Tests Fix)
- Closes #173

## Tier 1 Task
This is a **Tier 1 (Critical)** fix - fixes test misclassification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)