### PR TITLE
feat: Searchable exercise picker and progress chart (#354)

### DIFF
--- a/fittrack/lib/screens/analytics/components/exercise_picker.dart
+++ b/fittrack/lib/screens/analytics/components/exercise_picker.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/exercise.dart';
+
+/// A record representing a logged exercise available for selection.
+typedef LoggedExercise = ({
+  String exerciseId,
+  String exerciseName,
+  ExerciseType exerciseType,
+});
+
+/// Searchable exercise picker showing exercises the user has logged.
+///
+/// Displays a search field and a filterable list of exercises with
+/// type chips. Calls [onSelected] when an exercise is tapped.
+class ExercisePicker extends StatefulWidget {
+  final List<LoggedExercise> exercises;
+  final int? selectedIndex;
+  final ValueChanged<int> onSelected;
+
+  const ExercisePicker({
+    super.key,
+    required this.exercises,
+    this.selectedIndex,
+    required this.onSelected,
+  });
+
+  @override
+  State<ExercisePicker> createState() => _ExercisePickerState();
+}
+
+class _ExercisePickerState extends State<ExercisePicker> {
+  final _searchController = TextEditingController();
+  String _query = '';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  List<int> get _filteredIndices {
+    if (_query.isEmpty) {
+      return List.generate(widget.exercises.length, (i) => i);
+    }
+    final lower = _query.toLowerCase();
+    return [
+      for (int i = 0; i < widget.exercises.length; i++)
+        if (widget.exercises[i].exerciseName.toLowerCase().contains(lower)) i,
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Search field
+        TextField(
+          controller: _searchController,
+          decoration: InputDecoration(
+            hintText: 'Search exercises...',
+            prefixIcon: const Icon(Icons.search),
+            border: const OutlineInputBorder(),
+            suffixIcon: _query.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      _searchController.clear();
+                      setState(() => _query = '');
+                    },
+                  )
+                : null,
+          ),
+          onChanged: (value) => setState(() => _query = value),
+        ),
+        const SizedBox(height: 8),
+
+        // Exercise list
+        Expanded(
+          child: _filteredIndices.isEmpty
+              ? Center(
+                  child: Text(
+                    _query.isEmpty
+                        ? 'No exercises logged'
+                        : 'No matches for "$_query"',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                )
+              : Semantics(
+                  label: 'Exercise list, ${_filteredIndices.length} items',
+                  child: ListView.builder(
+                    itemCount: _filteredIndices.length,
+                    itemBuilder: (context, i) {
+                      final originalIndex = _filteredIndices[i];
+                      final exercise = widget.exercises[originalIndex];
+                      final isSelected =
+                          widget.selectedIndex == originalIndex;
+
+                      return ListTile(
+                        selected: isSelected,
+                        selectedTileColor:
+                            colorScheme.primaryContainer.withValues(alpha: 0.3),
+                        title: Text(exercise.exerciseName),
+                        trailing: Chip(
+                          label: Text(exercise.exerciseType.displayName),
+                          backgroundColor:
+                              _typeColor(exercise.exerciseType)
+                                  .withValues(alpha: 0.1),
+                          labelStyle: TextStyle(
+                            color: _typeColor(exercise.exerciseType),
+                            fontWeight: FontWeight.w600,
+                            fontSize: 12,
+                          ),
+                          padding: EdgeInsets.zero,
+                          visualDensity: VisualDensity.compact,
+                        ),
+                        onTap: () => widget.onSelected(originalIndex),
+                      );
+                    },
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  static Color _typeColor(ExerciseType type) {
+    switch (type) {
+      case ExerciseType.strength:
+        return Colors.blue;
+      case ExerciseType.cardio:
+        return Colors.red;
+      case ExerciseType.timeBased:
+        return Colors.orange;
+      case ExerciseType.bodyweight:
+        return Colors.green;
+      case ExerciseType.custom:
+        return Colors.purple;
+    }
+  }
+}

--- a/fittrack/lib/screens/analytics/components/exercise_progress_section.dart
+++ b/fittrack/lib/screens/analytics/components/exercise_progress_section.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/analytics.dart';
+import '../../../models/exercise.dart';
+import '../../../widgets/charts/chart_data.dart';
+import '../../../widgets/charts/line_chart_widget.dart';
+import '../../../widgets/charts/time_range_selector.dart';
+
+/// Displays a per-exercise progress chart with time range selector.
+///
+/// Shows different metrics based on exercise type:
+/// - Strength: Max Weight (primary) + Est. 1RM (secondary dashed)
+/// - Bodyweight: Max Reps
+/// - Cardio/Time-based: Duration
+/// - Custom: Volume (weight * reps)
+class ExerciseProgressSection extends StatelessWidget {
+  final ExerciseProgressData? progressData;
+  final TimeRange selectedTimeRange;
+  final ValueChanged<TimeRange> onTimeRangeChanged;
+  final bool isLoading;
+
+  const ExerciseProgressSection({
+    super.key,
+    required this.progressData,
+    required this.selectedTimeRange,
+    required this.onTimeRangeChanged,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Time range selector
+        TimeRangeSelector(
+          selected: selectedTimeRange,
+          onChanged: onTimeRangeChanged,
+        ),
+        const SizedBox(height: 16),
+
+        // Chart content
+        _buildChartContent(context),
+      ],
+    );
+  }
+
+  Widget _buildChartContent(BuildContext context) {
+    if (isLoading) {
+      return const SizedBox(
+        height: 250,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (progressData == null) {
+      return SizedBox(
+        height: 250,
+        child: Center(
+          child: Text(
+            'Select an exercise to see progress',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    if (progressData!.isEmpty) {
+      return SizedBox(
+        height: 250,
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.show_chart,
+                size: 48,
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withValues(alpha: 0.3),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'No data for this exercise in the selected time range',
+                style: Theme.of(context).textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    final isStrength =
+        progressData!.exerciseType == ExerciseType.strength;
+
+    // Build primary data points
+    final primaryData = _buildPrimaryData();
+
+    // Build secondary data points (est. 1RM for strength)
+    final secondaryData = isStrength ? _buildSecondaryData() : null;
+
+    // Determine labels based on exercise type
+    final labels = _labelsForType(progressData!.exerciseType);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Metric label
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: Text(
+            labels.metricDescription,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+        ),
+        LineChartWidget(
+          data: primaryData,
+          secondaryData: secondaryData,
+          primaryLabel: labels.primary,
+          secondaryLabel: labels.secondary,
+          yAxisLabel: labels.yAxis,
+          emptyMessage: 'No data available',
+        ),
+      ],
+    );
+  }
+
+  List<ChartDataPoint> _buildPrimaryData() {
+    return progressData!.dataPoints.map((point) {
+      double value;
+      switch (progressData!.exerciseType) {
+        case ExerciseType.strength:
+          value = point.maxWeight ?? 0;
+        case ExerciseType.bodyweight:
+          value = point.maxReps?.toDouble() ?? 0;
+        case ExerciseType.cardio:
+        case ExerciseType.timeBased:
+          value = point.totalDuration?.toDouble() ?? 0;
+        case ExerciseType.custom:
+          // Volume = weight * reps (best approximation)
+          value = (point.maxWeight ?? 0) * (point.maxReps ?? 1);
+      }
+      return ChartDataPoint(date: point.date, value: value);
+    }).toList();
+  }
+
+  List<ChartDataPoint>? _buildSecondaryData() {
+    final points = progressData!.dataPoints
+        .where((p) => p.estimated1RM != null)
+        .map((p) => ChartDataPoint(date: p.date, value: p.estimated1RM!))
+        .toList();
+    return points.isNotEmpty ? points : null;
+  }
+
+  static _ChartLabels _labelsForType(ExerciseType type) {
+    switch (type) {
+      case ExerciseType.strength:
+        return const _ChartLabels(
+          primary: 'Weight',
+          secondary: 'Est. 1RM',
+          yAxis: 'kg',
+          metricDescription: 'Showing max weight per session',
+        );
+      case ExerciseType.bodyweight:
+        return const _ChartLabels(
+          primary: 'Reps',
+          yAxis: 'reps',
+          metricDescription: 'Showing max reps per session',
+        );
+      case ExerciseType.cardio:
+      case ExerciseType.timeBased:
+        return const _ChartLabels(
+          primary: 'Duration',
+          yAxis: 'sec',
+          metricDescription: 'Showing total duration per session',
+        );
+      case ExerciseType.custom:
+        return const _ChartLabels(
+          primary: 'Volume',
+          yAxis: 'vol',
+          metricDescription: 'Showing estimated volume per session',
+        );
+    }
+  }
+}
+
+class _ChartLabels {
+  final String primary;
+  final String? secondary;
+  final String? yAxis;
+  final String metricDescription;
+
+  const _ChartLabels({
+    required this.primary,
+    this.secondary,
+    this.yAxis,
+    required this.metricDescription,
+  });
+}

--- a/fittrack/lib/screens/analytics/components/exercise_tab.dart
+++ b/fittrack/lib/screens/analytics/components/exercise_tab.dart
@@ -1,15 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../../models/exercise.dart';
 import '../../../providers/program_provider.dart';
-import '../../../widgets/charts/line_chart_widget.dart';
-import '../../../widgets/charts/chart_data.dart';
 import '../../../widgets/charts/time_range_selector.dart';
+import 'exercise_picker.dart';
+import 'exercise_progress_section.dart';
 
 /// Exercise tab showing per-exercise progress charts.
 ///
 /// Lazy-loads logged exercises on first visit, then displays
-/// a picker and line chart for the selected exercise.
+/// a searchable picker and progress chart for the selected exercise.
 class ExerciseTab extends StatefulWidget {
   const ExerciseTab({super.key});
 
@@ -24,8 +23,8 @@ class _ExerciseTabState extends State<ExerciseTab>
 
   bool _loaded = false;
   bool _loading = false;
-  List<({String exerciseId, String exerciseName, ExerciseType exerciseType})>
-      _exercises = [];
+  bool _loadingProgress = false;
+  List<LoggedExercise> _exercises = [];
   int? _selectedExerciseIndex;
   TimeRange _selectedTimeRange = TimeRange.threeMonths;
 
@@ -55,8 +54,10 @@ class _ExerciseTabState extends State<ExerciseTab>
   }
 
   Future<void> _loadExerciseProgress() async {
-    if (_selectedExerciseIndex == null || _selectedExerciseIndex! >= _exercises.length) return;
+    if (_selectedExerciseIndex == null ||
+        _selectedExerciseIndex! >= _exercises.length) return;
 
+    setState(() => _loadingProgress = true);
     final exercise = _exercises[_selectedExerciseIndex!];
     final provider = context.read<ProgramProvider>();
     await provider.loadExerciseProgress(
@@ -65,6 +66,9 @@ class _ExerciseTabState extends State<ExerciseTab>
       exerciseType: exercise.exerciseType,
       dateRange: _selectedTimeRange.toDateRange(),
     );
+    if (mounted) {
+      setState(() => _loadingProgress = false);
+    }
   }
 
   @override
@@ -83,7 +87,10 @@ class _ExerciseTabState extends State<ExerciseTab>
             Icon(
               Icons.show_chart,
               size: 64,
-              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.4),
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.4),
             ),
             const SizedBox(height: 16),
             Text(
@@ -103,123 +110,43 @@ class _ExerciseTabState extends State<ExerciseTab>
 
     return Consumer<ProgramProvider>(
       builder: (context, provider, child) {
-        return RefreshIndicator(
-          onRefresh: () async {
-            await provider.refreshAnalytics();
-            await _loadExercises();
-          },
-          child: SingleChildScrollView(
-            physics: const AlwaysScrollableScrollPhysics(),
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Exercise picker
-                _buildExercisePicker(context),
-                const SizedBox(height: 16),
-
-                // Time range selector
-                TimeRangeSelector(
-                  selected: _selectedTimeRange,
-                  onChanged: (range) {
+        return Column(
+          children: [
+            // Exercise picker (takes ~40% of available space)
+            Expanded(
+              flex: 2,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+                child: ExercisePicker(
+                  exercises: _exercises,
+                  selectedIndex: _selectedExerciseIndex,
+                  onSelected: (index) {
+                    setState(() => _selectedExerciseIndex = index);
+                    _loadExerciseProgress();
+                  },
+                ),
+              ),
+            ),
+            const Divider(),
+            // Progress chart section (takes ~60% of available space)
+            Expanded(
+              flex: 3,
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: ExerciseProgressSection(
+                  progressData: provider.exerciseProgress,
+                  selectedTimeRange: _selectedTimeRange,
+                  isLoading: _loadingProgress,
+                  onTimeRangeChanged: (range) {
                     setState(() => _selectedTimeRange = range);
                     _loadExerciseProgress();
                   },
                 ),
-                const SizedBox(height: 16),
-
-                // Progress chart
-                _buildProgressChart(provider),
-
-                const SizedBox(height: 24),
-              ],
+              ),
             ),
-          ),
+          ],
         );
       },
-    );
-  }
-
-  Widget _buildExercisePicker(BuildContext context) {
-    return DropdownButtonFormField<int>(
-      initialValue: _selectedExerciseIndex,
-      decoration: const InputDecoration(
-        labelText: 'Exercise',
-        border: OutlineInputBorder(),
-      ),
-      items: List.generate(_exercises.length, (index) {
-        final exercise = _exercises[index];
-        return DropdownMenuItem(
-          value: index,
-          child: Text(exercise.exerciseName),
-        );
-      }),
-      onChanged: (index) {
-        setState(() => _selectedExerciseIndex = index);
-        _loadExerciseProgress();
-      },
-    );
-  }
-
-  Widget _buildProgressChart(ProgramProvider provider) {
-    final progressData = provider.exerciseProgress;
-
-    if (progressData == null) {
-      return const SizedBox(
-        height: 250,
-        child: Center(child: CircularProgressIndicator()),
-      );
-    }
-
-    if (progressData.isEmpty) {
-      return SizedBox(
-        height: 250,
-        child: Center(
-          child: Text(
-            'No data for this exercise in the selected time range',
-            style: Theme.of(context).textTheme.bodyMedium,
-            textAlign: TextAlign.center,
-          ),
-        ),
-      );
-    }
-
-    final isStrength =
-        progressData.exerciseType == ExerciseType.strength;
-
-    // Build primary data points (weight or reps or duration)
-    final primaryData = progressData.dataPoints.map((point) {
-      double value;
-      if (point.maxWeight != null) {
-        value = point.maxWeight!;
-      } else if (point.maxReps != null) {
-        value = point.maxReps!.toDouble();
-      } else if (point.totalDuration != null) {
-        value = point.totalDuration!.toDouble();
-      } else {
-        value = 0;
-      }
-      return ChartDataPoint(date: point.date, value: value);
-    }).toList();
-
-    // Build secondary data points (est. 1RM for strength)
-    List<ChartDataPoint>? secondaryData;
-    if (isStrength) {
-      final points = progressData.dataPoints
-          .where((p) => p.estimated1RM != null)
-          .map((p) => ChartDataPoint(date: p.date, value: p.estimated1RM!))
-          .toList();
-      if (points.isNotEmpty) {
-        secondaryData = points;
-      }
-    }
-
-    return LineChartWidget(
-      data: primaryData,
-      secondaryData: secondaryData,
-      primaryLabel: isStrength ? 'Weight' : 'Value',
-      secondaryLabel: isStrength ? 'Est. 1RM' : null,
-      emptyMessage: 'No data available',
     );
   }
 }

--- a/fittrack/test/screens/analytics/components/exercise_picker_test.dart
+++ b/fittrack/test/screens/analytics/components/exercise_picker_test.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/exercise.dart';
+import 'package:fittrack/screens/analytics/components/exercise_picker.dart';
+
+void main() {
+  final sampleExercises = <LoggedExercise>[
+    (
+      exerciseId: 'ex1',
+      exerciseName: 'Bench Press',
+      exerciseType: ExerciseType.strength,
+    ),
+    (
+      exerciseId: 'ex2',
+      exerciseName: 'Pull Up',
+      exerciseType: ExerciseType.bodyweight,
+    ),
+    (
+      exerciseId: 'ex3',
+      exerciseName: 'Running',
+      exerciseType: ExerciseType.cardio,
+    ),
+    (
+      exerciseId: 'ex4',
+      exerciseName: 'Plank',
+      exerciseType: ExerciseType.timeBased,
+    ),
+  ];
+
+  Widget buildTestWidget({
+    List<LoggedExercise> exercises = const [],
+    int? selectedIndex,
+    ValueChanged<int>? onSelected,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          height: 400,
+          child: ExercisePicker(
+            exercises: exercises,
+            selectedIndex: selectedIndex,
+            onSelected: onSelected ?? (_) {},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('ExercisePicker', () {
+    testWidgets('renders search field', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.byIcon(Icons.search), findsOneWidget);
+    });
+
+    testWidgets('shows all exercises when no search query', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      expect(find.text('Bench Press'), findsOneWidget);
+      expect(find.text('Pull Up'), findsOneWidget);
+      expect(find.text('Running'), findsOneWidget);
+      expect(find.text('Plank'), findsOneWidget);
+    });
+
+    testWidgets('shows exercise type chips', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      expect(find.text('Strength'), findsOneWidget);
+      expect(find.text('Bodyweight'), findsOneWidget);
+      expect(find.text('Cardio'), findsOneWidget);
+      expect(find.text('Time-based'), findsOneWidget);
+    });
+
+    testWidgets('filters exercises by search query', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      await tester.enterText(find.byType(TextField), 'bench');
+      await tester.pump();
+
+      expect(find.text('Bench Press'), findsOneWidget);
+      expect(find.text('Pull Up'), findsNothing);
+      expect(find.text('Running'), findsNothing);
+      expect(find.text('Plank'), findsNothing);
+    });
+
+    testWidgets('shows no matches message when search has no results',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      await tester.enterText(find.byType(TextField), 'zzzzz');
+      await tester.pump();
+
+      expect(find.textContaining('No matches'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when no exercises', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('No exercises logged'), findsOneWidget);
+    });
+
+    testWidgets('calls onSelected when exercise tapped', (tester) async {
+      int? selectedIndex;
+      await tester.pumpWidget(buildTestWidget(
+        exercises: sampleExercises,
+        onSelected: (index) => selectedIndex = index,
+      ));
+
+      await tester.tap(find.text('Pull Up'));
+      await tester.pump();
+
+      expect(selectedIndex, equals(1));
+    });
+
+    testWidgets('highlights selected exercise', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        exercises: sampleExercises,
+        selectedIndex: 0,
+      ));
+
+      final listTile = tester.widget<ListTile>(
+        find.widgetWithText(ListTile, 'Bench Press'),
+      );
+      expect(listTile.selected, isTrue);
+    });
+
+    testWidgets('clear button clears search', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      await tester.enterText(find.byType(TextField), 'bench');
+      await tester.pump();
+
+      // Verify filtered
+      expect(find.text('Pull Up'), findsNothing);
+
+      // Tap clear
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      // All exercises visible again
+      expect(find.text('Bench Press'), findsOneWidget);
+      expect(find.text('Pull Up'), findsOneWidget);
+    });
+
+    testWidgets('search is case insensitive', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      await tester.enterText(find.byType(TextField), 'BENCH');
+      await tester.pump();
+
+      expect(find.text('Bench Press'), findsOneWidget);
+    });
+
+    testWidgets('has accessibility semantics', (tester) async {
+      await tester.pumpWidget(buildTestWidget(exercises: sampleExercises));
+
+      expect(
+        find.bySemanticsLabel(RegExp(r'Exercise list, 4 items')),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/fittrack/test/screens/analytics/components/exercise_progress_section_test.dart
+++ b/fittrack/test/screens/analytics/components/exercise_progress_section_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/analytics.dart';
+import 'package:fittrack/models/exercise.dart';
+import 'package:fittrack/screens/analytics/components/exercise_progress_section.dart';
+import 'package:fittrack/widgets/charts/line_chart_widget.dart';
+import 'package:fittrack/widgets/charts/time_range_selector.dart';
+
+void main() {
+  Widget buildTestWidget({
+    ExerciseProgressData? progressData,
+    TimeRange selectedTimeRange = TimeRange.threeMonths,
+    ValueChanged<TimeRange>? onTimeRangeChanged,
+    bool isLoading = false,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ExerciseProgressSection(
+          progressData: progressData,
+          selectedTimeRange: selectedTimeRange,
+          onTimeRangeChanged: onTimeRangeChanged ?? (_) {},
+          isLoading: isLoading,
+        ),
+      ),
+    );
+  }
+
+  ExerciseProgressData createProgressData({
+    ExerciseType type = ExerciseType.strength,
+    List<ExerciseProgressPoint>? dataPoints,
+  }) {
+    return ExerciseProgressData(
+      exerciseId: 'ex1',
+      exerciseName: 'Bench Press',
+      exerciseType: type,
+      dataPoints: dataPoints ??
+          [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 1, 1),
+              workoutId: 'w1',
+              maxWeight: 60,
+              maxReps: 8,
+              estimated1RM: 75,
+            ),
+            ExerciseProgressPoint(
+              date: DateTime(2024, 2, 1),
+              workoutId: 'w2',
+              maxWeight: 65,
+              maxReps: 8,
+              estimated1RM: 81.25,
+            ),
+            ExerciseProgressPoint(
+              date: DateTime(2024, 3, 1),
+              workoutId: 'w3',
+              maxWeight: 70,
+              maxReps: 8,
+              estimated1RM: 87.5,
+            ),
+          ],
+      dateRange: DateRange.last3Months(),
+    );
+  }
+
+  group('ExerciseProgressSection', () {
+    testWidgets('shows time range selector', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byType(TimeRangeSelector), findsOneWidget);
+    });
+
+    testWidgets('shows loading state', (tester) async {
+      await tester.pumpWidget(buildTestWidget(isLoading: true));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows select exercise message when no data', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Select an exercise to see progress'), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when data has no points', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(dataPoints: []),
+      ));
+
+      expect(
+        find.text('No data for this exercise in the selected time range'),
+        findsOneWidget,
+      );
+      expect(find.byIcon(Icons.show_chart), findsOneWidget);
+    });
+
+    testWidgets('shows line chart for strength exercise', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(),
+      ));
+
+      expect(find.byType(LineChartWidget), findsOneWidget);
+      expect(find.text('Showing max weight per session'), findsOneWidget);
+    });
+
+    testWidgets('shows line chart for bodyweight exercise', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(
+          type: ExerciseType.bodyweight,
+          dataPoints: [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 1, 1),
+              workoutId: 'w1',
+              maxReps: 10,
+            ),
+            ExerciseProgressPoint(
+              date: DateTime(2024, 2, 1),
+              workoutId: 'w2',
+              maxReps: 12,
+            ),
+          ],
+        ),
+      ));
+
+      expect(find.byType(LineChartWidget), findsOneWidget);
+      expect(find.text('Showing max reps per session'), findsOneWidget);
+    });
+
+    testWidgets('shows line chart for cardio exercise', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(
+          type: ExerciseType.cardio,
+          dataPoints: [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 1, 1),
+              workoutId: 'w1',
+              totalDuration: 1800,
+            ),
+            ExerciseProgressPoint(
+              date: DateTime(2024, 2, 1),
+              workoutId: 'w2',
+              totalDuration: 2000,
+            ),
+          ],
+        ),
+      ));
+
+      expect(find.byType(LineChartWidget), findsOneWidget);
+      expect(find.text('Showing total duration per session'), findsOneWidget);
+    });
+
+    testWidgets('shows line chart for custom exercise', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(
+          type: ExerciseType.custom,
+          dataPoints: [
+            ExerciseProgressPoint(
+              date: DateTime(2024, 1, 1),
+              workoutId: 'w1',
+              maxWeight: 20,
+              maxReps: 15,
+            ),
+          ],
+        ),
+      ));
+
+      expect(find.byType(LineChartWidget), findsOneWidget);
+      expect(
+          find.text('Showing estimated volume per session'), findsOneWidget);
+    });
+
+    testWidgets('calls onTimeRangeChanged when time range changes',
+        (tester) async {
+      TimeRange? changedRange;
+      await tester.pumpWidget(buildTestWidget(
+        progressData: createProgressData(),
+        onTimeRangeChanged: (range) => changedRange = range,
+      ));
+
+      // Tap the "1M" button
+      await tester.tap(find.text('1M'));
+      await tester.pump();
+
+      expect(changedRange, equals(TimeRange.oneMonth));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extracts `ExercisePicker` component with search field, exercise type chips, and selection highlighting
- Extracts `ExerciseProgressSection` component with per-type metric rendering and chart labels
- Updates `ExerciseTab` to use split layout: picker (top 40%) + chart (bottom 60%) with divider
- Supports all exercise types: strength (weight + 1RM), bodyweight (reps), cardio (duration), custom (volume)
- Adds 19 widget tests across both new components

## Test plan
- [ ] ExercisePicker: renders search field, shows all exercises, filters by query, case-insensitive search
- [ ] ExercisePicker: shows type chips, highlights selected exercise, calls onSelected, clear button works
- [ ] ExerciseProgressSection: shows time range selector, loading state, empty states
- [ ] ExerciseProgressSection: renders correct chart type per exercise type (strength, bodyweight, cardio, custom)
- [ ] CI passes all checks

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)