### PR TITLE
feat: Add 3-tab analytics screen layout (#353)

### DIFF
--- a/fittrack/lib/screens/analytics/analytics_screen.dart
+++ b/fittrack/lib/screens/analytics/analytics_screen.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../models/analytics.dart';
 import '../../models/navigation_section.dart';
 import '../../providers/program_provider.dart';
 import '../../services/analytics_service.dart';
 import '../../widgets/error_display.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
-import 'components/monthly_heatmap_section.dart';
-import 'components/key_statistics_section.dart';
-import 'components/charts_section.dart';
+import 'components/overview_tab.dart';
+import 'components/exercise_tab.dart';
+import 'components/trends_tab.dart';
 
-/// Analytics screen providing comprehensive workout insights
+/// Analytics screen with 3-tab layout: Overview, Exercise, Trends.
 class AnalyticsScreen extends StatefulWidget {
   final AnalyticsService? analyticsService;
 
@@ -24,35 +23,15 @@ class AnalyticsScreen extends StatefulWidget {
 }
 
 class _AnalyticsScreenState extends State<AnalyticsScreen> {
-
-  @override
-  void initState() {
-    super.initState();
-
-    // No need to manually load analytics - ProgramProvider auto-loads when userId is set
-    // Removed manual loadAnalytics() call to prevent race condition
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-        appBar: AppBar(
-        title: const Text('Analytics'),
-        backgroundColor: Theme.of(context).colorScheme.inversePrimary,
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.refresh),
-            onPressed: () {
-              context.read<ProgramProvider>().refreshAnalytics();
-            },
-            tooltip: 'Refresh Analytics',
-          ),
-        ],
-      ),
-      body: Consumer<ProgramProvider>(
-        builder: (context, provider, child) {
-          if (provider.isLoadingAnalytics) {
-            return const Center(
+    return Consumer<ProgramProvider>(
+      builder: (context, provider, child) {
+        // Show loading state
+        if (provider.isLoadingAnalytics) {
+          return Scaffold(
+            appBar: _buildAppBar(context, hasTabBar: false),
+            body: const Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
@@ -61,32 +40,44 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
                   Text('Loading analytics...'),
                 ],
               ),
-            );
-          }
+            ),
+            bottomNavigationBar: const GlobalBottomNavBar(
+              currentSection: NavigationSection.analytics,
+            ),
+          );
+        }
 
-          if (provider.error != null) {
-            return ErrorDisplay(
+        // Show error state
+        if (provider.error != null) {
+          return Scaffold(
+            appBar: _buildAppBar(context, hasTabBar: false),
+            body: ErrorDisplay(
               message: 'Unable to load analytics data. Please check your connection and try again.',
               technicalError: provider.error,
               onRetry: () {
-                // Get fresh provider reference in case it was recreated
                 final freshProvider = Provider.of<ProgramProvider>(context, listen: false);
                 freshProvider.clearError();
                 freshProvider.loadAnalytics();
               },
-            );
-          }
+            ),
+            bottomNavigationBar: const GlobalBottomNavBar(
+              currentSection: NavigationSection.analytics,
+            ),
+          );
+        }
 
-          // Check if we have any data to display
-          if (provider.monthHeatmapData == null && provider.currentAnalytics == null) {
-            return Center(
+        // Show empty state
+        if (provider.monthHeatmapData == null && provider.currentAnalytics == null) {
+          return Scaffold(
+            appBar: _buildAppBar(context, hasTabBar: false),
+            body: Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Icon(
                     Icons.analytics_outlined,
                     size: 64,
-                    color: Theme.of(context).colorScheme.onSurface.withOpacity(0.4),
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
                   ),
                   const SizedBox(height: 16),
                   Text(
@@ -109,47 +100,56 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
                   ),
                 ],
               ),
-            );
-          }
-
-          return RefreshIndicator(
-            onRefresh: () async {
-              await provider.refreshAnalytics();
-            },
-            child: SingleChildScrollView(
-              physics: const AlwaysScrollableScrollPhysics(),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Monthly Heatmap Section with swipe navigation
-                  if (provider.monthHeatmapData != null && provider.userId != null)
-                    MonthlyHeatmapSection(
-                      userId: provider.userId!,
-                      analyticsService: widget.analyticsService ?? AnalyticsService.instance,
-                    ),
-
-                  // Key Statistics Section
-                  if (provider.keyStatistics != null)
-                    KeyStatisticsSection(statistics: provider.keyStatistics!),
-
-                  // Charts Section
-                  if (provider.currentAnalytics != null || provider.recentPRs != null)
-                    ChartsSection(
-                      analytics: provider.currentAnalytics,
-                      personalRecords: provider.recentPRs ?? [],
-                    ),
-
-                  // Bottom padding
-                  const SizedBox(height: 24),
-                ],
-              ),
+            ),
+            bottomNavigationBar: const GlobalBottomNavBar(
+              currentSection: NavigationSection.analytics,
             ),
           );
-        },
-      ),
-      bottomNavigationBar: const GlobalBottomNavBar(
-        currentSection: NavigationSection.analytics,
-      ),
+        }
+
+        // Show tabbed content
+        return DefaultTabController(
+          length: 3,
+          child: Scaffold(
+            appBar: _buildAppBar(context, hasTabBar: true),
+            body: TabBarView(
+              children: [
+                OverviewTab(analyticsService: widget.analyticsService),
+                const ExerciseTab(),
+                const TrendsTab(),
+              ],
+            ),
+            bottomNavigationBar: const GlobalBottomNavBar(
+              currentSection: NavigationSection.analytics,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  PreferredSizeWidget _buildAppBar(BuildContext context, {required bool hasTabBar}) {
+    return AppBar(
+      title: const Text('Analytics'),
+      backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+      actions: [
+        IconButton(
+          icon: const Icon(Icons.refresh),
+          onPressed: () {
+            context.read<ProgramProvider>().refreshAnalytics();
+          },
+          tooltip: 'Refresh Analytics',
+        ),
+      ],
+      bottom: hasTabBar
+          ? const TabBar(
+              tabs: [
+                Tab(icon: Icon(Icons.dashboard), text: 'Overview'),
+                Tab(icon: Icon(Icons.show_chart), text: 'Exercise'),
+                Tab(icon: Icon(Icons.trending_up), text: 'Trends'),
+              ],
+            )
+          : null,
     );
   }
 }

--- a/fittrack/lib/screens/analytics/components/exercise_tab.dart
+++ b/fittrack/lib/screens/analytics/components/exercise_tab.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../models/exercise.dart';
+import '../../../providers/program_provider.dart';
+import '../../../widgets/charts/line_chart_widget.dart';
+import '../../../widgets/charts/chart_data.dart';
+import '../../../widgets/charts/time_range_selector.dart';
+
+/// Exercise tab showing per-exercise progress charts.
+///
+/// Lazy-loads logged exercises on first visit, then displays
+/// a picker and line chart for the selected exercise.
+class ExerciseTab extends StatefulWidget {
+  const ExerciseTab({super.key});
+
+  @override
+  State<ExerciseTab> createState() => _ExerciseTabState();
+}
+
+class _ExerciseTabState extends State<ExerciseTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  bool _loaded = false;
+  bool _loading = false;
+  List<({String exerciseId, String exerciseName, ExerciseType exerciseType})>
+      _exercises = [];
+  int? _selectedExerciseIndex;
+  TimeRange _selectedTimeRange = TimeRange.threeMonths;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_loaded && !_loading) {
+      _loadExercises();
+    }
+  }
+
+  Future<void> _loadExercises() async {
+    setState(() => _loading = true);
+    final provider = context.read<ProgramProvider>();
+    final exercises = await provider.getLoggedExercises();
+    if (mounted) {
+      setState(() {
+        _exercises = exercises;
+        _loaded = true;
+        _loading = false;
+        if (_exercises.isNotEmpty && _selectedExerciseIndex == null) {
+          _selectedExerciseIndex = 0;
+          _loadExerciseProgress();
+        }
+      });
+    }
+  }
+
+  Future<void> _loadExerciseProgress() async {
+    if (_selectedExerciseIndex == null || _selectedExerciseIndex! >= _exercises.length) return;
+
+    final exercise = _exercises[_selectedExerciseIndex!];
+    final provider = context.read<ProgramProvider>();
+    await provider.loadExerciseProgress(
+      exerciseId: exercise.exerciseId,
+      exerciseName: exercise.exerciseName,
+      exerciseType: exercise.exerciseType,
+      dateRange: _selectedTimeRange.toDateRange(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_exercises.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.show_chart,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'No Exercises Logged',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Complete workouts to track exercise progress',
+              style: Theme.of(context).textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Consumer<ProgramProvider>(
+      builder: (context, provider, child) {
+        return RefreshIndicator(
+          onRefresh: () async {
+            await provider.refreshAnalytics();
+            await _loadExercises();
+          },
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Exercise picker
+                _buildExercisePicker(context),
+                const SizedBox(height: 16),
+
+                // Time range selector
+                TimeRangeSelector(
+                  selected: _selectedTimeRange,
+                  onChanged: (range) {
+                    setState(() => _selectedTimeRange = range);
+                    _loadExerciseProgress();
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                // Progress chart
+                _buildProgressChart(provider),
+
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildExercisePicker(BuildContext context) {
+    return DropdownButtonFormField<int>(
+      initialValue: _selectedExerciseIndex,
+      decoration: const InputDecoration(
+        labelText: 'Exercise',
+        border: OutlineInputBorder(),
+      ),
+      items: List.generate(_exercises.length, (index) {
+        final exercise = _exercises[index];
+        return DropdownMenuItem(
+          value: index,
+          child: Text(exercise.exerciseName),
+        );
+      }),
+      onChanged: (index) {
+        setState(() => _selectedExerciseIndex = index);
+        _loadExerciseProgress();
+      },
+    );
+  }
+
+  Widget _buildProgressChart(ProgramProvider provider) {
+    final progressData = provider.exerciseProgress;
+
+    if (progressData == null) {
+      return const SizedBox(
+        height: 250,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (progressData.isEmpty) {
+      return SizedBox(
+        height: 250,
+        child: Center(
+          child: Text(
+            'No data for this exercise in the selected time range',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    final isStrength =
+        progressData.exerciseType == ExerciseType.strength;
+
+    // Build primary data points (weight or reps or duration)
+    final primaryData = progressData.dataPoints.map((point) {
+      double value;
+      if (point.maxWeight != null) {
+        value = point.maxWeight!;
+      } else if (point.maxReps != null) {
+        value = point.maxReps!.toDouble();
+      } else if (point.totalDuration != null) {
+        value = point.totalDuration!.toDouble();
+      } else {
+        value = 0;
+      }
+      return ChartDataPoint(date: point.date, value: value);
+    }).toList();
+
+    // Build secondary data points (est. 1RM for strength)
+    List<ChartDataPoint>? secondaryData;
+    if (isStrength) {
+      final points = progressData.dataPoints
+          .where((p) => p.estimated1RM != null)
+          .map((p) => ChartDataPoint(date: p.date, value: p.estimated1RM!))
+          .toList();
+      if (points.isNotEmpty) {
+        secondaryData = points;
+      }
+    }
+
+    return LineChartWidget(
+      data: primaryData,
+      secondaryData: secondaryData,
+      primaryLabel: isStrength ? 'Weight' : 'Value',
+      secondaryLabel: isStrength ? 'Est. 1RM' : null,
+      emptyMessage: 'No data available',
+    );
+  }
+}

--- a/fittrack/lib/screens/analytics/components/overview_tab.dart
+++ b/fittrack/lib/screens/analytics/components/overview_tab.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../providers/program_provider.dart';
+import '../../../services/analytics_service.dart';
+import 'monthly_heatmap_section.dart';
+import 'key_statistics_section.dart';
+import 'charts_section.dart';
+
+/// Overview tab displaying existing analytics content:
+/// monthly heatmap, key statistics, and exercise/PR charts.
+class OverviewTab extends StatefulWidget {
+  final AnalyticsService? analyticsService;
+
+  const OverviewTab({super.key, this.analyticsService});
+
+  @override
+  State<OverviewTab> createState() => _OverviewTabState();
+}
+
+class _OverviewTabState extends State<OverviewTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    return Consumer<ProgramProvider>(
+      builder: (context, provider, child) {
+        return RefreshIndicator(
+          onRefresh: () => provider.refreshAnalytics(),
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Monthly Heatmap Section with swipe navigation
+                if (provider.monthHeatmapData != null &&
+                    provider.userId != null)
+                  MonthlyHeatmapSection(
+                    userId: provider.userId!,
+                    analyticsService:
+                        widget.analyticsService ?? AnalyticsService.instance,
+                  ),
+
+                // Key Statistics Section
+                if (provider.keyStatistics != null)
+                  KeyStatisticsSection(statistics: provider.keyStatistics!),
+
+                // Charts Section
+                if (provider.currentAnalytics != null ||
+                    provider.recentPRs != null)
+                  ChartsSection(
+                    analytics: provider.currentAnalytics,
+                    personalRecords: provider.recentPRs ?? [],
+                  ),
+
+                // Bottom padding
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/fittrack/lib/screens/analytics/components/trends_tab.dart
+++ b/fittrack/lib/screens/analytics/components/trends_tab.dart
@@ -1,0 +1,270 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../models/custom_exercise.dart';
+import '../../../models/library_exercise.dart';
+import '../../../models/muscle_group.dart';
+import '../../../providers/program_provider.dart';
+import '../../../widgets/charts/bar_chart_widget.dart';
+import '../../../widgets/charts/chart_data.dart';
+import '../../../widgets/charts/line_chart_widget.dart';
+import '../../../widgets/charts/time_range_selector.dart';
+
+/// Trends tab showing streak, muscle group volume, and weekly trends.
+///
+/// Lazy-loads data on first visit. Displays three sections:
+/// 1. Configurable streak
+/// 2. Muscle group volume bar chart
+/// 3. Weekly training trends line chart
+class TrendsTab extends StatefulWidget {
+  const TrendsTab({super.key});
+
+  @override
+  State<TrendsTab> createState() => _TrendsTabState();
+}
+
+class _TrendsTabState extends State<TrendsTab>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  bool _loaded = false;
+  bool _loading = false;
+  TimeRange _selectedTimeRange = TimeRange.threeMonths;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_loaded && !_loading) {
+      _loadTrendsData();
+    }
+  }
+
+  Future<void> _loadTrendsData() async {
+    setState(() => _loading = true);
+    final provider = context.read<ProgramProvider>();
+    final dateRange = _selectedTimeRange.toDateRange();
+
+    await Future.wait([
+      provider.loadWeeklyTrends(dateRange: dateRange),
+      provider.loadMuscleGroupVolume(
+        dateRange: dateRange,
+        libraryExercises: const <LibraryExercise>[],
+        customExercises: const <CustomExercise>[],
+      ),
+    ]);
+
+    if (mounted) {
+      setState(() {
+        _loaded = true;
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+
+    return Consumer<ProgramProvider>(
+      builder: (context, provider, child) {
+        return RefreshIndicator(
+          onRefresh: () async {
+            await provider.refreshAnalytics();
+            await _loadTrendsData();
+          },
+          child: SingleChildScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Time range selector
+                TimeRangeSelector(
+                  selected: _selectedTimeRange,
+                  onChanged: (range) {
+                    setState(() {
+                      _selectedTimeRange = range;
+                      _loading = true;
+                    });
+                    _loadTrendsData();
+                  },
+                ),
+                const SizedBox(height: 24),
+
+                // Streak section
+                _buildStreakSection(context, provider),
+                const SizedBox(height: 24),
+
+                // Muscle group volume section
+                _buildMuscleGroupSection(context, provider),
+                const SizedBox(height: 24),
+
+                // Weekly trends section
+                _buildWeeklyTrendsSection(context, provider),
+                const SizedBox(height: 24),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildStreakSection(BuildContext context, ProgramProvider provider) {
+    final streak = provider.configurableStreak;
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Workout Streak', style: textTheme.titleMedium),
+                // Weekly target selector
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text('Target: ', style: textTheme.bodySmall),
+                    DropdownButton<int>(
+                      value: provider.weeklyWorkoutTarget,
+                      underline: const SizedBox.shrink(),
+                      isDense: true,
+                      items: List.generate(7, (i) => i + 1)
+                          .map((n) => DropdownMenuItem(
+                                value: n,
+                                child: Text('$n/wk'),
+                              ))
+                          .toList(),
+                      onChanged: (value) {
+                        if (value != null) {
+                          provider.setWeeklyWorkoutTarget(value);
+                        }
+                      },
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (streak != null) ...[
+              Row(
+                children: [
+                  Icon(Icons.local_fire_department,
+                      color: colorScheme.primary, size: 32),
+                  const SizedBox(width: 8),
+                  Text(
+                    streak.currentStreakString,
+                    style: textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Longest: ${streak.longestStreakString}',
+                style: textTheme.bodySmall,
+              ),
+            ] else if (_loading)
+              const Center(child: CircularProgressIndicator())
+            else
+              Text('No streak data', style: textTheme.bodyMedium),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMuscleGroupSection(
+      BuildContext context, ProgramProvider provider) {
+    final volumeData = provider.muscleGroupVolume;
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Muscle Group Volume', style: textTheme.titleMedium),
+            const SizedBox(height: 12),
+            if (_loading)
+              const Center(child: CircularProgressIndicator())
+            else if (volumeData == null || volumeData.isEmpty)
+              Text('No volume data for this period',
+                  style: textTheme.bodyMedium)
+            else
+              BarChartWidget(
+                entries: volumeData
+                    .map((v) => BarChartEntry(
+                          label: v.label,
+                          value: v.totalSets.toDouble(),
+                          percentage: v.percentage,
+                          color: _colorForMuscleGroup(v.muscleGroup, colorScheme),
+                        ))
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWeeklyTrendsSection(
+      BuildContext context, ProgramProvider provider) {
+    final trendsData = provider.weeklyTrends;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Weekly Training Volume', style: textTheme.titleMedium),
+            const SizedBox(height: 12),
+            if (_loading)
+              const Center(child: CircularProgressIndicator())
+            else if (trendsData == null || trendsData.isEmpty)
+              Text('No training data for this period',
+                  style: textTheme.bodyMedium)
+            else
+              LineChartWidget(
+                data: trendsData
+                    .map((w) => ChartDataPoint(
+                          date: w.weekStart,
+                          value: w.totalVolume,
+                          label: '${w.workoutCount} workouts',
+                        ))
+                    .toList(),
+                primaryLabel: 'Volume (kg)',
+                emptyMessage: 'No training data',
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _colorForMuscleGroup(MuscleGroup? muscleGroup, ColorScheme colorScheme) {
+    if (muscleGroup == null) return colorScheme.surfaceContainerHighest;
+    switch (muscleGroup) {
+      case MuscleGroup.chest:
+        return colorScheme.primary;
+      case MuscleGroup.back:
+        return colorScheme.secondary;
+      case MuscleGroup.shoulders:
+        return colorScheme.tertiary;
+      case MuscleGroup.arms:
+        return colorScheme.primaryContainer;
+      case MuscleGroup.legs:
+        return colorScheme.error;
+      case MuscleGroup.core:
+        return colorScheme.tertiaryContainer;
+    }
+  }
+}

--- a/fittrack/test/screens/analytics/analytics_screen_test.dart
+++ b/fittrack/test/screens/analytics/analytics_screen_test.dart
@@ -396,4 +396,65 @@ void main() {
       expect(refreshButton, findsOneWidget);
     });
   });
+
+  group('AnalyticsScreen - Tab Navigation', () {
+    void setupWithData() {
+      when(mockProvider.monthHeatmapData).thenReturn(MonthHeatmapData(
+        year: 2024,
+        month: 12,
+        dailySetCounts: {1: 5},
+        totalSets: 5,
+        fetchedAt: DateTime.now(),
+      ));
+      when(mockProvider.userId).thenReturn('test-user-id');
+
+      // Stub new provider getters
+      when(mockProvider.exerciseProgress).thenReturn(null);
+      when(mockProvider.muscleGroupVolume).thenReturn(null);
+      when(mockProvider.weeklyTrends).thenReturn(null);
+      when(mockProvider.configurableStreak).thenReturn(null);
+      when(mockProvider.weeklyWorkoutTarget).thenReturn(3);
+      when(mockProvider.getLoggedExercises()).thenAnswer((_) async => []);
+    }
+
+    testWidgets('shows TabBar with 3 tabs when data available', (WidgetTester tester) async {
+      setupWithData();
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.text('Overview'), findsOneWidget);
+      expect(find.text('Exercise'), findsOneWidget);
+      expect(find.text('Trends'), findsOneWidget);
+    });
+
+    testWidgets('does not show TabBar when loading', (WidgetTester tester) async {
+      when(mockProvider.isLoadingAnalytics).thenReturn(true);
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.byType(TabBar), findsNothing);
+    });
+
+    testWidgets('does not show TabBar when error', (WidgetTester tester) async {
+      when(mockProvider.error).thenReturn('Some error');
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.byType(TabBar), findsNothing);
+    });
+
+    testWidgets('does not show TabBar when no data', (WidgetTester tester) async {
+      // Default setup has no data
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.byType(TabBar), findsNothing);
+    });
+
+    testWidgets('shows tab icons', (WidgetTester tester) async {
+      setupWithData();
+      await tester.pumpWidget(createTestWidget());
+
+      expect(find.byIcon(Icons.dashboard), findsOneWidget);
+      expect(find.byIcon(Icons.show_chart), findsOneWidget);
+      expect(find.byIcon(Icons.trending_up), findsOneWidget);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Restructures `AnalyticsScreen` from single scrollable page to 3-tab layout (Overview, Exercise, Trends)
- Extracts existing analytics content into `OverviewTab` component
- Creates `ExerciseTab` with exercise picker, time range selector, and progress line chart
- Creates `TrendsTab` with configurable streak card, muscle group volume bar chart, and weekly trends line chart
- Adds 5 new tab navigation widget tests

## Implementation Details
- Uses `DefaultTabController` with `TabBar`/`TabBarView` for tab navigation
- `AutomaticKeepAliveClientMixin` preserves tab state when switching
- Exercise and Trends tabs lazy-load data on first visit via `didChangeDependencies`
- Loading/error/empty states render without tabs; data state renders with tabs
- Leverages chart widgets from task #352 (`LineChartWidget`, `BarChartWidget`, `TimeRangeSelector`)

## Test plan
- [ ] Widget tests verify TabBar appears only when data is present
- [ ] Widget tests verify TabBar hidden during loading/error/no-data states
- [ ] Widget tests verify all 3 tab icons render correctly
- [ ] Existing analytics screen tests continue to pass
- [ ] CI passes all checks

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)