### PR TITLE
[Task] Update main.dart Theme Configuration (#270)

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -91,7 +91,7 @@ class FitTrackApp extends StatelessWidget {
             themeMode: themeProvider.currentThemeMode,
             theme: ThemeData(
               colorScheme: ColorScheme.fromSeed(
-                seedColor: const Color(0xFF2196F3),
+                seedColor: themeProvider.seedColor,
                 brightness: Brightness.light,
               ),
               useMaterial3: true,
@@ -102,7 +102,7 @@ class FitTrackApp extends StatelessWidget {
             ),
             darkTheme: ThemeData(
               colorScheme: ColorScheme.fromSeed(
-                seedColor: const Color(0xFF2196F3),
+                seedColor: themeProvider.seedColor,
                 brightness: Brightness.dark,
               ),
               useMaterial3: true,


### PR DESCRIPTION
## Summary
- Replace hardcoded seedColor with themeProvider.seedColor in both light and dark themes
- Enables app-wide color scheme changes based on user selection

## Changes
- Updated `lib/main.dart` to use `themeProvider.seedColor` instead of hardcoded `const Color(0xFF2196F3)`

## Related
- Part of Issue #44 - Color Scheme Selector
- Closes #270
- Depends on #275 (merged)

## Test plan
- [ ] App launches without errors
- [ ] Theme changes are reflected when color scheme is updated
- [ ] Both light and dark modes use the selected color scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)