### PR TITLE
feat: Add workflow_dispatch trigger for manual CI runs

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -14,6 +14,7 @@ on:
     paths:
       - 'fittrack/**'
       - '.github/workflows/fittrack_test_suite.yml'
+  workflow_dispatch:  # Allow manual triggering from Actions tab
 
 # Required permissions for PR comments and test reports
 permissions:


### PR DESCRIPTION
## Purpose

Enables manual triggering of the test suite from GitHub Actions UI.

## Changes

Added `workflow_dispatch` trigger to `.github/workflows/fittrack_test_suite.yml`

## Benefits

- Allows manual CI re-runs without requiring new commits
- Useful for testing after fixes (like bug #255)
- Developers and agents can trigger tests from: https://github.com/justbuildstuff-dev/Fitness-App/actions/workflows/fittrack_test_suite.yml

## Testing

Once merged, the "Run workflow" button will appear in the Actions tab.

---

This is needed to manually trigger CI for PR #148 (Feature #53) after compilation fixes.