### PR TITLE
feat(templates): Add save template dialog #322

### DIFF
--- a/fittrack/lib/widgets/save_template_dialog.dart
+++ b/fittrack/lib/widgets/save_template_dialog.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+
+/// Result from the save template dialog
+class SaveTemplateResult {
+  final String name;
+  final String? description;
+
+  const SaveTemplateResult({
+    required this.name,
+    this.description,
+  });
+}
+
+/// Dialog for saving a workout, week, or program as a template.
+class SaveTemplateDialog extends StatefulWidget {
+  /// The type of template being saved (e.g., "Workout", "Week", "Program")
+  final String templateType;
+
+  /// Optional initial name for the template
+  final String? initialName;
+
+  /// Optional initial description for the template
+  final String? initialDescription;
+
+  const SaveTemplateDialog({
+    super.key,
+    required this.templateType,
+    this.initialName,
+    this.initialDescription,
+  });
+
+  /// Shows the dialog and returns the template info if saved, null if cancelled.
+  static Future<SaveTemplateResult?> show({
+    required BuildContext context,
+    required String templateType,
+    String? initialName,
+    String? initialDescription,
+  }) {
+    return showDialog<SaveTemplateResult>(
+      context: context,
+      builder: (context) => SaveTemplateDialog(
+        templateType: templateType,
+        initialName: initialName,
+        initialDescription: initialDescription,
+      ),
+    );
+  }
+
+  @override
+  State<SaveTemplateDialog> createState() => _SaveTemplateDialogState();
+}
+
+class _SaveTemplateDialogState extends State<SaveTemplateDialog> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+  bool _isSubmitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initialName ?? '');
+    _descriptionController =
+        TextEditingController(text: widget.initialDescription ?? '');
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  void _handleSave() {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isSubmitting = true);
+
+    final result = SaveTemplateResult(
+      name: _nameController.text.trim(),
+      description: _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim(),
+    );
+
+    Navigator.of(context).pop(result);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: [
+          Icon(
+            Icons.save_alt,
+            color: Theme.of(context).colorScheme.primary,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text('Save as ${widget.templateType} Template'),
+          ),
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Save this ${widget.templateType.toLowerCase()} as a reusable template.',
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurface
+                          .withValues(alpha: 0.7),
+                    ),
+              ),
+              const SizedBox(height: 20),
+
+              // Name field
+              TextFormField(
+                controller: _nameController,
+                decoration: InputDecoration(
+                  labelText: 'Template Name',
+                  hintText: 'Enter a name for the template',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  prefixIcon: const Icon(Icons.text_fields),
+                ),
+                textCapitalization: TextCapitalization.words,
+                autofocus: true,
+                maxLength: 100,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a template name';
+                  }
+                  if (value.trim().length < 2) {
+                    return 'Name must be at least 2 characters';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Description field
+              TextFormField(
+                controller: _descriptionController,
+                decoration: InputDecoration(
+                  labelText: 'Description (Optional)',
+                  hintText: 'Add a description for this template',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  prefixIcon: const Icon(Icons.description),
+                  alignLabelWithHint: true,
+                ),
+                textCapitalization: TextCapitalization.sentences,
+                maxLines: 3,
+                maxLength: 500,
+              ),
+
+              const SizedBox(height: 8),
+
+              // Info message
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(
+                    Icons.info_outline,
+                    size: 16,
+                    color: Theme.of(context)
+                        .colorScheme
+                        .onSurface
+                        .withValues(alpha: 0.5),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'The template will include all exercises and sets.',
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurface
+                                .withValues(alpha: 0.5),
+                          ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _isSubmitting ? null : () => Navigator.of(context).pop(),
+          child: const Text('Cancel'),
+        ),
+        FilledButton.icon(
+          onPressed: _isSubmitting ? null : _handleSave,
+          icon: _isSubmitting
+              ? SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Theme.of(context).colorScheme.onPrimary,
+                  ),
+                )
+              : const Icon(Icons.save, size: 18),
+          label: const Text('Save Template'),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `SaveTemplateDialog` widget for saving templates
- Add `SaveTemplateResult` class to hold dialog result

Features:
- Template name field with validation (required, 2-100 characters)
- Optional description field (max 500 characters)
- Form validation before save
- Clean, consistent dialog design matching existing patterns
- Static `show()` method for easy usage

## Test plan
- [ ] Dialog opens correctly with proper title
- [ ] Name validation works (required, min 2 chars)
- [ ] Description is optional
- [ ] Cancel closes dialog without result
- [ ] Save returns SaveTemplateResult with trimmed values
- [ ] Initial name/description pre-fill correctly

Implements #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)