### PR TITLE
feat: Configurable streak section & PR notification banner (#356)

### DIFF
--- a/fittrack/lib/screens/analytics/components/charts_section.dart
+++ b/fittrack/lib/screens/analytics/components/charts_section.dart
@@ -310,13 +310,37 @@ class PersonalRecordTile extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  record.exerciseName,
-                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                Row(
+                  children: [
+                    Flexible(
+                      child: Text(
+                        record.exerciseName,
+                        style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.w600,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    if (_isRecentPR(record.achievedAt)) ...[
+                      const SizedBox(width: 6),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.tertiary,
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Text(
+                          'NEW',
+                          style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color: Theme.of(context).colorScheme.onTertiary,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 10,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
                 const SizedBox(height: 2),
                 Row(
@@ -363,6 +387,10 @@ class PersonalRecordTile extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  bool _isRecentPR(DateTime achievedAt) {
+    return DateTime.now().difference(achievedAt).inDays <= 7;
   }
 
   String _getTimeAgo(DateTime date) {

--- a/fittrack/lib/screens/analytics/components/streak_section.dart
+++ b/fittrack/lib/screens/analytics/components/streak_section.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../../../models/analytics.dart';
+
+/// Streak section displaying configurable weekly workout streak.
+///
+/// Shows current streak with flame icon, longest streak, and a gear
+/// icon that opens a bottom sheet for setting the weekly target (1-7).
+class StreakSection extends StatelessWidget {
+  final ConfigurableStreak? streak;
+  final int weeklyTarget;
+  final ValueChanged<int> onTargetChanged;
+  final bool isLoading;
+
+  const StreakSection({
+    super.key,
+    required this.streak,
+    required this.weeklyTarget,
+    required this.onTargetChanged,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('Workout Streak', style: textTheme.titleMedium),
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Target: $weeklyTarget/wk',
+                      style: textTheme.bodySmall,
+                    ),
+                    const SizedBox(width: 4),
+                    IconButton(
+                      icon: const Icon(Icons.settings, size: 20),
+                      onPressed: () => _showTargetBottomSheet(context),
+                      tooltip: 'Set weekly target',
+                      visualDensity: VisualDensity.compact,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (isLoading)
+              const Center(child: CircularProgressIndicator())
+            else if (streak != null) ...[
+              Row(
+                children: [
+                  Icon(Icons.local_fire_department,
+                      color: colorScheme.primary, size: 32),
+                  const SizedBox(width: 8),
+                  Text(
+                    streak!.currentStreakString,
+                    style: textTheme.headlineSmall,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Longest: ${streak!.longestStreakString}',
+                style: textTheme.bodySmall,
+              ),
+            ] else
+              Text('No streak data', style: textTheme.bodyMedium),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showTargetBottomSheet(BuildContext context) {
+    showModalBottomSheet(
+      context: context,
+      builder: (sheetContext) {
+        return _TargetPickerSheet(
+          currentTarget: weeklyTarget,
+          onTargetChanged: (value) {
+            onTargetChanged(value);
+            Navigator.of(sheetContext).pop();
+          },
+        );
+      },
+    );
+  }
+}
+
+/// Bottom sheet for selecting weekly workout target (1-7).
+class _TargetPickerSheet extends StatefulWidget {
+  final int currentTarget;
+  final ValueChanged<int> onTargetChanged;
+
+  const _TargetPickerSheet({
+    required this.currentTarget,
+    required this.onTargetChanged,
+  });
+
+  @override
+  State<_TargetPickerSheet> createState() => _TargetPickerSheetState();
+}
+
+class _TargetPickerSheetState extends State<_TargetPickerSheet> {
+  late int _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.currentTarget;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            'Weekly Workout Target',
+            style: textTheme.titleLarge,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Streak counts consecutive weeks where you meet this target',
+            style: textTheme.bodySmall,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            alignment: WrapAlignment.center,
+            children: List.generate(7, (i) {
+              final value = i + 1;
+              final isSelected = value == _selected;
+              return ChoiceChip(
+                label: Text('$value'),
+                selected: isSelected,
+                onSelected: (_) => setState(() => _selected = value),
+                selectedColor: colorScheme.primaryContainer,
+                labelStyle: TextStyle(
+                  fontWeight:
+                      isSelected ? FontWeight.bold : FontWeight.normal,
+                ),
+              );
+            }),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '$_selected workout${_selected == 1 ? '' : 's'} per week',
+            style: textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            onPressed: () => widget.onTargetChanged(_selected),
+            child: const Text('Save'),
+          ),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}

--- a/fittrack/lib/screens/analytics/components/trends_tab.dart
+++ b/fittrack/lib/screens/analytics/components/trends_tab.dart
@@ -4,6 +4,7 @@ import '../../../providers/exercise_library_provider.dart';
 import '../../../providers/program_provider.dart';
 import '../../../widgets/charts/time_range_selector.dart';
 import 'muscle_group_section.dart';
+import 'streak_section.dart';
 import 'training_trends_section.dart';
 
 /// Trends tab showing streak, muscle group volume, and weekly trends.
@@ -90,7 +91,14 @@ class _TrendsTabState extends State<TrendsTab>
                 const SizedBox(height: 24),
 
                 // Streak section
-                _buildStreakSection(context, provider),
+                StreakSection(
+                  streak: provider.configurableStreak,
+                  weeklyTarget: provider.weeklyWorkoutTarget,
+                  onTargetChanged: (value) {
+                    provider.setWeeklyWorkoutTarget(value);
+                  },
+                  isLoading: _loading,
+                ),
                 const SizedBox(height: 16),
 
                 // Muscle group volume section
@@ -114,71 +122,4 @@ class _TrendsTabState extends State<TrendsTab>
     );
   }
 
-  Widget _buildStreakSection(BuildContext context, ProgramProvider provider) {
-    final streak = provider.configurableStreak;
-    final textTheme = Theme.of(context).textTheme;
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Text('Workout Streak', style: textTheme.titleMedium),
-                // Weekly target selector
-                Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text('Target: ', style: textTheme.bodySmall),
-                    DropdownButton<int>(
-                      value: provider.weeklyWorkoutTarget,
-                      underline: const SizedBox.shrink(),
-                      isDense: true,
-                      items: List.generate(7, (i) => i + 1)
-                          .map((n) => DropdownMenuItem(
-                                value: n,
-                                child: Text('$n/wk'),
-                              ))
-                          .toList(),
-                      onChanged: (value) {
-                        if (value != null) {
-                          provider.setWeeklyWorkoutTarget(value);
-                        }
-                      },
-                    ),
-                  ],
-                ),
-              ],
-            ),
-            const SizedBox(height: 12),
-            if (streak != null) ...[
-              Row(
-                children: [
-                  Icon(Icons.local_fire_department,
-                      color: colorScheme.primary, size: 32),
-                  const SizedBox(width: 8),
-                  Text(
-                    streak.currentStreakString,
-                    style: textTheme.headlineSmall,
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Longest: ${streak.longestStreakString}',
-                style: textTheme.bodySmall,
-              ),
-            ] else if (_loading)
-              const Center(child: CircularProgressIndicator())
-            else
-              Text('No streak data', style: textTheme.bodyMedium),
-          ],
-        ),
-      ),
-    );
-  }
 }

--- a/fittrack/lib/widgets/pr_notification_banner.dart
+++ b/fittrack/lib/widgets/pr_notification_banner.dart
@@ -1,0 +1,186 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../models/analytics.dart';
+
+/// An animated banner that slides in from the top to announce a new PR.
+///
+/// Auto-dismisses after 5 seconds. Tappable to dismiss immediately.
+/// Uses `Semantics.liveRegion` for screen reader announcement.
+class PRNotificationBanner extends StatefulWidget {
+  final PersonalRecord pr;
+  final VoidCallback? onDismissed;
+
+  const PRNotificationBanner({
+    super.key,
+    required this.pr,
+    this.onDismissed,
+  });
+
+  @override
+  State<PRNotificationBanner> createState() => _PRNotificationBannerState();
+
+  /// Shows the PR banner as an overlay on the given context.
+  ///
+  /// Returns the [OverlayEntry] so callers can remove it if needed.
+  static OverlayEntry show(BuildContext context, PersonalRecord pr) {
+    late OverlayEntry entry;
+    entry = OverlayEntry(
+      builder: (context) => Positioned(
+        top: MediaQuery.of(context).padding.top + 8,
+        left: 16,
+        right: 16,
+        child: Material(
+          color: Colors.transparent,
+          child: PRNotificationBanner(
+            pr: pr,
+            onDismissed: () => entry.remove(),
+          ),
+        ),
+      ),
+    );
+    Overlay.of(context).insert(entry);
+    return entry;
+  }
+}
+
+class _PRNotificationBannerState extends State<PRNotificationBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<Offset> _slideAnimation;
+  late final Animation<double> _fadeAnimation;
+  Timer? _dismissTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 300),
+      vsync: this,
+    );
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0, -1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _controller,
+      curve: Curves.easeOut,
+    ));
+    _fadeAnimation = Tween<double>(begin: 0, end: 1).animate(_controller);
+
+    _controller.forward();
+    _dismissTimer = Timer(const Duration(seconds: 5), _dismiss);
+  }
+
+  @override
+  void dispose() {
+    _dismissTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _dismiss() async {
+    _dismissTimer?.cancel();
+    await _controller.reverse();
+    widget.onDismissed?.call();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final pr = widget.pr;
+
+    final valueStr = _formatValue(pr.value, pr.prType);
+    final improvementStr = pr.previousValue != null
+        ? ' (+${_formatValue(pr.improvement, pr.prType)})'
+        : '';
+
+    return SlideTransition(
+      position: _slideAnimation,
+      child: FadeTransition(
+        opacity: _fadeAnimation,
+        child: Semantics(
+          liveRegion: true,
+          label:
+              'New personal record: ${pr.exerciseName}, ${pr.prType.displayName}: $valueStr$improvementStr',
+          child: GestureDetector(
+            onTap: _dismiss,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: colorScheme.primaryContainer,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: colorScheme.shadow.withValues(alpha: 0.2),
+                    blurRadius: 8,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.emoji_events,
+                    color: colorScheme.onPrimaryContainer,
+                    size: 28,
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'New PR!',
+                          style:
+                              Theme.of(context).textTheme.labelLarge?.copyWith(
+                                    color: colorScheme.onPrimaryContainer,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                        ),
+                        Text(
+                          '${pr.exerciseName} - ${pr.prType.displayName}: $valueStr$improvementStr',
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: colorScheme.onPrimaryContainer,
+                                  ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Icon(
+                    Icons.close,
+                    color: colorScheme.onPrimaryContainer.withValues(alpha: 0.6),
+                    size: 18,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _formatValue(double value, PRType prType) {
+    switch (prType) {
+      case PRType.oneRepMax:
+      case PRType.maxWeight:
+        return '${value.toStringAsFixed(1)}kg';
+      case PRType.maxReps:
+        return '${value.toInt()} reps';
+      case PRType.maxVolume:
+        return '${value.toStringAsFixed(0)}kg';
+      case PRType.maxDuration:
+        final minutes = (value / 60).floor();
+        final seconds = (value % 60).toInt();
+        return minutes > 0 ? '${minutes}m ${seconds}s' : '${seconds}s';
+      case PRType.maxDistance:
+        if (value >= 1000) {
+          return '${(value / 1000).toStringAsFixed(2)}km';
+        }
+        return '${value.toStringAsFixed(0)}m';
+    }
+  }
+}

--- a/fittrack/test/screens/analytics/components/streak_section_test.dart
+++ b/fittrack/test/screens/analytics/components/streak_section_test.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/analytics.dart';
+import 'package:fittrack/screens/analytics/components/streak_section.dart';
+
+void main() {
+  Widget buildTestWidget({
+    ConfigurableStreak? streak,
+    int weeklyTarget = 3,
+    ValueChanged<int>? onTargetChanged,
+    bool isLoading = false,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SingleChildScrollView(
+          child: StreakSection(
+            streak: streak,
+            weeklyTarget: weeklyTarget,
+            onTargetChanged: onTargetChanged ?? (_) {},
+            isLoading: isLoading,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('StreakSection', () {
+    testWidgets('shows title', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('Workout Streak'), findsOneWidget);
+    });
+
+    testWidgets('shows current target label', (tester) async {
+      await tester.pumpWidget(buildTestWidget(weeklyTarget: 4));
+
+      expect(find.text('Target: 4/wk'), findsOneWidget);
+    });
+
+    testWidgets('shows loading state', (tester) async {
+      await tester.pumpWidget(buildTestWidget(isLoading: true));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('shows no streak data when null', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.text('No streak data'), findsOneWidget);
+    });
+
+    testWidgets('shows streak data with flame icon', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        streak: const ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 5,
+          longestStreak: 12,
+        ),
+      ));
+
+      expect(find.byIcon(Icons.local_fire_department), findsOneWidget);
+      expect(find.text('5-week streak'), findsOneWidget);
+      expect(find.text('Longest: 12 weeks'), findsOneWidget);
+    });
+
+    testWidgets('shows single week streak correctly', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        streak: const ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 1,
+          longestStreak: 1,
+        ),
+      ));
+
+      expect(find.text('1-week streak'), findsOneWidget);
+      expect(find.text('Longest: 1 week'), findsOneWidget);
+    });
+
+    testWidgets('shows no streak message for zero streak', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        streak: const ConfigurableStreak(
+          weeklyTarget: 3,
+          currentStreak: 0,
+          longestStreak: 0,
+        ),
+      ));
+
+      expect(find.text('No streak'), findsOneWidget);
+      expect(find.text('Longest: No record'), findsOneWidget);
+    });
+
+    testWidgets('settings icon opens bottom sheet', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Weekly Workout Target'), findsOneWidget);
+      expect(find.text('Save'), findsOneWidget);
+    });
+
+    testWidgets('bottom sheet shows 7 choice chips', (tester) async {
+      await tester.pumpWidget(buildTestWidget(weeklyTarget: 3));
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      for (int i = 1; i <= 7; i++) {
+        expect(find.text('$i'), findsOneWidget);
+      }
+    });
+
+    testWidgets('bottom sheet save calls onTargetChanged', (tester) async {
+      int? changedTarget;
+      await tester.pumpWidget(buildTestWidget(
+        weeklyTarget: 3,
+        onTargetChanged: (value) => changedTarget = value,
+      ));
+
+      await tester.tap(find.byIcon(Icons.settings));
+      await tester.pumpAndSettle();
+
+      // Select target 5
+      await tester.tap(find.text('5'));
+      await tester.pumpAndSettle();
+
+      // Tap save
+      await tester.tap(find.text('Save'));
+      await tester.pumpAndSettle();
+
+      expect(changedTarget, equals(5));
+    });
+
+    testWidgets('renders in a Card', (tester) async {
+      await tester.pumpWidget(buildTestWidget());
+
+      expect(find.byType(Card), findsOneWidget);
+    });
+  });
+}

--- a/fittrack/test/widgets/pr_notification_banner_test.dart
+++ b/fittrack/test/widgets/pr_notification_banner_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/analytics.dart';
+import 'package:fittrack/models/exercise.dart';
+import 'package:fittrack/widgets/pr_notification_banner.dart';
+
+void main() {
+  PersonalRecord createPR({
+    PRType prType = PRType.maxWeight,
+    double value = 100,
+    double? previousValue = 95,
+    String exerciseName = 'Bench Press',
+  }) {
+    return PersonalRecord(
+      id: 'pr1',
+      userId: 'user1',
+      exerciseId: 'ex1',
+      exerciseName: exerciseName,
+      exerciseType: ExerciseType.strength,
+      prType: prType,
+      value: value,
+      previousValue: previousValue,
+      achievedAt: DateTime.now(),
+      workoutId: 'w1',
+      setId: 's1',
+    );
+  }
+
+  Widget buildTestWidget({
+    required PersonalRecord pr,
+    VoidCallback? onDismissed,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: PRNotificationBanner(
+          pr: pr,
+          onDismissed: onDismissed,
+        ),
+      ),
+    );
+  }
+
+  group('PRNotificationBanner', () {
+    testWidgets('shows New PR! title', (tester) async {
+      await tester.pumpWidget(buildTestWidget(pr: createPR()));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.text('New PR!'), findsOneWidget);
+    });
+
+    testWidgets('shows exercise name and PR type', (tester) async {
+      await tester.pumpWidget(buildTestWidget(pr: createPR()));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.textContaining('Bench Press'), findsOneWidget);
+      expect(find.textContaining('Max Weight'), findsOneWidget);
+    });
+
+    testWidgets('shows value and improvement for max weight', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(value: 100, previousValue: 95),
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.textContaining('100.0kg'), findsOneWidget);
+      expect(find.textContaining('+5.0kg'), findsOneWidget);
+    });
+
+    testWidgets('shows value without improvement when no previous',
+        (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(previousValue: null),
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.textContaining('100.0kg'), findsOneWidget);
+      expect(find.textContaining('+'), findsNothing);
+    });
+
+    testWidgets('shows trophy icon', (tester) async {
+      await tester.pumpWidget(buildTestWidget(pr: createPR()));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byIcon(Icons.emoji_events), findsOneWidget);
+    });
+
+    testWidgets('shows close icon', (tester) async {
+      await tester.pumpWidget(buildTestWidget(pr: createPR()));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('dismisses on tap', (tester) async {
+      bool dismissed = false;
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(),
+        onDismissed: () => dismissed = true,
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      await tester.tap(find.text('New PR!'));
+      await tester.pumpAndSettle();
+
+      expect(dismissed, isTrue);
+    });
+
+    testWidgets('auto-dismisses after 5 seconds', (tester) async {
+      bool dismissed = false;
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(),
+        onDismissed: () => dismissed = true,
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      // Not dismissed yet
+      expect(dismissed, isFalse);
+
+      // Advance past auto-dismiss timer
+      await tester.pump(const Duration(seconds: 5));
+      await tester.pumpAndSettle();
+
+      expect(dismissed, isTrue);
+    });
+
+    testWidgets('formats reps correctly', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(prType: PRType.maxReps, value: 15, previousValue: 12),
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.textContaining('15 reps'), findsOneWidget);
+      expect(find.textContaining('+3 reps'), findsOneWidget);
+    });
+
+    testWidgets('formats duration correctly', (tester) async {
+      await tester.pumpWidget(buildTestWidget(
+        pr: createPR(
+            prType: PRType.maxDuration, value: 125, previousValue: null),
+      ));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      expect(find.textContaining('2m 5s'), findsOneWidget);
+    });
+
+    testWidgets('has semantics live region', (tester) async {
+      await tester.pumpWidget(buildTestWidget(pr: createPR()));
+      await tester.pump(const Duration(milliseconds: 350));
+
+      final semantics = find.bySemanticsLabel(
+        RegExp(r'New personal record: Bench Press'),
+      );
+      expect(semantics, findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extracts `StreakSection` component with bottom sheet target picker (1-7 workouts/week)
- Creates `PRNotificationBanner` widget with slide-in animation, 5-second auto-dismiss, and accessibility support
- Updates `TrendsTab` to use extracted `StreakSection` instead of inline streak builder
- Adds "NEW" badge on `PersonalRecordTile` for PRs achieved within the last 7 days
- Static `PRNotificationBanner.show()` method for easy overlay integration from any screen

## Implementation Details
- Bottom sheet uses `ChoiceChip` for target selection with save confirmation
- PR banner uses `SlideTransition` + `FadeTransition` with `SingleTickerProviderStateMixin`
- `Semantics.liveRegion` announces PR to screen readers
- Value formatting handles kg, reps, duration (m/s), and distance (m/km)
- "NEW" badge auto-hides after 7 days without any timer logic

## Test plan
- [ ] StreakSection: shows streak data, flame icon, longest streak, settings opens bottom sheet
- [ ] StreakSection: bottom sheet shows 7 chips, save calls onTargetChanged
- [ ] PRNotificationBanner: shows exercise name, PR type, value, improvement
- [ ] PRNotificationBanner: auto-dismisses after 5s, tap dismisses, formats reps/duration
- [ ] "NEW" badge appears on recent PR tiles in charts section
- [ ] CI passes all checks

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)