### PR TITLE
[Task] Write Unit Tests for Color Scheme (#272)

### DIFF
--- a/fittrack/test/providers/theme_provider_test.dart
+++ b/fittrack/test/providers/theme_provider_test.dart
@@ -14,6 +14,8 @@ import 'theme_provider_test.mocks.dart';
 /// - Persists theme mode to SharedPreferences
 /// - Loads saved theme mode from SharedPreferences
 /// - Notifies listeners on theme changes
+/// - Manages color scheme selection and persistence
+/// - Returns correct seed color for each color scheme
 ///
 /// Tests use mocked SharedPreferences to ensure isolation
 @GenerateMocks([SharedPreferences])
@@ -246,6 +248,196 @@ void main() {
         // Verify listener was called
         expect(listenerCalled, isTrue,
           reason: 'Should notify listeners after loading theme mode');
+      });
+    });
+
+    group('Color Scheme Initialization', () {
+      test('initializes with classicBlue when no saved preference', () {
+        /// Test Purpose: Verify default color scheme when no preference saved
+
+        // Mock no saved preferences
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn(null);
+
+        themeProvider = ThemeProvider(mockPrefs);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.classicBlue),
+          reason: 'Should default to classicBlue when no preference saved');
+      });
+
+      test('initializes with saved energeticOrange preference', () {
+        /// Test Purpose: Verify loading of saved energeticOrange preference
+
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn('energeticOrange');
+
+        themeProvider = ThemeProvider(mockPrefs);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.energeticOrange),
+          reason: 'Should load saved energeticOrange preference');
+      });
+
+      test('initializes with saved electricPurple preference', () {
+        /// Test Purpose: Verify loading of saved electricPurple preference
+
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn('electricPurple');
+
+        themeProvider = ThemeProvider(mockPrefs);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.electricPurple),
+          reason: 'Should load saved electricPurple preference');
+      });
+
+      test('initializes with saved crimsonPower preference', () {
+        /// Test Purpose: Verify loading of saved crimsonPower preference
+
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn('crimsonPower');
+
+        themeProvider = ThemeProvider(mockPrefs);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.crimsonPower),
+          reason: 'Should load saved crimsonPower preference');
+      });
+
+      test('defaults to classicBlue for invalid saved value', () {
+        /// Test Purpose: Verify fallback to classicBlue for invalid values
+
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn('invalidScheme');
+
+        themeProvider = ThemeProvider(mockPrefs);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.classicBlue),
+          reason: 'Should default to classicBlue for invalid saved values');
+      });
+    });
+
+    group('setColorScheme', () {
+      setUp(() {
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn(null);
+        when(mockPrefs.setString(any, any)).thenAnswer((_) async => true);
+
+        themeProvider = ThemeProvider(mockPrefs);
+      });
+
+      test('sets color scheme to energeticOrange and persists', () async {
+        /// Test Purpose: Verify setting energeticOrange updates state and persists
+
+        await themeProvider.setColorScheme(ColorSchemeType.energeticOrange);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.energeticOrange),
+          reason: 'Should update current color scheme to energeticOrange');
+
+        verify(mockPrefs.setString('color_scheme', 'energeticOrange')).called(1);
+      });
+
+      test('sets color scheme to electricPurple and persists', () async {
+        /// Test Purpose: Verify setting electricPurple updates state and persists
+
+        await themeProvider.setColorScheme(ColorSchemeType.electricPurple);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.electricPurple),
+          reason: 'Should update current color scheme to electricPurple');
+
+        verify(mockPrefs.setString('color_scheme', 'electricPurple')).called(1);
+      });
+
+      test('sets color scheme to crimsonPower and persists', () async {
+        /// Test Purpose: Verify setting crimsonPower updates state and persists
+
+        await themeProvider.setColorScheme(ColorSchemeType.crimsonPower);
+
+        expect(themeProvider.currentColorScheme, equals(ColorSchemeType.crimsonPower),
+          reason: 'Should update current color scheme to crimsonPower');
+
+        verify(mockPrefs.setString('color_scheme', 'crimsonPower')).called(1);
+      });
+
+      test('does not persist if color scheme is already set', () async {
+        /// Test Purpose: Verify no unnecessary persistence calls
+
+        // Color scheme starts as classicBlue by default
+        clearInteractions(mockPrefs);
+
+        await themeProvider.setColorScheme(ColorSchemeType.classicBlue);
+
+        verifyNever(mockPrefs.setString(any, any));
+      });
+
+      test('notifies listeners when color scheme changes', () async {
+        /// Test Purpose: Verify listeners are notified on color scheme change
+
+        bool listenerCalled = false;
+        themeProvider.addListener(() {
+          listenerCalled = true;
+        });
+
+        await themeProvider.setColorScheme(ColorSchemeType.electricPurple);
+
+        expect(listenerCalled, isTrue,
+          reason: 'Should notify listeners when color scheme changes');
+      });
+
+      test('does not notify listeners when setting same color scheme', () async {
+        /// Test Purpose: Verify listeners not notified unnecessarily
+
+        int listenerCallCount = 0;
+        themeProvider.addListener(() {
+          listenerCallCount++;
+        });
+
+        // Try to set same scheme (classicBlue is default)
+        await themeProvider.setColorScheme(ColorSchemeType.classicBlue);
+
+        expect(listenerCallCount, equals(0),
+          reason: 'Should not notify listeners when color scheme unchanged');
+      });
+    });
+
+    group('seedColor', () {
+      setUp(() {
+        when(mockPrefs.getString('theme_mode')).thenReturn(null);
+        when(mockPrefs.getString('color_scheme')).thenReturn(null);
+        when(mockPrefs.setString(any, any)).thenAnswer((_) async => true);
+
+        themeProvider = ThemeProvider(mockPrefs);
+      });
+
+      test('returns correct color for classicBlue', () {
+        /// Test Purpose: Verify seedColor returns correct hex for classicBlue
+
+        expect(themeProvider.seedColor, equals(const Color(0xFF2196F3)),
+          reason: 'classicBlue should return #2196F3');
+      });
+
+      test('returns correct color for energeticOrange', () async {
+        /// Test Purpose: Verify seedColor returns correct hex for energeticOrange
+
+        await themeProvider.setColorScheme(ColorSchemeType.energeticOrange);
+
+        expect(themeProvider.seedColor, equals(const Color(0xFFFF6B35)),
+          reason: 'energeticOrange should return #FF6B35');
+      });
+
+      test('returns correct color for electricPurple', () async {
+        /// Test Purpose: Verify seedColor returns correct hex for electricPurple
+
+        await themeProvider.setColorScheme(ColorSchemeType.electricPurple);
+
+        expect(themeProvider.seedColor, equals(const Color(0xFF7C3AED)),
+          reason: 'electricPurple should return #7C3AED');
+      });
+
+      test('returns correct color for crimsonPower', () async {
+        /// Test Purpose: Verify seedColor returns correct hex for crimsonPower
+
+        await themeProvider.setColorScheme(ColorSchemeType.crimsonPower);
+
+        expect(themeProvider.seedColor, equals(const Color(0xFFDC143C)),
+          reason: 'crimsonPower should return #DC143C');
       });
     });
   });


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for color scheme functionality in ThemeProvider
- Tests cover initialization, setColorScheme, and seedColor getter

## Test Coverage
- **Color Scheme Initialization (5 tests):**
  - Default to classicBlue when no preference saved
  - Load all 4 saved color scheme preferences
  - Fallback to classicBlue for invalid values

- **setColorScheme (6 tests):**
  - Set and persist each color scheme
  - No-op when setting same color scheme
  - Listener notification behavior

- **seedColor (4 tests):**
  - Verify correct hex color for each scheme

## Related
- Part of Issue #44 - Color Scheme Selector
- Closes #272

## Test plan
- [ ] All new unit tests pass
- [ ] No regression in existing theme mode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)