### PR TITLE
fix: Add visible drag handle to exercise cards for reordering (#306)

### DIFF
--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -199,7 +199,7 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen> {
     return ReorderableListView.builder(
       padding: const EdgeInsets.all(16),
       itemCount: exercises.length,
-      buildDefaultDragHandles: true, // Let ReorderableListView handle drag handles
+      buildDefaultDragHandles: false, // We use custom visible drag handles in ExerciseCard
       physics: const AlwaysScrollableScrollPhysics(), // Improve scroll performance
       proxyDecorator: (child, index, animation) {
         // Animate the dragged item
@@ -227,7 +227,8 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen> {
           key: ValueKey(exercise.id),
           exercise: exercise,
           sets: sets,
-          isReorderEnabled: true, // Keep showing that reordering is possible
+          isReorderEnabled: true, // Show visible drag handle
+          index: index, // Pass index for ReorderableDragStartListener
           onAddSet: isAddingSet || sets.length >= 10 ? null : () => _addSet(context, exercise),
           onEditName: () => _editExerciseName(context, exercise),
           onDelete: () => _deleteExercise(context, exercise),

--- a/fittrack/lib/widgets/exercise_card.dart
+++ b/fittrack/lib/widgets/exercise_card.dart
@@ -9,6 +9,8 @@ class ExerciseCard extends StatefulWidget {
   final Exercise exercise;
   final List<ExerciseSet> sets;
   final bool isReorderEnabled;
+  /// The index of this card in the list - required for ReorderableDragStartListener
+  final int index;
   final VoidCallback? onAddSet;
   final VoidCallback? onEditName;
   final VoidCallback? onDelete;
@@ -20,6 +22,7 @@ class ExerciseCard extends StatefulWidget {
     required this.exercise,
     required this.sets,
     this.isReorderEnabled = true,
+    this.index = 0,
     this.onAddSet,
     this.onEditName,
     this.onDelete,
@@ -51,6 +54,20 @@ class _ExerciseCardState extends State<ExerciseCard> {
               padding: const EdgeInsets.all(12),
               child: Row(
                 children: [
+                  // Drag handle (visible when reordering is enabled)
+                  if (widget.isReorderEnabled)
+                    ReorderableDragStartListener(
+                      index: widget.index,
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: Icon(
+                          Icons.drag_handle,
+                          color: theme.colorScheme.onSurface.withValues(alpha: 0.4),
+                          size: 24,
+                        ),
+                      ),
+                    ),
+
                   // Exercise type icon
                   Icon(
                     _getExerciseTypeIcon(widget.exercise.exerciseType),

--- a/fittrack/test/widgets/exercise_card_test.dart
+++ b/fittrack/test/widgets/exercise_card_test.dart
@@ -245,10 +245,35 @@ void main() {
       expect(find.byIcon(Icons.delete), findsAtLeastNWidgets(1));
     });
 
-    // NOTE: Drag handle tests removed
-    // Drag handles are now managed by ReorderableListView.buildDefaultDragHandles
-    // in the parent screen (ConsolidatedWorkoutScreen), not by ExerciseCard itself.
-    // ExerciseCard no longer controls drag handle visibility.
+    testWidgets('shows drag handle when isReorderEnabled is true', (tester) async {
+      /// Test Purpose: Verify drag handle is visible for reordering
+      /// Drag handle should be visible when isReorderEnabled is true
+
+      await tester.pumpWidget(createTestWidget(
+        exercise: testExercise,
+        sets: testSets,
+        isReorderEnabled: true,
+        onUpdateSet: (_) {},
+        onDeleteSet: (_, __) {},
+      ));
+
+      expect(find.byIcon(Icons.drag_handle), findsOneWidget);
+    });
+
+    testWidgets('hides drag handle when isReorderEnabled is false', (tester) async {
+      /// Test Purpose: Verify drag handle is hidden when disabled
+      /// Drag handle should not be visible when isReorderEnabled is false
+
+      await tester.pumpWidget(createTestWidget(
+        exercise: testExercise,
+        sets: testSets,
+        isReorderEnabled: false,
+        onUpdateSet: (_) {},
+        onDeleteSet: (_, __) {},
+      ));
+
+      expect(find.byIcon(Icons.drag_handle), findsNothing);
+    });
 
     testWidgets('calls onAddSet when Add button tapped', (tester) async {
       /// Test Purpose: Verify onAddSet callback is triggered


### PR DESCRIPTION
## Summary

- Adds a visible drag handle icon (☰) on the left side of exercise card headers
- Users can now clearly see and tap the drag handle to reorder exercises in workouts
- Disabled default invisible drag handles in favor of custom visible ones

## Changes

- **ExerciseCard**: Added `index` parameter and visible drag handle with `ReorderableDragStartListener`
- **ConsolidatedWorkoutScreen**: Pass index to ExerciseCard, set `buildDefaultDragHandles: false`
- **Tests**: Added widget tests for drag handle visibility

## Bugs Fixed

- **#306**: Exercise card grab handle missing - FIXED
- **#307**: No navigation path to create exercise manually - Closed as duplicate (already fixed by #303)

## Test Plan

- [ ] Verify drag handle icon is visible on exercise cards in workout screen
- [ ] Verify exercises can be reordered by dragging the handle
- [ ] Verify widget tests pass for drag handle visibility
- [ ] Verify existing exercise card functionality still works (expand/collapse, add set, edit, delete)

## Related Issues

- Parent: #259 (Exercise Library feature)
- Fixes: #306
- Related: #307 (closed as resolved by #303)

🤖 Generated with [Claude Code](https://claude.com/claude-code)