### PR TITLE
feat: Analytics data models & 1RM calculator (#349)

### DIFF
--- a/fittrack/lib/models/analytics.dart
+++ b/fittrack/lib/models/analytics.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'exercise.dart';
 import 'exercise_set.dart';
+import 'muscle_group.dart';
 import 'workout.dart';
 
 /// Analytics data for a specific date range
@@ -653,6 +654,38 @@ class DateRange {
     return DateRange(start: start, end: end);
   }
 
+  /// Creates a rolling 1-month date range ending today
+  factory DateRange.lastMonth() {
+    final now = DateTime.now();
+    final end = DateTime(now.year, now.month, now.day, 23, 59, 59);
+    final start = DateTime(now.year, now.month - 1, now.day);
+    return DateRange(start: start, end: end);
+  }
+
+  /// Creates a rolling 3-month date range ending today
+  factory DateRange.last3Months() {
+    final now = DateTime.now();
+    final end = DateTime(now.year, now.month, now.day, 23, 59, 59);
+    final start = DateTime(now.year, now.month - 3, now.day);
+    return DateRange(start: start, end: end);
+  }
+
+  /// Creates a rolling 6-month date range ending today
+  factory DateRange.last6Months() {
+    final now = DateTime.now();
+    final end = DateTime(now.year, now.month, now.day, 23, 59, 59);
+    final start = DateTime(now.year, now.month - 6, now.day);
+    return DateRange(start: start, end: end);
+  }
+
+  /// Creates a date range from Jan 1, 2020 to today (all historical data)
+  factory DateRange.allTime() {
+    final now = DateTime.now();
+    final end = DateTime(now.year, now.month, now.day, 23, 59, 59);
+    final start = DateTime(2020, 1, 1);
+    return DateRange(start: start, end: end);
+  }
+
   /// Check if a date falls within this range
   bool contains(DateTime date) {
     return date.isAfter(start.subtract(const Duration(microseconds: 1))) &&
@@ -661,5 +694,251 @@ class DateRange {
 
   /// Duration of the range in days
   int get durationInDays => end.difference(start).inDays + 1;
+}
+
+/// Per-exercise progress data point representing one workout session
+///
+/// Each point aggregates all sets for a specific exercise within a single
+/// workout session. The metrics captured depend on the exercise type.
+class ExerciseProgressPoint {
+  /// Date of the workout session
+  final DateTime date;
+
+  /// Workout that contained this exercise
+  final String workoutId;
+
+  /// Highest weight used in any set (strength exercises)
+  final double? maxWeight;
+
+  /// Highest reps in any set (bodyweight exercises)
+  final int? maxReps;
+
+  /// Sum of (weight * reps) across all sets in the session
+  final double? totalVolume;
+
+  /// Sum of duration across all sets in the session (seconds)
+  final int? totalDuration;
+
+  /// Sum of distance across all sets in the session (meters)
+  final double? totalDistance;
+
+  /// Estimated 1RM from the best set in the session (Epley formula)
+  /// Null if no eligible set (reps > 10 or weight <= 0)
+  final double? estimated1RM;
+
+  const ExerciseProgressPoint({
+    required this.date,
+    required this.workoutId,
+    this.maxWeight,
+    this.maxReps,
+    this.totalVolume,
+    this.totalDuration,
+    this.totalDistance,
+    this.estimated1RM,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExerciseProgressPoint &&
+        other.date == date &&
+        other.workoutId == workoutId &&
+        other.maxWeight == maxWeight &&
+        other.maxReps == maxReps &&
+        other.totalVolume == totalVolume &&
+        other.totalDuration == totalDuration &&
+        other.totalDistance == totalDistance &&
+        other.estimated1RM == estimated1RM;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        date, workoutId, maxWeight, maxReps,
+        totalVolume, totalDuration, totalDistance, estimated1RM,
+      );
+}
+
+/// Aggregated exercise progress data for charting
+///
+/// Contains all data points for a single exercise across a date range,
+/// ready to be rendered as a line chart.
+class ExerciseProgressData {
+  /// Unique identifier of the exercise
+  final String exerciseId;
+
+  /// Display name of the exercise
+  final String exerciseName;
+
+  /// Type of exercise (determines which metrics to chart)
+  final ExerciseType exerciseType;
+
+  /// Chronologically ordered data points (one per workout session)
+  final List<ExerciseProgressPoint> dataPoints;
+
+  /// Date range the data was queried for
+  final DateRange dateRange;
+
+  const ExerciseProgressData({
+    required this.exerciseId,
+    required this.exerciseName,
+    required this.exerciseType,
+    required this.dataPoints,
+    required this.dateRange,
+  });
+
+  /// Whether there is any data to display
+  bool get isEmpty => dataPoints.isEmpty;
+
+  /// Whether there is only a single data point (renders as dot, no line)
+  bool get isSinglePoint => dataPoints.length == 1;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ExerciseProgressData &&
+        other.exerciseId == exerciseId &&
+        other.exerciseName == exerciseName &&
+        other.exerciseType == exerciseType &&
+        other.dataPoints.length == dataPoints.length &&
+        other.dateRange.start == dateRange.start &&
+        other.dateRange.end == dateRange.end;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        exerciseId, exerciseName, exerciseType,
+        dataPoints.length, dateRange.start, dateRange.end,
+      );
+}
+
+/// Muscle group volume breakdown for a date range
+///
+/// Represents the total number of sets performed for a specific muscle group,
+/// along with its percentage of total training volume.
+class MuscleGroupVolume {
+  /// The muscle group (or null for "Other" category)
+  final MuscleGroup? muscleGroup;
+
+  /// Display label (muscle group name or "Other")
+  final String label;
+
+  /// Total number of sets for this muscle group
+  final int totalSets;
+
+  /// Percentage of total sets across all muscle groups (0-100)
+  final double percentage;
+
+  const MuscleGroupVolume({
+    this.muscleGroup,
+    required this.label,
+    required this.totalSets,
+    required this.percentage,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MuscleGroupVolume &&
+        other.muscleGroup == muscleGroup &&
+        other.label == label &&
+        other.totalSets == totalSets &&
+        other.percentage == percentage;
+  }
+
+  @override
+  int get hashCode => Object.hash(muscleGroup, label, totalSets, percentage);
+}
+
+/// Weekly training trend data point
+///
+/// Represents aggregated training data for a single calendar week (Mon-Sun).
+/// Used to show volume and frequency trends over time.
+class WeeklyTrendPoint {
+  /// Monday of the week this data point represents
+  final DateTime weekStart;
+
+  /// Total volume (sum of weight * reps) for the week
+  final double totalVolume;
+
+  /// Number of workouts completed during the week
+  final int workoutCount;
+
+  const WeeklyTrendPoint({
+    required this.weekStart,
+    required this.totalVolume,
+    required this.workoutCount,
+  });
+
+  /// The Sunday ending this week
+  DateTime get weekEnd => weekStart.add(const Duration(days: 6));
+
+  /// Display string for the week range (e.g., "Jan 6 - Jan 12")
+  String get weekRangeString {
+    final months = [
+      '', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    final end = weekEnd;
+    return '${months[weekStart.month]} ${weekStart.day} - ${months[end.month]} ${end.day}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WeeklyTrendPoint &&
+        other.weekStart == weekStart &&
+        other.totalVolume == totalVolume &&
+        other.workoutCount == workoutCount;
+  }
+
+  @override
+  int get hashCode => Object.hash(weekStart, totalVolume, workoutCount);
+}
+
+/// Configurable weekly streak data
+///
+/// Tracks consecutive weeks where the user met their workout target.
+/// The streak resets when a completed week has fewer workouts than the target.
+class ConfigurableStreak {
+  /// User's weekly workout target (1-7)
+  final int weeklyTarget;
+
+  /// Consecutive weeks meeting the target (ending at current/most recent week)
+  final int currentStreak;
+
+  /// Longest streak of consecutive weeks meeting the target
+  final int longestStreak;
+
+  const ConfigurableStreak({
+    required this.weeklyTarget,
+    required this.currentStreak,
+    required this.longestStreak,
+  });
+
+  /// Display string for current streak (e.g., "12-week streak")
+  String get currentStreakString {
+    if (currentStreak == 0) return 'No streak';
+    if (currentStreak == 1) return '1-week streak';
+    return '$currentStreak-week streak';
+  }
+
+  /// Display string for longest streak
+  String get longestStreakString {
+    if (longestStreak == 0) return 'No record';
+    if (longestStreak == 1) return '1 week';
+    return '$longestStreak weeks';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is ConfigurableStreak &&
+        other.weeklyTarget == weeklyTarget &&
+        other.currentStreak == currentStreak &&
+        other.longestStreak == longestStreak;
+  }
+
+  @override
+  int get hashCode => Object.hash(weeklyTarget, currentStreak, longestStreak);
 }
 

--- a/fittrack/lib/utils/one_rm_calculator.dart
+++ b/fittrack/lib/utils/one_rm_calculator.dart
@@ -1,0 +1,84 @@
+import '../models/exercise_set.dart';
+
+/// Utility class for estimating one-repetition maximum (1RM) from sub-maximal
+/// lift data.
+///
+/// Provides two industry-standard formulas:
+/// - **Epley** (primary): Most accurate for moderate rep ranges (2-10)
+/// - **Brzycki** (alternative): Tends to give slightly lower estimates
+///
+/// Both formulas are only reliable when reps <= 10. For higher rep ranges,
+/// the estimates become increasingly inaccurate.
+///
+/// Example:
+/// ```dart
+/// // 100kg for 5 reps
+/// final epley1RM = OneRMCalculator.epley(100, 5);   // ~116.67kg
+/// final brzycki1RM = OneRMCalculator.brzycki(100, 5); // ~112.50kg
+/// ```
+class OneRMCalculator {
+  OneRMCalculator._();
+
+  /// Maximum reps for reliable 1RM estimation
+  static const int maxReliableReps = 10;
+
+  /// Calculate estimated 1RM using the Epley formula.
+  ///
+  /// Formula: weight * (1 + reps / 30)
+  ///
+  /// Returns the raw calculation regardless of rep count.
+  /// For reps == 1, returns the weight itself (actual 1RM).
+  static double epley(double weight, int reps) {
+    if (reps <= 0 || weight <= 0) return 0;
+    if (reps == 1) return weight;
+    return weight * (1 + reps / 30);
+  }
+
+  /// Calculate estimated 1RM using the Brzycki formula.
+  ///
+  /// Formula: weight * (36 / (37 - reps))
+  ///
+  /// Returns the raw calculation regardless of rep count.
+  /// For reps == 1, returns the weight itself (actual 1RM).
+  /// Note: Formula is undefined at reps == 37 (division by zero).
+  static double brzycki(double weight, int reps) {
+    if (reps <= 0 || weight <= 0) return 0;
+    if (reps == 1) return weight;
+    if (reps >= 37) return 0;
+    return weight * (36 / (37 - reps));
+  }
+
+  /// Estimate 1RM from the best set in a list of exercise sets.
+  ///
+  /// Finds the set that produces the highest estimated 1RM (using Epley)
+  /// from all eligible sets. A set is eligible if:
+  /// - `weight > 0`
+  /// - `reps > 0` and `reps <= 10`
+  ///
+  /// Returns `null` if no eligible sets are found.
+  ///
+  /// Example:
+  /// ```dart
+  /// final sets = [
+  ///   ExerciseSet(weight: 80, reps: 8, ...),  // 1RM ≈ 101.3
+  ///   ExerciseSet(weight: 100, reps: 3, ...),  // 1RM ≈ 110.0
+  /// ];
+  /// final best1RM = OneRMCalculator.estimateFromSets(sets); // ≈ 110.0
+  /// ```
+  static double? estimateFromSets(List<ExerciseSet> sets) {
+    double? best1RM;
+
+    for (final set in sets) {
+      if (set.weight == null || set.reps == null) continue;
+      if (set.weight! <= 0 || set.reps! <= 0) continue;
+      if (set.reps! > maxReliableReps) continue;
+
+      final estimated = epley(set.weight!, set.reps!);
+      if (best1RM == null || estimated > best1RM) {
+        best1RM = estimated;
+      }
+    }
+
+    return best1RM;
+  }
+}

--- a/fittrack/test/models/analytics_test.dart
+++ b/fittrack/test/models/analytics_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:fittrack/models/analytics.dart';
 import 'package:fittrack/models/exercise.dart';
 import 'package:fittrack/models/exercise_set.dart';
+import 'package:fittrack/models/muscle_group.dart';
 import 'package:fittrack/models/workout.dart';
 
 void main() {
@@ -454,6 +455,373 @@ void main() {
         expect(monthData.getIntensityForDay(5), equals(HeatmapIntensity.high));
         expect(monthData.getIntensityForDay(6), equals(HeatmapIntensity.high));
         expect(monthData.getIntensityForDay(7), equals(HeatmapIntensity.veryHigh));
+      });
+    });
+
+    group('DateRange - new factories', () {
+      test('lastMonth creates ~30 day range ending today', () {
+        final range = DateRange.lastMonth();
+        final now = DateTime.now();
+        expect(range.end.year, equals(now.year));
+        expect(range.end.month, equals(now.month));
+        expect(range.end.day, equals(now.day));
+        // Start should be roughly 1 month ago
+        expect(range.durationInDays, greaterThanOrEqualTo(28));
+        expect(range.durationInDays, lessThanOrEqualTo(32));
+      });
+
+      test('last3Months creates ~90 day range ending today', () {
+        final range = DateRange.last3Months();
+        final now = DateTime.now();
+        expect(range.end.year, equals(now.year));
+        expect(range.end.month, equals(now.month));
+        expect(range.end.day, equals(now.day));
+        expect(range.durationInDays, greaterThanOrEqualTo(89));
+        expect(range.durationInDays, lessThanOrEqualTo(93));
+      });
+
+      test('last6Months creates ~180 day range ending today', () {
+        final range = DateRange.last6Months();
+        final now = DateTime.now();
+        expect(range.end.year, equals(now.year));
+        expect(range.end.month, equals(now.month));
+        expect(range.end.day, equals(now.day));
+        expect(range.durationInDays, greaterThanOrEqualTo(181));
+        expect(range.durationInDays, lessThanOrEqualTo(185));
+      });
+
+      test('allTime starts from Jan 1 2020 and ends today', () {
+        final range = DateRange.allTime();
+        final now = DateTime.now();
+        expect(range.start.year, equals(2020));
+        expect(range.start.month, equals(1));
+        expect(range.start.day, equals(1));
+        expect(range.end.year, equals(now.year));
+        expect(range.end.month, equals(now.month));
+        expect(range.end.day, equals(now.day));
+      });
+
+      test('last3Months contains dates within range', () {
+        final range = DateRange.last3Months();
+        final now = DateTime.now();
+        expect(range.contains(now), isTrue);
+        expect(range.contains(now.subtract(const Duration(days: 30))), isTrue);
+        expect(range.contains(now.subtract(const Duration(days: 60))), isTrue);
+      });
+
+      test('last3Months does not contain dates outside range', () {
+        final range = DateRange.last3Months();
+        final now = DateTime.now();
+        // A date well outside 3 months ago
+        expect(range.contains(now.subtract(const Duration(days: 200))), isFalse);
+      });
+    });
+
+    group('ExerciseProgressPoint', () {
+      test('creates with all fields', () {
+        final point = ExerciseProgressPoint(
+          date: DateTime(2024, 6, 15),
+          workoutId: 'w1',
+          maxWeight: 100.0,
+          maxReps: 10,
+          totalVolume: 1500.0,
+          totalDuration: 300,
+          totalDistance: 5000.0,
+          estimated1RM: 133.3,
+        );
+
+        expect(point.date, equals(DateTime(2024, 6, 15)));
+        expect(point.workoutId, equals('w1'));
+        expect(point.maxWeight, equals(100.0));
+        expect(point.maxReps, equals(10));
+        expect(point.totalVolume, equals(1500.0));
+        expect(point.totalDuration, equals(300));
+        expect(point.totalDistance, equals(5000.0));
+        expect(point.estimated1RM, equals(133.3));
+      });
+
+      test('creates with nullable fields as null', () {
+        final point = ExerciseProgressPoint(
+          date: DateTime(2024, 6, 15),
+          workoutId: 'w1',
+        );
+
+        expect(point.maxWeight, isNull);
+        expect(point.maxReps, isNull);
+        expect(point.totalVolume, isNull);
+        expect(point.totalDuration, isNull);
+        expect(point.totalDistance, isNull);
+        expect(point.estimated1RM, isNull);
+      });
+
+      test('equality works correctly', () {
+        final point1 = ExerciseProgressPoint(
+          date: DateTime(2024, 6, 15),
+          workoutId: 'w1',
+          maxWeight: 100.0,
+        );
+        final point2 = ExerciseProgressPoint(
+          date: DateTime(2024, 6, 15),
+          workoutId: 'w1',
+          maxWeight: 100.0,
+        );
+        final point3 = ExerciseProgressPoint(
+          date: DateTime(2024, 6, 16),
+          workoutId: 'w1',
+          maxWeight: 100.0,
+        );
+
+        expect(point1, equals(point2));
+        expect(point1, isNot(equals(point3)));
+      });
+    });
+
+    group('ExerciseProgressData', () {
+      test('creates with data points', () {
+        final data = ExerciseProgressData(
+          exerciseId: 'ex1',
+          exerciseName: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          dataPoints: [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 6, 1),
+              workoutId: 'w1',
+              maxWeight: 80.0,
+            ),
+            ExerciseProgressPoint(
+              date: DateTime(2024, 6, 8),
+              workoutId: 'w2',
+              maxWeight: 85.0,
+            ),
+          ],
+          dateRange: DateRange(
+            start: DateTime(2024, 6, 1),
+            end: DateTime(2024, 6, 30),
+          ),
+        );
+
+        expect(data.exerciseId, equals('ex1'));
+        expect(data.exerciseName, equals('Bench Press'));
+        expect(data.exerciseType, equals(ExerciseType.strength));
+        expect(data.dataPoints.length, equals(2));
+        expect(data.isEmpty, isFalse);
+        expect(data.isSinglePoint, isFalse);
+      });
+
+      test('isEmpty returns true for empty data points', () {
+        final data = ExerciseProgressData(
+          exerciseId: 'ex1',
+          exerciseName: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          dataPoints: [],
+          dateRange: DateRange(
+            start: DateTime(2024, 6, 1),
+            end: DateTime(2024, 6, 30),
+          ),
+        );
+
+        expect(data.isEmpty, isTrue);
+        expect(data.isSinglePoint, isFalse);
+      });
+
+      test('isSinglePoint returns true for exactly one data point', () {
+        final data = ExerciseProgressData(
+          exerciseId: 'ex1',
+          exerciseName: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          dataPoints: [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 6, 1),
+              workoutId: 'w1',
+              maxWeight: 80.0,
+            ),
+          ],
+          dateRange: DateRange(
+            start: DateTime(2024, 6, 1),
+            end: DateTime(2024, 6, 30),
+          ),
+        );
+
+        expect(data.isEmpty, isFalse);
+        expect(data.isSinglePoint, isTrue);
+      });
+    });
+
+    group('MuscleGroupVolume', () {
+      test('creates with muscle group', () {
+        final volume = MuscleGroupVolume(
+          muscleGroup: MuscleGroup.chest,
+          label: 'Chest',
+          totalSets: 45,
+          percentage: 25.0,
+        );
+
+        expect(volume.muscleGroup, equals(MuscleGroup.chest));
+        expect(volume.label, equals('Chest'));
+        expect(volume.totalSets, equals(45));
+        expect(volume.percentage, equals(25.0));
+      });
+
+      test('creates Other category with null muscle group', () {
+        final volume = MuscleGroupVolume(
+          muscleGroup: null,
+          label: 'Other',
+          totalSets: 10,
+          percentage: 5.5,
+        );
+
+        expect(volume.muscleGroup, isNull);
+        expect(volume.label, equals('Other'));
+      });
+
+      test('equality works correctly', () {
+        final v1 = MuscleGroupVolume(
+          muscleGroup: MuscleGroup.back,
+          label: 'Back',
+          totalSets: 30,
+          percentage: 20.0,
+        );
+        final v2 = MuscleGroupVolume(
+          muscleGroup: MuscleGroup.back,
+          label: 'Back',
+          totalSets: 30,
+          percentage: 20.0,
+        );
+
+        expect(v1, equals(v2));
+      });
+    });
+
+    group('WeeklyTrendPoint', () {
+      test('creates with correct fields', () {
+        final monday = DateTime(2024, 6, 10); // A Monday
+        final point = WeeklyTrendPoint(
+          weekStart: monday,
+          totalVolume: 15000.0,
+          workoutCount: 4,
+        );
+
+        expect(point.weekStart, equals(monday));
+        expect(point.totalVolume, equals(15000.0));
+        expect(point.workoutCount, equals(4));
+      });
+
+      test('weekEnd returns correct Sunday', () {
+        final monday = DateTime(2024, 6, 10);
+        final point = WeeklyTrendPoint(
+          weekStart: monday,
+          totalVolume: 0,
+          workoutCount: 0,
+        );
+
+        expect(point.weekEnd, equals(DateTime(2024, 6, 16)));
+      });
+
+      test('weekRangeString formats correctly', () {
+        final point = WeeklyTrendPoint(
+          weekStart: DateTime(2024, 6, 10),
+          totalVolume: 0,
+          workoutCount: 0,
+        );
+
+        expect(point.weekRangeString, equals('Jun 10 - Jun 16'));
+      });
+
+      test('weekRangeString handles month boundary', () {
+        final point = WeeklyTrendPoint(
+          weekStart: DateTime(2024, 6, 27),
+          totalVolume: 0,
+          workoutCount: 0,
+        );
+
+        // June 27 (Thu) + 6 days = July 3
+        expect(point.weekRangeString, equals('Jun 27 - Jul 3'));
+      });
+
+      test('equality works correctly', () {
+        final p1 = WeeklyTrendPoint(
+          weekStart: DateTime(2024, 6, 10),
+          totalVolume: 15000.0,
+          workoutCount: 4,
+        );
+        final p2 = WeeklyTrendPoint(
+          weekStart: DateTime(2024, 6, 10),
+          totalVolume: 15000.0,
+          workoutCount: 4,
+        );
+
+        expect(p1, equals(p2));
+      });
+    });
+
+    group('ConfigurableStreak', () {
+      test('creates with correct fields', () {
+        final streak = ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 12,
+          longestStreak: 15,
+        );
+
+        expect(streak.weeklyTarget, equals(3));
+        expect(streak.currentStreak, equals(12));
+        expect(streak.longestStreak, equals(15));
+      });
+
+      test('currentStreakString formats correctly', () {
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 0, longestStreak: 0)
+              .currentStreakString,
+          equals('No streak'),
+        );
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 1, longestStreak: 1)
+              .currentStreakString,
+          equals('1-week streak'),
+        );
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 12, longestStreak: 15)
+              .currentStreakString,
+          equals('12-week streak'),
+        );
+      });
+
+      test('longestStreakString formats correctly', () {
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 0, longestStreak: 0)
+              .longestStreakString,
+          equals('No record'),
+        );
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 0, longestStreak: 1)
+              .longestStreakString,
+          equals('1 week'),
+        );
+        expect(
+          ConfigurableStreak(weeklyTarget: 3, currentStreak: 5, longestStreak: 15)
+              .longestStreakString,
+          equals('15 weeks'),
+        );
+      });
+
+      test('equality works correctly', () {
+        final s1 = ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 5,
+          longestStreak: 10,
+        );
+        final s2 = ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 5,
+          longestStreak: 10,
+        );
+        final s3 = ConfigurableStreak(
+          weeklyTarget: 4,
+          currentStreak: 5,
+          longestStreak: 10,
+        );
+
+        expect(s1, equals(s2));
+        expect(s1, isNot(equals(s3)));
       });
     });
   });

--- a/fittrack/test/utils/one_rm_calculator_test.dart
+++ b/fittrack/test/utils/one_rm_calculator_test.dart
@@ -1,0 +1,240 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/utils/one_rm_calculator.dart';
+import 'package:fittrack/models/exercise_set.dart';
+
+void main() {
+  group('OneRMCalculator', () {
+    group('epley', () {
+      test('calculates 1RM correctly for standard inputs', () {
+        // 100kg for 5 reps: 100 * (1 + 5/30) = 100 * 1.1667 ≈ 116.67
+        final result = OneRMCalculator.epley(100, 5);
+        expect(result, closeTo(116.67, 0.01));
+      });
+
+      test('calculates 1RM for 10 reps', () {
+        // 80kg for 10 reps: 80 * (1 + 10/30) = 80 * 1.3333 ≈ 106.67
+        final result = OneRMCalculator.epley(80, 10);
+        expect(result, closeTo(106.67, 0.01));
+      });
+
+      test('returns weight itself for 1 rep (actual 1RM)', () {
+        final result = OneRMCalculator.epley(120, 1);
+        expect(result, equals(120.0));
+      });
+
+      test('returns 0 for 0 reps', () {
+        final result = OneRMCalculator.epley(100, 0);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for negative reps', () {
+        final result = OneRMCalculator.epley(100, -1);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for 0 weight', () {
+        final result = OneRMCalculator.epley(0, 5);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for negative weight', () {
+        final result = OneRMCalculator.epley(-50, 5);
+        expect(result, equals(0.0));
+      });
+
+      test('handles decimal weight', () {
+        // 67.5kg for 8 reps: 67.5 * (1 + 8/30) = 67.5 * 1.2667 ≈ 85.5
+        final result = OneRMCalculator.epley(67.5, 8);
+        expect(result, closeTo(85.5, 0.01));
+      });
+    });
+
+    group('brzycki', () {
+      test('calculates 1RM correctly for standard inputs', () {
+        // 100kg for 5 reps: 100 * (36 / (37 - 5)) = 100 * (36/32) = 112.5
+        final result = OneRMCalculator.brzycki(100, 5);
+        expect(result, closeTo(112.5, 0.01));
+      });
+
+      test('calculates 1RM for 10 reps', () {
+        // 80kg for 10 reps: 80 * (36 / (37 - 10)) = 80 * (36/27) ≈ 106.67
+        final result = OneRMCalculator.brzycki(80, 10);
+        expect(result, closeTo(106.67, 0.01));
+      });
+
+      test('returns weight itself for 1 rep (actual 1RM)', () {
+        final result = OneRMCalculator.brzycki(120, 1);
+        expect(result, equals(120.0));
+      });
+
+      test('returns 0 for 0 reps', () {
+        final result = OneRMCalculator.brzycki(100, 0);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for negative reps', () {
+        final result = OneRMCalculator.brzycki(100, -1);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for 0 weight', () {
+        final result = OneRMCalculator.brzycki(0, 5);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for negative weight', () {
+        final result = OneRMCalculator.brzycki(-50, 5);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for reps >= 37 (division by zero protection)', () {
+        final result = OneRMCalculator.brzycki(100, 37);
+        expect(result, equals(0.0));
+      });
+
+      test('returns 0 for reps > 37', () {
+        final result = OneRMCalculator.brzycki(100, 40);
+        expect(result, equals(0.0));
+      });
+    });
+
+    group('estimateFromSets', () {
+      ExerciseSet createTestSet({
+        double? weight,
+        int? reps,
+        String id = '1',
+      }) {
+        return ExerciseSet(
+          id: id,
+          setNumber: 1,
+          reps: reps,
+          weight: weight,
+          createdAt: DateTime.now(),
+          updatedAt: DateTime.now(),
+          userId: 'user123',
+          exerciseId: 'ex1',
+          workoutId: 'w1',
+          weekId: 'wk1',
+          programId: 'p1',
+        );
+      }
+
+      test('returns best 1RM from multiple sets', () {
+        final sets = [
+          createTestSet(weight: 80, reps: 8, id: '1'),   // Epley: 80*(1+8/30) ≈ 101.33
+          createTestSet(weight: 100, reps: 3, id: '2'),   // Epley: 100*(1+3/30) = 110.0
+          createTestSet(weight: 90, reps: 5, id: '3'),    // Epley: 90*(1+5/30) = 105.0
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNotNull);
+        expect(result, closeTo(110.0, 0.01));
+      });
+
+      test('returns null for empty set list', () {
+        final result = OneRMCalculator.estimateFromSets([]);
+        expect(result, isNull);
+      });
+
+      test('returns null when all sets have reps > 10', () {
+        final sets = [
+          createTestSet(weight: 60, reps: 12, id: '1'),
+          createTestSet(weight: 50, reps: 15, id: '2'),
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNull);
+      });
+
+      test('returns null when all sets have null weight', () {
+        final sets = [
+          createTestSet(weight: null, reps: 5, id: '1'),
+          createTestSet(weight: null, reps: 8, id: '2'),
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNull);
+      });
+
+      test('returns null when all sets have null reps', () {
+        final sets = [
+          createTestSet(weight: 100, reps: null, id: '1'),
+          createTestSet(weight: 80, reps: null, id: '2'),
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNull);
+      });
+
+      test('skips sets with weight <= 0', () {
+        final sets = [
+          createTestSet(weight: 0, reps: 5, id: '1'),
+          createTestSet(weight: -10, reps: 3, id: '2'),
+          createTestSet(weight: 80, reps: 5, id: '3'),  // Only eligible set
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNotNull);
+        expect(result, closeTo(OneRMCalculator.epley(80, 5), 0.01));
+      });
+
+      test('skips sets with reps <= 0', () {
+        final sets = [
+          createTestSet(weight: 100, reps: 0, id: '1'),
+          createTestSet(weight: 100, reps: -1, id: '2'),
+          createTestSet(weight: 80, reps: 5, id: '3'),  // Only eligible set
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNotNull);
+        expect(result, closeTo(OneRMCalculator.epley(80, 5), 0.01));
+      });
+
+      test('filters out sets with reps > 10 but uses eligible ones', () {
+        final sets = [
+          createTestSet(weight: 60, reps: 15, id: '1'),  // Skipped: reps > 10
+          createTestSet(weight: 100, reps: 5, id: '2'),   // Eligible
+          createTestSet(weight: 50, reps: 20, id: '3'),   // Skipped: reps > 10
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNotNull);
+        expect(result, closeTo(OneRMCalculator.epley(100, 5), 0.01));
+      });
+
+      test('handles single eligible set', () {
+        final sets = [
+          createTestSet(weight: 100, reps: 1, id: '1'),  // Actual 1RM
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, equals(100.0));
+      });
+
+      test('handles set at max reliable reps boundary (10)', () {
+        final sets = [
+          createTestSet(weight: 70, reps: 10, id: '1'),
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNotNull);
+        expect(result, closeTo(OneRMCalculator.epley(70, 10), 0.01));
+      });
+
+      test('excludes set at reps = 11 (above max reliable)', () {
+        final sets = [
+          createTestSet(weight: 70, reps: 11, id: '1'),
+        ];
+
+        final result = OneRMCalculator.estimateFromSets(sets);
+        expect(result, isNull);
+      });
+    });
+
+    group('maxReliableReps constant', () {
+      test('is set to 10', () {
+        expect(OneRMCalculator.maxReliableReps, equals(10));
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Added 5 new analytics model classes (`ExerciseProgressPoint`, `ExerciseProgressData`, `MuscleGroupVolume`, `WeeklyTrendPoint`, `ConfigurableStreak`) to `lib/models/analytics.dart`
- Added 4 `DateRange` factory constructors (`lastMonth`, `last3Months`, `last6Months`, `allTime`)
- Created `OneRMCalculator` utility (`lib/utils/one_rm_calculator.dart`) with Epley and Brzycki formulas plus `estimateFromSets` helper
- Comprehensive unit tests for all new models and the 1RM calculator (52+ test cases)

## Changes
| File | Change |
|------|--------|
| `lib/models/analytics.dart` | +5 model classes, +4 DateRange factories |
| `lib/utils/one_rm_calculator.dart` | New 1RM calculator utility |
| `test/models/analytics_test.dart` | +24 tests for new models |
| `test/utils/one_rm_calculator_test.dart` | +28 tests for 1RM calculator |

## Test plan
- [x] Unit tests for Epley formula (standard, edge cases, decimals)
- [x] Unit tests for Brzycki formula (standard, edge cases, division-by-zero protection)
- [x] Unit tests for `estimateFromSets` (filtering, null handling, boundaries)
- [x] Unit tests for all 5 new model classes (construction, equality, getters)
- [x] Unit tests for DateRange factory constructors
- [ ] CI pipeline passes all tests

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)