### PR TITLE
feat: Set completedAt on checkbox toggle (#372)

### DIFF
--- a/fittrack/lib/screens/exercises/exercise_detail_screen.dart
+++ b/fittrack/lib/screens/exercises/exercise_detail_screen.dart
@@ -483,10 +483,14 @@ class _ExerciseDetailScreenState extends State<ExerciseDetailScreen> {
 
   void _toggleSetCompletion(ExerciseSet set) async {
     final provider = Provider.of<ProgramProvider>(context, listen: false);
-    
+
+    final now = DateTime.now();
+    final newChecked = !set.checked;
     final updatedSet = set.copyWith(
-      checked: !set.checked,
-      updatedAt: DateTime.now(),
+      checked: newChecked,
+      completedAt: newChecked ? now : null,
+      clearCompletedAt: !newChecked,
+      updatedAt: now,
     );
 
     await provider.updateSet(updatedSet);

--- a/fittrack/lib/widgets/set_row.dart
+++ b/fittrack/lib/widgets/set_row.dart
@@ -61,9 +61,12 @@ class _SetRowState extends State<SetRow> {
   void _handleCheckboxChange(bool? checked) {
     if (checked == null) return;
 
+    final now = DateTime.now();
     final updatedSet = widget.set.copyWith(
       checked: checked,
-      updatedAt: DateTime.now(),
+      completedAt: checked ? now : null,
+      clearCompletedAt: !checked,
+      updatedAt: now,
     );
 
     widget.onUpdate(updatedSet);

--- a/fittrack/test/widgets/set_row_test.dart
+++ b/fittrack/test/widgets/set_row_test.dart
@@ -114,6 +114,60 @@ void main() {
       expect(updatedSet!.checked, isTrue);
     });
 
+    testWidgets('checking checkbox sets completedAt to current time', (tester) async {
+      /// Test Purpose: Verify completedAt is populated when set is checked
+
+      ExerciseSet? updatedSet;
+      final beforeCheck = DateTime.now();
+
+      await tester.pumpWidget(createTestWidget(
+        set: testSet,
+        exerciseType: ExerciseType.strength,
+        onUpdate: (set) => updatedSet = set,
+      ));
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+
+      expect(updatedSet, isNotNull);
+      expect(updatedSet!.completedAt, isNotNull);
+      expect(updatedSet!.completedAt!.isAfter(beforeCheck) || updatedSet!.completedAt!.isAtSameMomentAs(beforeCheck), isTrue);
+    });
+
+    testWidgets('unchecking checkbox clears completedAt', (tester) async {
+      /// Test Purpose: Verify completedAt is cleared when set is unchecked
+
+      final checkedSet = ExerciseSet(
+        id: testSet.id,
+        setNumber: testSet.setNumber,
+        checked: true,
+        reps: testSet.reps,
+        weight: testSet.weight,
+        completedAt: DateTime.now().subtract(const Duration(minutes: 5)),
+        createdAt: testSet.createdAt,
+        updatedAt: testSet.updatedAt,
+        userId: testSet.userId,
+        exerciseId: testSet.exerciseId,
+        workoutId: testSet.workoutId,
+        weekId: testSet.weekId,
+        programId: testSet.programId,
+      );
+
+      ExerciseSet? updatedSet;
+      await tester.pumpWidget(createTestWidget(
+        set: checkedSet,
+        exerciseType: ExerciseType.strength,
+        onUpdate: (set) => updatedSet = set,
+      ));
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+
+      expect(updatedSet, isNotNull);
+      expect(updatedSet!.checked, isFalse);
+      expect(updatedSet!.completedAt, isNull);
+    });
+
     testWidgets('displays duration and distance for cardio exercise', (tester) async {
       /// Test Purpose: Verify cardio fields are shown
 


### PR DESCRIPTION
## Summary
- Updates `SetRow._handleCheckboxChange` to set `completedAt: DateTime.now()` when checking a set and clear it via `clearCompletedAt: true` when unchecking
- Updates deprecated `ExerciseDetailScreen._toggleSetCompletion` with same logic for consistency
- Adds widget tests verifying `completedAt` is set on check and cleared on uncheck

## Test plan
- [ ] Checking a set results in `completedAt != null` (timestamped at check time)
- [ ] Unchecking a set results in `completedAt == null`
- [ ] Existing checkbox tests still pass (checked=true, checked=false)

Closes #372
Part of #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)