### PR TITLE
Fix: Monthly Calendar Navigation Page Offset Bug (#234)

### DIFF
--- a/fittrack/lib/screens/analytics/components/monthly_heatmap_section.dart
+++ b/fittrack/lib/screens/analytics/components/monthly_heatmap_section.dart
@@ -153,9 +153,14 @@ class _MonthlyHeatmapSectionState extends State<MonthlyHeatmapSection> {
   /// Navigate to a specific month
   void _navigateToMonth(DateTime month) {
     final targetMonth = DateTime(month.year, month.month, 1);
+
+    // Use current page position as base instead of _virtualCenter
+    // This prevents drift when _currentMonth updates but page doesn't reset
+    final currentPage = _pageController.page?.round() ?? _virtualCenter;
+
     final monthOffset = (targetMonth.year - _currentMonth.year) * 12 +
                         (targetMonth.month - _currentMonth.month);
-    final targetPage = _virtualCenter + monthOffset;
+    final targetPage = currentPage + monthOffset;
 
     _pageController.animateToPage(
       targetPage,


### PR DESCRIPTION
## Summary
Fixes monthly calendar heatmap navigation bugs where swipe gestures skip months and the Today button jumps to incorrect dates.

## Problem
- **Swipe right** skipped months (December → February, skipping January)
- **Swipe left** jumped erratically (February → October)
- **Today button** jumped to future dates exponentially with each click
- **Refresh button** worked correctly (returns to current date)

## Root Cause
The `_navigateToMonth` method calculated page offset from `_virtualCenter` (constant 10000), but `_currentMonth` updates on each swipe without resetting the PageController position. This created **drift** where `_currentMonth` no longer corresponded to the page at `_virtualCenter`.

**Example of Bug:**
1. Start at December 2024 (`_currentMonth` = Dec 2024, page = 10000)
2. Swipe to January 2025 (page = 10001, `_currentMonth` = Jan 2025)
3. Click "Today" → offset calculated from wrong base (10000 instead of 10001)
4. Each navigation compounds the error

## Solution
Use `PageController.page` (current page position) as the base for offset calculation instead of `_virtualCenter`. This ensures navigation is always relative to the actual current page position, eliminating drift.

## Changes
**File:** `lib/screens/analytics/components/monthly_heatmap_section.dart`

- Updated `_navigateToMonth()` to use `currentPage` as base
- Added explanatory comments documenting the fix

```dart
// Before (buggy):
final targetPage = _virtualCenter + monthOffset;

// After (fixed):
final currentPage = _pageController.page?.round() ?? _virtualCenter;
final targetPage = currentPage + monthOffset;
```

## Testing
- All widget tests in `monthly_heatmap_section_test.dart` pass
- Verified via GitHub Actions CI
- Tests cover:
  - Swipe navigation between months
  - Year boundary navigation (Dec ↔ Jan)
  - Today button navigation to current month
  - Month picker navigation

## Acceptance Criteria
✅ Swipe right advances exactly 1 month
✅ Swipe left regresses exactly 1 month  
✅ Today button always returns to current month
✅ Year boundaries handled correctly (December ↔ January)
✅ All widget tests pass

## Related Issue
Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)