### PR TITLE
fix: QA bug fixes - set row padding and custom exercises filter (#311, #312)

### DIFF
--- a/fittrack/lib/screens/exercises/exercise_picker_screen.dart
+++ b/fittrack/lib/screens/exercises/exercise_picker_screen.dart
@@ -7,6 +7,24 @@ import '../../models/muscle_group.dart';
 import '../../models/exercise.dart';
 import 'custom_exercise_form_screen.dart';
 
+/// Filter for exercise source (library vs custom)
+enum ExerciseSource {
+  all,
+  library,
+  custom;
+
+  String get displayName {
+    switch (this) {
+      case ExerciseSource.all:
+        return 'All';
+      case ExerciseSource.library:
+        return 'Library';
+      case ExerciseSource.custom:
+        return 'My Exercises';
+    }
+  }
+}
+
 /// A screen for browsing and selecting exercises from the library or custom exercises.
 /// Returns the selected exercise data when the user taps "Add to Workout".
 class ExercisePickerScreen extends StatefulWidget {
@@ -29,6 +47,7 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
   String _searchQuery = '';
   MuscleGroup? _selectedMuscleGroup;
   ExerciseType? _selectedExerciseType;
+  ExerciseSource _selectedSource = ExerciseSource.all;
 
   @override
   void dispose() {
@@ -91,11 +110,22 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
             );
           }
 
-          final searchResults = provider.searchExercises(
+          var searchResults = provider.searchExercises(
             query: _searchQuery,
             muscleGroup: _selectedMuscleGroup,
             exerciseType: _selectedExerciseType,
           );
+
+          // Filter by source if not "All"
+          if (_selectedSource == ExerciseSource.library) {
+            searchResults = searchResults
+                .where((e) => e is LibraryExercise)
+                .toList();
+          } else if (_selectedSource == ExerciseSource.custom) {
+            searchResults = searchResults
+                .where((e) => e is CustomExercise)
+                .toList();
+          }
 
           return Column(
             children: [
@@ -225,6 +255,16 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
               });
             },
           ),
+          const SizedBox(width: 8),
+          // Source filter dropdown (Library vs Custom)
+          _SourceFilterChip(
+            value: _selectedSource,
+            onSelected: (value) {
+              setState(() {
+                _selectedSource = value;
+              });
+            },
+          ),
         ],
       ),
     );
@@ -233,7 +273,8 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
   Widget _buildEmptyState() {
     final hasFilters = _searchQuery.isNotEmpty ||
         _selectedMuscleGroup != null ||
-        _selectedExerciseType != null;
+        _selectedExerciseType != null ||
+        _selectedSource != ExerciseSource.all;
 
     return Center(
       child: Padding(
@@ -284,6 +325,7 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
       _searchQuery = '';
       _selectedMuscleGroup = null;
       _selectedExerciseType = null;
+      _selectedSource = ExerciseSource.all;
     });
   }
 
@@ -482,6 +524,57 @@ class _FilterChipDropdown<T> extends StatelessWidget {
             ? Theme.of(context).colorScheme.primaryContainer
             : null,
         side: value != null
+            ? BorderSide(color: Theme.of(context).colorScheme.primary)
+            : null,
+      ),
+    );
+  }
+}
+
+/// Filter chip specifically for ExerciseSource filtering
+class _SourceFilterChip extends StatelessWidget {
+  final ExerciseSource value;
+  final ValueChanged<ExerciseSource> onSelected;
+
+  const _SourceFilterChip({
+    required this.value,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isFiltered = value != ExerciseSource.all;
+
+    return PopupMenuButton<ExerciseSource>(
+      onSelected: onSelected,
+      offset: const Offset(0, 40),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+      ),
+      itemBuilder: (context) => ExerciseSource.values
+          .map((source) => PopupMenuItem<ExerciseSource>(
+                value: source,
+                child: Text(
+                  source.displayName,
+                  style: TextStyle(
+                    fontWeight:
+                        value == source ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ))
+          .toList(),
+      child: Chip(
+        label: Text(value.displayName),
+        avatar: isFiltered
+            ? Icon(
+                Icons.check,
+                size: 18,
+                color: Theme.of(context).colorScheme.primary,
+              )
+            : null,
+        backgroundColor:
+            isFiltered ? Theme.of(context).colorScheme.primaryContainer : null,
+        side: isFiltered
             ? BorderSide(color: Theme.of(context).colorScheme.primary)
             : null,
       ),

--- a/fittrack/lib/widgets/exercise_card.dart
+++ b/fittrack/lib/widgets/exercise_card.dart
@@ -156,7 +156,7 @@ class _ExerciseCardState extends State<ExerciseCard> {
           if (_isExpanded) ...[
             const Divider(height: 1),
             Padding(
-              padding: const EdgeInsets.fromLTRB(12, 12, 48, 12), // Increased right padding to 48px for drag handle clearance
+              padding: const EdgeInsets.all(12), // Standard padding - drag handle is now in header
               child: Column(
                 children: [
                   // Set rows


### PR DESCRIPTION
## Summary

- **#311 (Medium)**: Remove excessive right padding in set rows - the 48px padding was for drag handle clearance when drag handle was in the set area, now that it's in the card header, using standard 12px padding
- **#312 (Medium)**: Add "Source" filter chip to Exercise Picker with options: All, Library, My Exercises - allows users to filter exercises by source

## Changes

### exercise_card.dart
- Changed set row padding from `EdgeInsets.fromLTRB(12, 12, 48, 12)` to `EdgeInsets.all(12)`

### exercise_picker_screen.dart
- Added `ExerciseSource` enum with `all`, `library`, `custom` values
- Added `_selectedSource` state variable
- Added source filtering after search results
- Added `_SourceFilterChip` widget in filter chips row
- Updated `_clearFilters()` to reset source filter
- Updated `_buildEmptyState()` to include source in `hasFilters`

## Test plan
- [ ] Verify set rows no longer have excessive right padding
- [ ] Verify "Source" filter chip appears in Exercise Picker
- [ ] Verify filtering by "Library" shows only library exercises
- [ ] Verify filtering by "My Exercises" shows only custom exercises
- [ ] Verify "All" shows both library and custom exercises
- [ ] Verify "Clear all filters" resets the source filter

## Related Issues
Closes #311
Closes #312
Parent Issue: #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)