### PR TITLE
feat: Muscle group volume & training trends components (#355)

### DIFF
--- a/fittrack/lib/screens/analytics/components/muscle_group_section.dart
+++ b/fittrack/lib/screens/analytics/components/muscle_group_section.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/analytics.dart';
+import '../../../models/muscle_group.dart';
+import '../../../widgets/charts/bar_chart_widget.dart';
+import '../../../widgets/charts/chart_data.dart';
+
+/// Displays a horizontal bar chart of muscle group volume (sets per group).
+///
+/// Color-coded per muscle group with "Other" for unmatched exercises.
+class MuscleGroupSection extends StatelessWidget {
+  final List<MuscleGroupVolume>? volumeData;
+  final bool isLoading;
+
+  const MuscleGroupSection({
+    super.key,
+    required this.volumeData,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Muscle Group Volume', style: textTheme.titleMedium),
+            const SizedBox(height: 12),
+            if (isLoading)
+              const Center(child: CircularProgressIndicator())
+            else if (volumeData == null || volumeData!.isEmpty)
+              Text(
+                'Complete some workouts to see muscle group breakdown',
+                style: textTheme.bodyMedium,
+              )
+            else
+              BarChartWidget(
+                entries: volumeData!
+                    .map((v) => BarChartEntry(
+                          label: v.label,
+                          value: v.totalSets.toDouble(),
+                          percentage: v.percentage,
+                          color: colorForMuscleGroup(v.muscleGroup),
+                        ))
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// Consistent color mapping for muscle groups.
+  static Color colorForMuscleGroup(MuscleGroup? muscleGroup) {
+    if (muscleGroup == null) return Colors.grey;
+    switch (muscleGroup) {
+      case MuscleGroup.chest:
+        return Colors.red.shade400;
+      case MuscleGroup.back:
+        return Colors.blue.shade400;
+      case MuscleGroup.shoulders:
+        return Colors.orange.shade400;
+      case MuscleGroup.arms:
+        return Colors.purple.shade400;
+      case MuscleGroup.legs:
+        return Colors.green.shade400;
+      case MuscleGroup.core:
+        return Colors.teal.shade400;
+    }
+  }
+}

--- a/fittrack/lib/screens/analytics/components/training_trends_section.dart
+++ b/fittrack/lib/screens/analytics/components/training_trends_section.dart
@@ -1,0 +1,152 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/analytics.dart';
+import '../../../widgets/charts/chart_data.dart';
+import '../../../widgets/charts/line_chart_widget.dart';
+
+/// Displays weekly training trends: total volume and workout frequency.
+///
+/// Shows two stacked line charts with optional 4-week moving average overlay.
+class TrainingTrendsSection extends StatelessWidget {
+  final List<WeeklyTrendPoint>? trendsData;
+  final bool isLoading;
+
+  const TrainingTrendsSection({
+    super.key,
+    required this.trendsData,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        // Weekly Volume chart
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Weekly Training Volume', style: textTheme.titleMedium),
+                const SizedBox(height: 12),
+                _buildVolumeChart(context),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+
+        // Weekly Frequency chart
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Weekly Workout Frequency', style: textTheme.titleMedium),
+                const SizedBox(height: 12),
+                _buildFrequencyChart(context),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildVolumeChart(BuildContext context) {
+    if (isLoading) {
+      return const SizedBox(
+        height: 200,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (trendsData == null || trendsData!.isEmpty) {
+      return Text(
+        'Complete some workouts to see training trends',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    final primaryData = trendsData!
+        .map((w) => ChartDataPoint(
+              date: w.weekStart,
+              value: w.totalVolume,
+              label: '${w.workoutCount} workouts',
+            ))
+        .toList();
+
+    // 4-week moving average
+    final movingAvgData = _computeMovingAverage(
+      trendsData!.map((w) => w.totalVolume).toList(),
+      trendsData!.map((w) => w.weekStart).toList(),
+    );
+
+    return LineChartWidget(
+      data: primaryData,
+      secondaryData: movingAvgData,
+      primaryLabel: 'Volume',
+      secondaryLabel: movingAvgData != null ? '4-wk avg' : null,
+      yAxisLabel: 'kg',
+      emptyMessage: 'No training data',
+    );
+  }
+
+  Widget _buildFrequencyChart(BuildContext context) {
+    if (isLoading) {
+      return const SizedBox(
+        height: 200,
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (trendsData == null || trendsData!.isEmpty) {
+      return Text(
+        'Complete some workouts to see frequency trends',
+        style: Theme.of(context).textTheme.bodyMedium,
+      );
+    }
+
+    final primaryData = trendsData!
+        .map((w) => ChartDataPoint(
+              date: w.weekStart,
+              value: w.workoutCount.toDouble(),
+            ))
+        .toList();
+
+    // 4-week moving average
+    final movingAvgData = _computeMovingAverage(
+      trendsData!.map((w) => w.workoutCount.toDouble()).toList(),
+      trendsData!.map((w) => w.weekStart).toList(),
+    );
+
+    return LineChartWidget(
+      data: primaryData,
+      secondaryData: movingAvgData,
+      primaryLabel: 'Workouts',
+      secondaryLabel: movingAvgData != null ? '4-wk avg' : null,
+      yAxisLabel: 'count',
+      emptyMessage: 'No frequency data',
+    );
+  }
+
+  /// Computes a 4-week moving average. Returns null if fewer than 4 points.
+  static List<ChartDataPoint>? _computeMovingAverage(
+    List<double> values,
+    List<DateTime> dates,
+  ) {
+    if (values.length < 4) return null;
+
+    final result = <ChartDataPoint>[];
+    for (int i = 3; i < values.length; i++) {
+      final avg = (values[i] + values[i - 1] + values[i - 2] + values[i - 3]) / 4;
+      result.add(ChartDataPoint(date: dates[i], value: avg));
+    }
+    return result.isNotEmpty ? result : null;
+  }
+}

--- a/fittrack/lib/screens/analytics/components/trends_tab.dart
+++ b/fittrack/lib/screens/analytics/components/trends_tab.dart
@@ -1,20 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import '../../../models/custom_exercise.dart';
-import '../../../models/library_exercise.dart';
-import '../../../models/muscle_group.dart';
+import '../../../providers/exercise_library_provider.dart';
 import '../../../providers/program_provider.dart';
-import '../../../widgets/charts/bar_chart_widget.dart';
-import '../../../widgets/charts/chart_data.dart';
-import '../../../widgets/charts/line_chart_widget.dart';
 import '../../../widgets/charts/time_range_selector.dart';
+import 'muscle_group_section.dart';
+import 'training_trends_section.dart';
 
 /// Trends tab showing streak, muscle group volume, and weekly trends.
 ///
 /// Lazy-loads data on first visit. Displays three sections:
 /// 1. Configurable streak
 /// 2. Muscle group volume bar chart
-/// 3. Weekly training trends line chart
+/// 3. Weekly training trends line charts (volume + frequency)
 class TrendsTab extends StatefulWidget {
   const TrendsTab({super.key});
 
@@ -42,14 +39,15 @@ class _TrendsTabState extends State<TrendsTab>
   Future<void> _loadTrendsData() async {
     setState(() => _loading = true);
     final provider = context.read<ProgramProvider>();
+    final exerciseLibrary = context.read<ExerciseLibraryProvider>();
     final dateRange = _selectedTimeRange.toDateRange();
 
     await Future.wait([
       provider.loadWeeklyTrends(dateRange: dateRange),
       provider.loadMuscleGroupVolume(
         dateRange: dateRange,
-        libraryExercises: const <LibraryExercise>[],
-        customExercises: const <CustomExercise>[],
+        libraryExercises: exerciseLibrary.libraryExercises,
+        customExercises: exerciseLibrary.customExercises,
       ),
     ]);
 
@@ -93,14 +91,20 @@ class _TrendsTabState extends State<TrendsTab>
 
                 // Streak section
                 _buildStreakSection(context, provider),
-                const SizedBox(height: 24),
+                const SizedBox(height: 16),
 
                 // Muscle group volume section
-                _buildMuscleGroupSection(context, provider),
-                const SizedBox(height: 24),
+                MuscleGroupSection(
+                  volumeData: provider.muscleGroupVolume,
+                  isLoading: _loading,
+                ),
+                const SizedBox(height: 16),
 
-                // Weekly trends section
-                _buildWeeklyTrendsSection(context, provider),
+                // Weekly trends section (volume + frequency)
+                TrainingTrendsSection(
+                  trendsData: provider.weeklyTrends,
+                  isLoading: _loading,
+                ),
                 const SizedBox(height: 24),
               ],
             ),
@@ -176,95 +180,5 @@ class _TrendsTabState extends State<TrendsTab>
         ),
       ),
     );
-  }
-
-  Widget _buildMuscleGroupSection(
-      BuildContext context, ProgramProvider provider) {
-    final volumeData = provider.muscleGroupVolume;
-    final textTheme = Theme.of(context).textTheme;
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Muscle Group Volume', style: textTheme.titleMedium),
-            const SizedBox(height: 12),
-            if (_loading)
-              const Center(child: CircularProgressIndicator())
-            else if (volumeData == null || volumeData.isEmpty)
-              Text('No volume data for this period',
-                  style: textTheme.bodyMedium)
-            else
-              BarChartWidget(
-                entries: volumeData
-                    .map((v) => BarChartEntry(
-                          label: v.label,
-                          value: v.totalSets.toDouble(),
-                          percentage: v.percentage,
-                          color: _colorForMuscleGroup(v.muscleGroup, colorScheme),
-                        ))
-                    .toList(),
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildWeeklyTrendsSection(
-      BuildContext context, ProgramProvider provider) {
-    final trendsData = provider.weeklyTrends;
-    final textTheme = Theme.of(context).textTheme;
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Weekly Training Volume', style: textTheme.titleMedium),
-            const SizedBox(height: 12),
-            if (_loading)
-              const Center(child: CircularProgressIndicator())
-            else if (trendsData == null || trendsData.isEmpty)
-              Text('No training data for this period',
-                  style: textTheme.bodyMedium)
-            else
-              LineChartWidget(
-                data: trendsData
-                    .map((w) => ChartDataPoint(
-                          date: w.weekStart,
-                          value: w.totalVolume,
-                          label: '${w.workoutCount} workouts',
-                        ))
-                    .toList(),
-                primaryLabel: 'Volume (kg)',
-                emptyMessage: 'No training data',
-              ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Color _colorForMuscleGroup(MuscleGroup? muscleGroup, ColorScheme colorScheme) {
-    if (muscleGroup == null) return colorScheme.surfaceContainerHighest;
-    switch (muscleGroup) {
-      case MuscleGroup.chest:
-        return colorScheme.primary;
-      case MuscleGroup.back:
-        return colorScheme.secondary;
-      case MuscleGroup.shoulders:
-        return colorScheme.tertiary;
-      case MuscleGroup.arms:
-        return colorScheme.primaryContainer;
-      case MuscleGroup.legs:
-        return colorScheme.error;
-      case MuscleGroup.core:
-        return colorScheme.tertiaryContainer;
-    }
   }
 }

--- a/fittrack/test/screens/analytics/components/muscle_group_section_test.dart
+++ b/fittrack/test/screens/analytics/components/muscle_group_section_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/analytics.dart';
+import 'package:fittrack/models/muscle_group.dart';
+import 'package:fittrack/screens/analytics/components/muscle_group_section.dart';
+import 'package:fittrack/widgets/charts/bar_chart_widget.dart';
+
+void main() {
+  Widget buildTestWidget({
+    List<MuscleGroupVolume>? volumeData,
+    bool isLoading = false,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: MuscleGroupSection(
+            volumeData: volumeData,
+            isLoading: isLoading,
+          ),
+        ),
+      ),
+    );
+  }
+
+  final sampleVolumeData = [
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.chest,
+      label: 'Chest',
+      totalSets: 20,
+      percentage: 25.0,
+    ),
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.back,
+      label: 'Back',
+      totalSets: 18,
+      percentage: 22.5,
+    ),
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.legs,
+      label: 'Legs',
+      totalSets: 16,
+      percentage: 20.0,
+    ),
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.shoulders,
+      label: 'Shoulders',
+      totalSets: 12,
+      percentage: 15.0,
+    ),
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.arms,
+      label: 'Arms',
+      totalSets: 10,
+      percentage: 12.5,
+    ),
+    const MuscleGroupVolume(
+      muscleGroup: MuscleGroup.core,
+      label: 'Core',
+      totalSets: 4,
+      percentage: 5.0,
+    ),
+  ];
+
+  group('MuscleGroupSection', () {
+    testWidgets('shows title', (tester) async {
+      await tester.pumpWidget(buildTestWidget(volumeData: sampleVolumeData));
+
+      expect(find.text('Muscle Group Volume'), findsOneWidget);
+    });
+
+    testWidgets('shows loading state', (tester) async {
+      await tester.pumpWidget(buildTestWidget(isLoading: true));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows empty state when null data', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(
+        find.text('Complete some workouts to see muscle group breakdown'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows empty state when empty list', (tester) async {
+      await tester.pumpWidget(buildTestWidget(volumeData: []));
+
+      expect(
+        find.text('Complete some workouts to see muscle group breakdown'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows bar chart when data available', (tester) async {
+      await tester.pumpWidget(buildTestWidget(volumeData: sampleVolumeData));
+
+      expect(find.byType(BarChartWidget), findsOneWidget);
+    });
+
+    testWidgets('renders in a Card', (tester) async {
+      await tester.pumpWidget(buildTestWidget(volumeData: sampleVolumeData));
+
+      expect(find.byType(Card), findsOneWidget);
+    });
+  });
+
+  group('MuscleGroupSection.colorForMuscleGroup', () {
+    test('returns distinct colors for each muscle group', () {
+      final colors = MuscleGroup.values
+          .map((g) => MuscleGroupSection.colorForMuscleGroup(g))
+          .toSet();
+      // All 6 muscle groups should have unique colors
+      expect(colors.length, equals(6));
+    });
+
+    test('returns grey for null (Other)', () {
+      final color = MuscleGroupSection.colorForMuscleGroup(null);
+      expect(color, equals(Colors.grey));
+    });
+  });
+}

--- a/fittrack/test/screens/analytics/components/training_trends_section_test.dart
+++ b/fittrack/test/screens/analytics/components/training_trends_section_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/analytics.dart';
+import 'package:fittrack/screens/analytics/components/training_trends_section.dart';
+import 'package:fittrack/widgets/charts/line_chart_widget.dart';
+
+void main() {
+  Widget buildTestWidget({
+    List<WeeklyTrendPoint>? trendsData,
+    bool isLoading = false,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: TrainingTrendsSection(
+            trendsData: trendsData,
+            isLoading: isLoading,
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<WeeklyTrendPoint> createTrendData({int weeks = 6}) {
+    return List.generate(weeks, (i) {
+      final weekStart = DateTime(2024, 1, 1).add(Duration(days: i * 7));
+      return WeeklyTrendPoint(
+        weekStart: weekStart,
+        totalVolume: 1000.0 + i * 200,
+        workoutCount: 3 + (i % 3),
+      );
+    });
+  }
+
+  group('TrainingTrendsSection', () {
+    testWidgets('shows both chart titles', (tester) async {
+      await tester.pumpWidget(
+          buildTestWidget(trendsData: createTrendData()));
+
+      expect(find.text('Weekly Training Volume'), findsOneWidget);
+      expect(find.text('Weekly Workout Frequency'), findsOneWidget);
+    });
+
+    testWidgets('shows loading state for both charts', (tester) async {
+      await tester.pumpWidget(buildTestWidget(isLoading: true));
+
+      expect(find.byType(CircularProgressIndicator), findsNWidgets(2));
+    });
+
+    testWidgets('shows empty state when null data', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(
+        find.text('Complete some workouts to see training trends'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Complete some workouts to see frequency trends'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows empty state when empty list', (tester) async {
+      await tester.pumpWidget(buildTestWidget(trendsData: []));
+
+      expect(
+        find.text('Complete some workouts to see training trends'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows two line charts with data', (tester) async {
+      await tester.pumpWidget(
+          buildTestWidget(trendsData: createTrendData()));
+
+      expect(find.byType(LineChartWidget), findsNWidgets(2));
+    });
+
+    testWidgets('renders in two Cards', (tester) async {
+      await tester.pumpWidget(
+          buildTestWidget(trendsData: createTrendData()));
+
+      expect(find.byType(Card), findsNWidgets(2));
+    });
+
+    testWidgets('shows moving average with enough data points',
+        (tester) async {
+      // 6 weeks of data - should produce 3 moving average points
+      await tester.pumpWidget(
+          buildTestWidget(trendsData: createTrendData(weeks: 6)));
+
+      // Both charts should show "4-wk avg" legend
+      expect(find.text('4-wk avg'), findsNWidgets(2));
+    });
+
+    testWidgets('no moving average with fewer than 4 points',
+        (tester) async {
+      await tester.pumpWidget(
+          buildTestWidget(trendsData: createTrendData(weeks: 3)));
+
+      // No "4-wk avg" should appear
+      expect(find.text('4-wk avg'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extracts `MuscleGroupSection` component with horizontal bar chart, consistent color mapping per muscle group, and "Other" category for unmatched exercises
- Extracts `TrainingTrendsSection` component with dual line charts: weekly volume + workout frequency
- Adds 4-week moving average overlay on both trend charts (shown when >= 4 data points)
- Updates `TrendsTab` to integrate with `ExerciseLibraryProvider` for proper muscle group matching
- Adds 16 widget tests across both new components

## Implementation Details
- Muscle group colors: Chest=red, Back=blue, Shoulders=orange, Arms=purple, Legs=green, Core=teal, Other=grey
- Moving average computed with sliding window of 4 weeks
- `ExerciseLibraryProvider` now provides real library/custom exercises for volume calculation instead of empty lists

## Test plan
- [ ] MuscleGroupSection: shows title, loading, empty states, bar chart with data
- [ ] MuscleGroupSection: distinct colors per group, grey for "Other"
- [ ] TrainingTrendsSection: shows both chart titles, loading states, empty states
- [ ] TrainingTrendsSection: renders two line charts, shows moving average with 4+ points
- [ ] CI passes all checks

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)