### PR TITLE
[Task] Add completedAt field to ExerciseSet model, converter, and Firestore rules (#371)

### DIFF
--- a/Docs/PRDs/Analytics_Completion_Date_PRD.md
+++ b/Docs/PRDs/Analytics_Completion_Date_PRD.md
@@ -1,0 +1,171 @@
+# PRD: Analytics Based on Set Completion Date
+
+**GitHub Issue:** [#370](https://github.com/justbuildstuff-dev/Fitness-App/issues/370)
+**Priority:** Medium
+**Platform:** Both (iOS & Android)
+**Status:** Requirements Gathering
+**Created:** 2026-02-22
+**Feature Type:** Enhancement
+
+---
+
+## Overview
+
+Update all analytics calculations to use the date a set was **completed** (checked off) rather than the date it was created. This requires adding a `completedAt` timestamp to `ExerciseSet`, populated when `checked` transitions to `true`, and updating the analytics service to use this field for grouping, filtering, and dating all analytics output.
+
+## User Problem
+
+Users typically plan their workouts in advance — creating workout structures and sets ahead of time. Currently, analytics (heatmap activity, volume totals, exercise progress charts, personal records) are grouped by the date a set was **created**, not when it was **completed**. This means:
+
+1. A workout planned on Monday but performed on Wednesday shows up in Monday's heatmap and stats
+2. The activity heatmap does not accurately reflect actual training days
+3. Volume and progress charts misrepresent when improvements were actually achieved
+4. Personal record dates are incorrect — they show when the set was entered, not when it was lifted
+
+---
+
+## Existing Implementation
+
+The `ExerciseSet` model currently has:
+- `createdAt: DateTime` — when the set document was created in Firestore
+- `updatedAt: DateTime` — last modification timestamp (updated on every field change)
+- `checked: bool` — completion status (default: `false`)
+
+There is **no dedicated completion timestamp**. The analytics service (`lib/services/analytics_service.dart`) uses `set.createdAt` throughout for:
+- Heatmap day grouping (`generateSetBasedHeatmapData`, `getMonthHeatmapData`)
+- Exercise progress session dates (`getExerciseProgress`)
+- Weekly trend volume grouping (`getWeeklyTrends`)
+- Personal record achievement dates (`_findPRsForExercise`, `_checkForPRInSet`)
+- Date-range filtering of sets (`_getAllUserSets`)
+
+The `_toggleSetCompletion` method in `exercise_detail_screen.dart` already sets `updatedAt: DateTime.now()` when toggling `checked`, making `updatedAt` a reasonable proxy for existing data.
+
+---
+
+## User Stories
+
+### US-1: Heatmap Reflects Actual Workout Days
+
+As a user viewing my activity heatmap,
+I want each day's activity count to reflect the sets I actually completed on that day,
+so that the heatmap accurately shows my training schedule.
+
+**Acceptance Criteria:**
+- [ ] Monthly heatmap calendar groups checked sets by `completedAt` date (not `createdAt`)
+- [ ] A set checked on Wednesday appears in Wednesday's count, regardless of when the workout was created
+- [ ] Current streak and longest streak calculations use completion date
+- [ ] Sets that are unchecked are not shown in heatmap counts
+- [ ] Historical sets without `completedAt` fall back to `updatedAt` for display
+- [ ] Works on both iOS and Android
+
+### US-2: Volume and Key Statistics Reflect Completion Date
+
+As a user reviewing my training stats for a date range,
+I want volume totals and set counts to be based on when I completed those sets,
+so that "This Month" stats actually represent work done this month.
+
+**Acceptance Criteria:**
+- [ ] Total volume for a date range counts only sets with a `completedAt` (or `updatedAt` fallback) within that range
+- [ ] Date-range filtering in analytics queries uses completion date, not creation date
+- [ ] Weekly trend volume is grouped by the week the set was completed
+- [ ] Key statistics (total sets, total volume, workouts per week) reflect completion dates
+- [ ] Completion percentage calculation is unaffected (it's already set-level, not date-dependent)
+- [ ] Works on both iOS and Android
+
+### US-3: Exercise Progress Charts Plot on Completion Date
+
+As a user viewing my exercise progress chart,
+I want each data point to be plotted on the date I completed that session,
+so that the X-axis accurately represents my training timeline.
+
+**Acceptance Criteria:**
+- [ ] Each data point on the exercise progress chart uses `completedAt` (or `updatedAt` fallback) as the session date
+- [ ] Sets within a workout session are grouped by their completion date, not creation date
+- [ ] If sets in a session are completed across midnight, they group to the date of the first completed set in that session
+- [ ] Chart date range filtering uses completion date for inclusion
+- [ ] Works on both iOS and Android
+
+### US-4: Personal Records Show Accurate Achievement Date
+
+As a user reviewing my personal records,
+I want each PR to display the date I actually achieved it,
+so that I know the real date of my best performance.
+
+**Acceptance Criteria:**
+- [ ] `PersonalRecord.achievedAt` is populated from `set.completedAt` (or `updatedAt` fallback)
+- [ ] PR detection sorts sets by completion date when scanning for progression
+- [ ] "New PRs this period" count uses completion date to determine if a PR falls within the selected range
+- [ ] Works on both iOS and Android
+
+### US-5: Completion Timestamp Captured at Check-Off
+
+As a user marking a set as complete,
+I want the app to record the exact time I checked it off,
+so that my analytics accurately reflect when I trained.
+
+**Acceptance Criteria:**
+- [ ] `ExerciseSet` gains a `completedAt: DateTime?` field (nullable, null by default)
+- [ ] `completedAt` is set to `DateTime.now()` when `checked` transitions from `false` to `true`
+- [ ] `completedAt` is cleared (set to `null`) when a set is unchecked
+- [ ] `completedAt` is stored as a Firestore `Timestamp` field
+- [ ] `completedAt` is included in `ExerciseSet.copyWith()`, `toMap()`, and the Firestore converter
+- [ ] Duplicated sets have `completedAt` reset to `null` (alongside `checked: false`)
+- [ ] Firestore security rules updated to allow the `completedAt` field
+- [ ] Works on both iOS and Android
+
+### US-6: Historical Data Remains Visible
+
+As a user with existing workout history,
+I want my past analytics to remain visible after this update,
+so that I don't lose my historical progress data.
+
+**Acceptance Criteria:**
+- [ ] Sets without a `completedAt` field (created before this feature) use `updatedAt` as the fallback completion date
+- [ ] Fallback logic is: `completedAt ?? updatedAt` for all checked sets
+- [ ] Historical heatmap, volume, and progress data continues to render correctly
+- [ ] No migration or backfill of existing Firestore data is required
+- [ ] Works on both iOS and Android
+
+---
+
+## Non-Functional Requirements
+
+- **Performance**: No additional Firestore reads required — `completedAt` is a field on the already-fetched set document
+- **Backward Compatibility**: The `completedAt` field is nullable; all existing documents without it gracefully fall back to `updatedAt`
+- **Cache**: Existing 5-minute analytics cache is unaffected; cache keys do not need to change
+- **Firestore Rules**: `completedAt` must be added as an allowed field in `firestore.rules` validation
+
+---
+
+## Out of Scope
+
+- Migrating or backfilling `completedAt` on existing Firestore documents
+- Showing `completedAt` time (not date) in the UI
+- Any changes to how sets are created or deleted
+- Changes to the `workout.createdAt` date used for workout-level analytics (workouts do not have a completion concept)
+
+---
+
+## Success Metrics
+
+- Heatmap shows correct training days for workouts planned in advance
+- Volume and PR dates match the actual day training occurred
+- No regressions in analytics loading, caching, or display
+- All existing and new analytics tests pass
+
+---
+
+## Dependencies
+
+- `ExerciseSet` model (`lib/models/exercise_set.dart`)
+- `ExerciseSetConverter` (`lib/converters/exercise_set_converter.dart`)
+- `AnalyticsService` (`lib/services/analytics_service.dart`)
+- `exercise_detail_screen.dart` — `_toggleSetCompletion` method
+- `firestore.rules` — field validation
+- Any other screen that calls `set.copyWith(checked: ...)`
+
+---
+
+## Priority
+
+**Medium** — Analytics correctness improvement. Does not block core workout tracking functionality.

--- a/Docs/Technical_Designs/Analytics_Completion_Date_Technical_Design.md
+++ b/Docs/Technical_Designs/Analytics_Completion_Date_Technical_Design.md
@@ -1,0 +1,327 @@
+# Technical Design: Analytics Based on Set Completion Date
+
+**GitHub Issue:** [#370](https://github.com/justbuildstuff-dev/Fitness-App/issues/370)
+**PRD:** [Docs/PRDs/Analytics_Completion_Date_PRD.md](../PRDs/Analytics_Completion_Date_PRD.md)
+**Status:** Design Complete
+**Created:** 2026-02-22
+**SA Agent:** In Progress
+
+---
+
+## Current Architecture Analysis
+
+### State Management
+- Provider pattern (`ProgramProvider extends ChangeNotifier`) — consistent throughout the app
+- Analytics data computed in `AnalyticsService` (singleton) and cached in `ProgramProvider`
+
+### Completion Toggle Flow (Discovered via Codebase Analysis)
+
+The primary UI path for toggling set completion is:
+```
+SetRow._handleCheckboxChange (lib/widgets/set_row.dart:61)
+  → set.copyWith(checked: checked, updatedAt: DateTime.now())
+  → widget.onUpdate(updatedSet)
+    → ConsolidatedWorkoutScreen._updateSet (lib/screens/workouts/consolidated_workout_screen.dart:309)
+      → provider.updateSet(updatedSet)
+        → ProgramProvider.updateSet (lib/providers/program_provider.dart:1218)
+          → set.copyWith(updatedAt: DateTime.now())  // re-stamps updatedAt
+          → _firestoreService.updateSet(updatedSet)
+```
+
+A secondary (deprecated) path exists in `ExerciseDetailScreen._toggleSetCompletion` (lib/screens/exercises/exercise_detail_screen.dart:484).
+
+### Date Fields in ExerciseSet (Current)
+```
+createdAt: DateTime   // when set was created in Firestore
+updatedAt: DateTime   // last modification (ANY field change)
+checked: bool         // completion status
+```
+No dedicated completion timestamp exists. Analytics throughout `AnalyticsService` use `set.createdAt` for grouping and dating.
+
+### Key Analytics Methods Using `createdAt` (Must Change)
+| Method | File | Current Usage | Required Change |
+|--------|------|---------------|-----------------|
+| `generateSetBasedHeatmapData` | analytics_service.dart:153 | `set.createdAt.year/month/day` | `completionDate.year/month/day` |
+| `getMonthHeatmapData` | analytics_service.dart:244 | `set.createdAt.day` | `completionDate.day` |
+| `getExerciseProgress` | analytics_service.dart:452 | `workoutSets.first.createdAt` | `completionDate` of first set |
+| `getWeeklyTrends` | analytics_service.dart:646 | `set.createdAt` | `completionDate` |
+| `_findPRsForExercise` | analytics_service.dart:959 | `set.createdAt` for sort + achievedAt | `completionDate` |
+| `_checkForPRInSet` | analytics_service.dart:1108 | `newSet.createdAt` achievedAt | `completionDate` |
+| `_detectPersonalRecords` | analytics_service.dart:959 | sort by `createdAt` | sort by `completionDate` |
+| `WorkoutAnalytics.fromWorkoutData` | analytics.dart:57 | all sets regardless of checked | completed sets only |
+
+### Test Files Affected
+- `test/models/enhanced_exercise_set_test.dart`
+- `test/widgets/set_row_test.dart`
+- `test/test_utilities/test_data_factory.dart`
+- `test/services/analytics_service_integration_test.dart` (stub — no changes needed)
+- `test/models/analytics_test.dart`
+- `test/providers/program_provider_analytics_test.dart`
+
+---
+
+## Architecture Overview
+
+This feature adds a single nullable field (`completedAt: DateTime?`) to `ExerciseSet` and propagates its use through the data, service, and widget layers. No new architecture is introduced — the change follows the existing `ExerciseSet` model conventions exactly.
+
+**Strategy:**
+1. **Model Layer**: Add `completedAt` field; update `copyWith`, converter, Firestore rules
+2. **Widget Layer**: Set/clear `completedAt` at the checkbox toggle site (`SetRow`)
+3. **Service Layer**: Add a private `_completionDate(ExerciseSet)` helper and use it consistently throughout `AnalyticsService`
+
+**Fallback for historical data**: `completedAt ?? updatedAt`
+- No Firestore migration required
+- Backward compatible — null field simply uses `updatedAt` as best approximation
+
+**`_getAllUserSets` inner filter change**: The existing inner set-level date filter (`sets.where((s) => dateRange.contains(s.createdAt))`) is removed. The outer workout-level `createdAt` filter already scopes the query to the correct time window. Removing the inner filter allows sets added to a workout after its creation to be included correctly.
+
+---
+
+## Component Design
+
+### Modified: `ExerciseSet` (lib/models/exercise_set.dart)
+
+Add `completedAt: DateTime?` field. Update `copyWith` to support explicit null-clearing via a `clearCompletedAt` flag (needed to uncheck a set). Update `createDuplicateCopy` to reset `completedAt` to null.
+
+```dart
+// New field
+final DateTime? completedAt;
+
+// Updated constructor
+ExerciseSet({
+  ...existing fields...
+  this.completedAt,  // nullable, default null
+});
+
+// Updated copyWith
+ExerciseSet copyWith({
+  ...existing params...
+  DateTime? completedAt,
+  bool clearCompletedAt = false,  // explicit null-clear flag
+}) {
+  return ExerciseSet(
+    ...existing...
+    completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
+  );
+}
+
+// Updated createDuplicateCopy
+return ExerciseSet(
+  ...existing...
+  checked: false,
+  completedAt: null,  // reset alongside checked
+);
+```
+
+**Follows pattern from:** existing `copyWith` in `lib/models/exercise_set.dart:61`
+
+### Modified: `ExerciseSetConverter` (lib/converters/exercise_set_converter.dart)
+
+```dart
+// toFirestore: add completedAt (nullable Timestamp)
+'completedAt': set.completedAt != null
+    ? Timestamp.fromDate(set.completedAt!)
+    : null,
+
+// fromFirestore: read completedAt (nullable)
+completedAt: data['completedAt'] != null
+    ? (data['completedAt'] as Timestamp).toDate()
+    : null,
+```
+
+**Follows pattern from:** `createdAt` / `updatedAt` handling in `lib/converters/exercise_set_converter.dart:17`
+
+### Modified: `firestore.rules` (fittrack/firestore.rules)
+
+Add to `validSet` function:
+```javascript
+&& (data.completedAt == null || isTimestamp(data.completedAt))
+```
+
+**Follows pattern from:** `data.checked == null || isBoolean(data.checked)` at line 300
+
+### Modified: `SetRow` (lib/widgets/set_row.dart)
+
+Update `_handleCheckboxChange` to set/clear `completedAt`:
+
+```dart
+void _handleCheckboxChange(bool? checked) {
+  if (checked == null) return;
+
+  final now = DateTime.now();
+  final updatedSet = widget.set.copyWith(
+    checked: checked,
+    updatedAt: now,
+    completedAt: checked ? now : null,
+    clearCompletedAt: !checked,  // explicitly null completedAt when unchecking
+  );
+
+  widget.onUpdate(updatedSet);
+}
+```
+
+**Also update:** `ExerciseDetailScreen._toggleSetCompletion` (deprecated screen, same pattern)
+
+### Modified: `AnalyticsService` (lib/services/analytics_service.dart)
+
+**Add private helper** (add near top of class body):
+```dart
+/// Returns the effective completion date for a checked set.
+/// Falls back to updatedAt for sets without an explicit completedAt (historical data).
+DateTime _completionDate(ExerciseSet set) => set.completedAt ?? set.updatedAt;
+```
+
+**Update `_getAllUserSets`**: Remove the inner set-level `createdAt` filter:
+```dart
+// BEFORE:
+final filteredSets = sets.where((s) => dateRange.contains(s.createdAt));
+allSets.addAll(filteredSets);
+
+// AFTER:
+allSets.addAll(sets);  // Outer workout filter is sufficient
+```
+
+**Update `generateSetBasedHeatmapData`** (line 153):
+```dart
+// BEFORE:
+final date = DateTime(set.createdAt.year, set.createdAt.month, set.createdAt.day);
+
+// AFTER:
+final completionDate = _completionDate(set);
+final date = DateTime(completionDate.year, completionDate.month, completionDate.day);
+```
+
+**Update `getMonthHeatmapData`** (line 244):
+```dart
+// BEFORE:
+final day = set.createdAt.day;
+
+// AFTER:
+final day = _completionDate(set).day;
+```
+
+**Update `getExerciseProgress`** (line 452):
+```dart
+// BEFORE:
+workoutSets.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+final sessionDate = workoutSets.first.createdAt;
+
+// AFTER:
+workoutSets.sort((a, b) => _completionDate(a).compareTo(_completionDate(b)));
+final sessionDate = _completionDate(workoutSets.first);
+```
+
+**Update `getWeeklyTrends`** (line 646):
+```dart
+// BEFORE (sets):
+final weekStart = getWeekStart(set.createdAt);
+
+// AFTER (only include completed sets):
+for (final set in allSets.where((s) => s.checked)) {
+  final weekStart = getWeekStart(_completionDate(set));
+  ...
+}
+```
+
+**Update `_detectPersonalRecords`** (line 959):
+```dart
+// BEFORE:
+exerciseSets.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+// AFTER:
+exerciseSets.sort((a, b) => _completionDate(a).compareTo(_completionDate(b)));
+```
+
+**Update `_findPRsForExercise`** (achievedAt fields):
+```dart
+// BEFORE:
+achievedAt: set.createdAt,
+
+// AFTER:
+achievedAt: _completionDate(set),
+```
+(Multiple occurrences — all PR type checks within the method)
+
+**Update `_checkForPRInSet`** (achievedAt fields):
+```dart
+// BEFORE:
+achievedAt: newSet.createdAt,
+
+// AFTER:
+achievedAt: _completionDate(newSet),
+```
+(Multiple occurrences within switch cases)
+
+**Update `computeWorkoutAnalytics` / `WorkoutAnalytics.fromWorkoutData`**: Filter to only count completed sets. The `_getAllUserSets` call already fetches all sets; the `fromWorkoutData` factory should only tally checked sets for volume/totalSets. Update the factory to filter by `checked == true`:
+```dart
+// In WorkoutAnalytics.fromWorkoutData (analytics.dart ~line 57):
+for (final set in sets.where((s) => s.checked)) {  // Add checked filter
+  totalSetsCount++;
+  if (set.weight != null && set.reps != null) {
+    volume += set.weight! * set.reps!;
+  }
+  ...
+}
+```
+
+---
+
+## Implementation Tasks
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| 1 | [#371](https://github.com/justbuildstuff-dev/Fitness-App/issues/371) ExerciseSet model + converter + Firestore rules | `exercise_set.dart`, `exercise_set_converter.dart`, `firestore.rules` | 1 day |
+| 2 | [#372](https://github.com/justbuildstuff-dev/Fitness-App/issues/372) SetRow checkbox toggle + deprecated screen | `set_row.dart`, `exercise_detail_screen.dart` | 0.5 day |
+| 3 | [#373](https://github.com/justbuildstuff-dev/Fitness-App/issues/373) Analytics Service: heatmap methods | `analytics_service.dart` | 0.5 day |
+| 4 | [#374](https://github.com/justbuildstuff-dev/Fitness-App/issues/374) Analytics Service: exercise progress + weekly trends | `analytics_service.dart` | 0.5 day |
+| 5 | [#375](https://github.com/justbuildstuff-dev/Fitness-App/issues/375) Analytics Service: PRs + WorkoutAnalytics total volume | `analytics_service.dart`, `analytics.dart` | 0.5 day |
+
+**Total Estimated Effort: ~3 days**
+
+---
+
+## Testing Strategy
+
+All tests follow existing patterns in `test/` directory.
+
+### Task 1 Tests (Unit — `test/models/`)
+- `enhanced_exercise_set_test.dart`: Add tests for `completedAt` field default null, `copyWith` preserves/sets/clears `completedAt`, `createDuplicateCopy` resets to null, `toMap` includes field
+- `test_data_factory.dart`: Update `createSet` factory method to include `completedAt` parameter
+
+### Task 2 Tests (Widget — `test/widgets/`)
+- `set_row_test.dart`: Add tests that checking a set sets `completedAt`, unchecking clears it, `completedAt != null` when `checked = true`
+
+### Tasks 3-5 Tests (Unit — `test/providers/`, `test/models/`)
+- `program_provider_analytics_test.dart` or `test/models/analytics_test.dart`: Update/add tests for:
+  - Heatmap groups by `completedAt`, not `createdAt`
+  - Historical sets (no `completedAt`) fall back to `updatedAt`
+  - Exercise progress session date uses completion date
+  - Weekly trends only count completed sets by completion date
+  - PR `achievedAt` uses completion date
+  - `WorkoutAnalytics.fromWorkoutData` only counts checked sets
+
+---
+
+## Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Historical sets showing wrong dates (updatedAt mismatch) | Low | Low | Documented fallback; `updatedAt` is set at check time historically |
+| Firestore rules rejection of new field | Low | High | Add `completedAt` to `validSet` before deploying (Task 1) |
+| Analytics showing zero data after change | Low | Medium | Extensive unit tests before merge; fallback ensures data continuity |
+| ProgramProvider.updateSet re-stampings `updatedAt` invalidating `completedAt` | None | High | `completedAt` is set before `updateSet` is called; `copyWith(updatedAt:)` does not clear `completedAt` |
+
+---
+
+## Deployment Notes
+
+- Deploy updated Firestore rules before or alongside app update: `firebase deploy --only firestore:rules`
+- No data migration required
+- `completedAt` being null on existing documents is handled by the `?? updatedAt` fallback
+- Feature is backward compatible with existing Firestore data
+
+---
+
+## Implementation Notes
+
+*(Developer Agent: add notes here as you implement)*

--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -298,6 +298,7 @@ service cloud.firestore {
         && (data.distance == null || isNumber(data.distance) && data.distance >= 0)
         && (data.restTime == null || isNumber(data.restTime) && data.restTime >= 0)
         && (data.checked == null || isBoolean(data.checked))
+        && (data.completedAt == null || isTimestamp(data.completedAt))
         && (data.notes == null || isString(data.notes))
         && (data.createdAt != null && isTimestamp(data.createdAt))
         && (data.updatedAt != null && isTimestamp(data.updatedAt))

--- a/fittrack/lib/converters/exercise_set_converter.dart
+++ b/fittrack/lib/converters/exercise_set_converter.dart
@@ -14,6 +14,7 @@ class ExerciseSetConverter {
       'restTime': set.restTime,
       'checked': set.checked,
       'notes': set.notes,
+      'completedAt': set.completedAt != null ? Timestamp.fromDate(set.completedAt!) : null,
       'createdAt': Timestamp.fromDate(set.createdAt),
       'updatedAt': Timestamp.fromDate(set.updatedAt),
       'userId': set.userId,
@@ -43,6 +44,9 @@ class ExerciseSetConverter {
       restTime: data['restTime']?.toInt(),
       checked: data['checked'] ?? false,
       notes: data['notes'],
+      completedAt: data['completedAt'] != null
+          ? (data['completedAt'] as Timestamp).toDate()
+          : null,
       createdAt: (data['createdAt'] as Timestamp).toDate(),
       updatedAt: (data['updatedAt'] as Timestamp).toDate(),
       userId: data['userId'] ?? '',

--- a/fittrack/lib/models/exercise_set.dart
+++ b/fittrack/lib/models/exercise_set.dart
@@ -10,6 +10,7 @@ class ExerciseSet {
   final int? restTime; // seconds
   final bool checked;
   final String? notes;
+  final DateTime? completedAt;
   final DateTime createdAt;
   final DateTime updatedAt;
   final String userId;
@@ -28,6 +29,7 @@ class ExerciseSet {
     this.restTime,
     this.checked = false,
     this.notes,
+    this.completedAt,
     required this.createdAt,
     required this.updatedAt,
     required this.userId,
@@ -48,6 +50,7 @@ class ExerciseSet {
       'restTime': restTime,
       'checked': checked,
       'notes': notes,
+      'completedAt': completedAt?.toIso8601String(),
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
       'userId': userId,
@@ -67,6 +70,8 @@ class ExerciseSet {
     int? restTime,
     bool? checked,
     String? notes,
+    DateTime? completedAt,
+    bool clearCompletedAt = false,
     DateTime? updatedAt,
   }) {
     return ExerciseSet(
@@ -79,6 +84,7 @@ class ExerciseSet {
       restTime: restTime ?? this.restTime,
       checked: checked ?? this.checked,
       notes: notes ?? this.notes,
+      completedAt: clearCompletedAt ? null : (completedAt ?? this.completedAt),
       createdAt: createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       userId: userId,
@@ -166,6 +172,7 @@ class ExerciseSet {
       distance: newDistance,
       restTime: restTime,
       checked: false, // Always reset checked status
+      completedAt: null, // Always reset completion timestamp
       notes: notes,
       createdAt: now,
       updatedAt: now,

--- a/fittrack/test/models/enhanced_exercise_set_test.dart
+++ b/fittrack/test/models/enhanced_exercise_set_test.dart
@@ -715,6 +715,151 @@ void main() {
       });
     });
 
+    group('completedAt Field', () {
+      late ExerciseSet baseSet;
+
+      setUp(() {
+        baseSet = ExerciseSet(
+          id: 'set-ca',
+          setNumber: 1,
+          reps: 10,
+          weight: 80.0,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          exerciseId: 'exercise-1',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+      });
+
+      test('completedAt defaults to null on construction', () {
+        /// Test Purpose: Verify new sets have no completion timestamp by default
+        expect(baseSet.completedAt, isNull);
+        expect(baseSet.checked, false);
+      });
+
+      test('completedAt can be set on construction', () {
+        /// Test Purpose: Verify completedAt can be explicitly provided
+        final completedSet = ExerciseSet(
+          id: 'set-ca2',
+          setNumber: 1,
+          reps: 10,
+          completedAt: testDate,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          exerciseId: 'exercise-1',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+
+        expect(completedSet.completedAt, testDate);
+      });
+
+      test('copyWith sets completedAt when provided', () {
+        /// Test Purpose: Verify copyWith correctly sets completedAt (checking a set)
+        final completionTime = testDate.add(const Duration(hours: 2));
+        final checked = baseSet.copyWith(
+          checked: true,
+          completedAt: completionTime,
+          updatedAt: completionTime,
+        );
+
+        expect(checked.completedAt, completionTime);
+        expect(checked.checked, true);
+      });
+
+      test('copyWith preserves existing completedAt when not specified', () {
+        /// Test Purpose: Verify copyWith does not clear completedAt on unrelated updates
+        final completionTime = testDate.add(const Duration(hours: 1));
+        final checked = baseSet.copyWith(
+          checked: true,
+          completedAt: completionTime,
+          updatedAt: completionTime,
+        );
+
+        // Update weight without touching completedAt
+        final weightUpdated = checked.copyWith(weight: 90.0);
+
+        expect(weightUpdated.completedAt, completionTime); // Preserved
+        expect(weightUpdated.weight, 90.0);
+      });
+
+      test('copyWith clears completedAt when clearCompletedAt is true', () {
+        /// Test Purpose: Verify unchecking a set clears the completion timestamp
+        final completionTime = testDate.add(const Duration(hours: 1));
+        final checked = baseSet.copyWith(
+          checked: true,
+          completedAt: completionTime,
+          updatedAt: completionTime,
+        );
+
+        final unchecked = checked.copyWith(
+          checked: false,
+          clearCompletedAt: true,
+          updatedAt: testDate.add(const Duration(hours: 2)),
+        );
+
+        expect(unchecked.completedAt, isNull);
+        expect(unchecked.checked, false);
+      });
+
+      test('createDuplicateCopy always resets completedAt to null', () {
+        /// Test Purpose: Verify duplicated sets start with no completion timestamp
+        final completionTime = testDate.add(const Duration(hours: 1));
+        final completedSet = ExerciseSet(
+          id: 'original',
+          setNumber: 1,
+          reps: 10,
+          weight: 100.0,
+          checked: true,
+          completedAt: completionTime,
+          createdAt: testDate,
+          updatedAt: completionTime,
+          userId: 'user-123',
+          exerciseId: 'exercise-1',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+
+        final duplicate = completedSet.createDuplicateCopy(
+          newId: 'duplicate',
+          newExerciseId: 'exercise-2',
+          newWorkoutId: 'workout-2',
+          newWeekId: 'week-2',
+          newProgramId: 'program-2',
+          exerciseType: ExerciseType.strength,
+        );
+
+        expect(duplicate.completedAt, isNull);
+        expect(duplicate.checked, false);
+      });
+
+      test('toMap includes completedAt as ISO8601 string when set', () {
+        /// Test Purpose: Verify completedAt is serialized correctly
+        final completionTime = testDate.add(const Duration(hours: 3));
+        final completedSet = baseSet.copyWith(
+          checked: true,
+          completedAt: completionTime,
+          updatedAt: completionTime,
+        );
+
+        final map = completedSet.toMap();
+        expect(map['completedAt'], completionTime.toIso8601String());
+      });
+
+      test('toMap includes null for completedAt when not set', () {
+        /// Test Purpose: Verify null completedAt serializes as null (not missing key)
+        final map = baseSet.toMap();
+        expect(map.containsKey('completedAt'), isTrue);
+        expect(map['completedAt'], isNull);
+      });
+    });
+
     group('Comprehensive Validation Tests', () {
       test('validates complete strength set correctly', () {
         /// Test Purpose: Verify comprehensive validation for strength exercises

--- a/fittrack/test/test_utilities/test_data_factory.dart
+++ b/fittrack/test/test_utilities/test_data_factory.dart
@@ -147,10 +147,11 @@ class TestDataFactory {
     String programId = 'test-program-1',
     String userId = 'test-user-123',
     bool checked = false,
+    DateTime? completedAt,
     SetIntensity intensity = SetIntensity.moderate,
   }) {
     final now = DateTime.now();
-    
+
     return ExerciseSet(
       id: id ?? generateId('set'),
       setNumber: setNumber,
@@ -160,6 +161,7 @@ class TestDataFactory {
       distance: _getRealisticDistance(exerciseType, intensity),
       restTime: _getRealisticRestTime(exerciseType, intensity),
       checked: checked,
+      completedAt: completedAt,
       notes: _getSetNotes(exerciseType, setNumber),
       createdAt: now.subtract(Duration(minutes: _random.nextInt(180))),
       updatedAt: now.subtract(Duration(minutes: _random.nextInt(30))),


### PR DESCRIPTION
## Changes
- Added `completedAt: DateTime?` nullable field to `ExerciseSet` model
- Added `clearCompletedAt: bool` flag to `copyWith` to handle explicit null-clearing when unchecking a set
- Reset `completedAt` to null in `createDuplicateCopy` (alongside `checked: false`)
- Updated `toMap()` to include `completedAt` as nullable ISO8601 string
- Updated `ExerciseSetConverter.toFirestore` to write `completedAt` as nullable Firestore Timestamp
- Updated `ExerciseSetConverter.fromFirestore` to read `completedAt` as nullable Timestamp
- Added `completedAt == null || isTimestamp(completedAt)` to `validSet` in `firestore.rules`
- Added comprehensive `completedAt` tests to `enhanced_exercise_set_test.dart`
- Added `completedAt` parameter to `TestDataFactory.createExerciseSet`

## Testing
- [x] completedAt defaults to null on construction
- [x] copyWith sets completedAt when provided
- [x] copyWith preserves completedAt when not specified
- [x] copyWith(clearCompletedAt: true) sets completedAt to null
- [x] createDuplicateCopy always resets completedAt to null
- [x] toMap includes completedAt key (null or ISO8601 string)
- [x] No linter warnings
- [x] Follows existing ExerciseSet field conventions

## Design Reference
Technical Design: `Docs/Technical_Designs/Analytics_Completion_Date_Technical_Design.md`
Follows pattern from: `lib/converters/exercise_set_converter.dart` (createdAt/updatedAt handling)

## Issue Links
Closes #371
Part of #370