### PR TITLE
fix: Allow workflow_dispatch to trigger all test jobs

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -38,7 +38,7 @@ jobs:
   unit-tests:
     name: Unit Tests (Business Logic)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -96,7 +96,7 @@ jobs:
   widget-tests:
     name: Widget Tests (UI Components)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -137,7 +137,7 @@ jobs:
     name: E2E Tests (Android Emulator)
     runs-on: ubuntu-latest
     timeout-minutes: 80
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -469,7 +469,7 @@ jobs:
   performance-tests:
     name: Performance Tests (Edge Cases)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -504,7 +504,7 @@ jobs:
   enhanced-tests:
     name: Integration Tests (Firebase Emulators)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -590,7 +590,7 @@ jobs:
     name: Test Summary Report
     runs-on: ubuntu-latest
     needs: [unit-tests, widget-tests, integration-tests, performance-tests, enhanced-tests]
-    if: github.event_name == 'pull_request' && always() # Run even if some tests fail
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && always() # Run even if some tests fail
     
     steps:
     - name: Checkout code
@@ -614,7 +614,7 @@ jobs:
         echo "Coverage reports available in artifacts." >> test-summary.md
         
     - name: Comment test summary on PR
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
       uses: actions/github-script@v6
       with:
         script: |
@@ -631,7 +631,7 @@ jobs:
   integration-coverage-check:
     name: Integration Test Coverage Gate
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code
@@ -717,7 +717,7 @@ jobs:
     name: All Tests Status
     runs-on: ubuntu-latest
     needs: [unit-tests, widget-tests, integration-tests, performance-tests, enhanced-tests, security-checks, integration-coverage-check]
-    if: github.event_name == 'pull_request' && always()
+    if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && always()
 
     steps:
     - name: Check all test results
@@ -748,7 +748,7 @@ jobs:
   security-checks:
     name: Security and Dependency Checks
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Problem

PR #256 added \ trigger, but all jobs were still skipping when manually triggered because every job had:
\
When using workflow_dispatch, the event name is \, not \, so all jobs were skipped.

## Solution

Updated all job conditions to allow both event types:
\
Also fixed operator precedence for jobs with \ conditions by adding parentheses:
\
## Jobs Updated

- unit-tests
- widget-tests  
- integration-tests
- performance-tests
- enhanced-tests
- security-checks
- test-summary
- integration-coverage-check
- all-tests-passed

## Testing

After merge, manual workflow_dispatch triggers will run all jobs instead of skipping them.

---

This unblocks manual CI runs for PR #148 (Feature #53) after compilation fixes in bug #255.