### PR TITLE
feat: Use completedAt for heatmap analytics grouping (#373)

### DIFF
--- a/fittrack/lib/services/analytics_service.dart
+++ b/fittrack/lib/services/analytics_service.dart
@@ -147,13 +147,14 @@ class AnalyticsService {
     // Filter only checked sets (completed sets)
     final checkedSets = allSets.where((set) => set.checked).toList();
 
-    // Group sets by date (normalize to midnight for consistent day-level grouping)
+    // Group sets by completion date (normalize to midnight for consistent day-level grouping)
     final Map<DateTime, int> dailySetCounts = {};
     for (final set in checkedSets) {
+      final completionDate = _completionDate(set);
       final date = DateTime(
-        set.createdAt.year,
-        set.createdAt.month,
-        set.createdAt.day,
+        completionDate.year,
+        completionDate.month,
+        completionDate.day,
       );
       dailySetCounts[date] = (dailySetCounts[date] ?? 0) + 1;
     }
@@ -238,10 +239,10 @@ class AnalyticsService {
     // Filter only checked sets (completed sets)
     final checkedSets = allSets.where((set) => set.checked).toList();
 
-    // Group sets by day of month
+    // Group sets by day of month using completion date
     final Map<int, int> dailySetCounts = {};
     for (final set in checkedSets) {
-      final day = set.createdAt.day;
+      final day = _completionDate(set).day;
       dailySetCounts[day] = (dailySetCounts[day] ?? 0) + 1;
     }
 
@@ -839,6 +840,14 @@ class AnalyticsService {
 
   // Private helper methods
 
+  /// Returns the date to use for analytics grouping for a completed set.
+  ///
+  /// Uses [ExerciseSet.completedAt] when available (set when a set is checked),
+  /// falling back to [ExerciseSet.updatedAt] for historical sets created before
+  /// the completedAt field was introduced. This ensures no Firestore migration
+  /// is needed while still providing accurate completion-date analytics.
+  DateTime _completionDate(ExerciseSet set) => set.completedAt ?? set.updatedAt;
+
   Future<List<Workout>> _getAllUserWorkouts(String userId, DateRange dateRange) async {
     final List<Workout> allWorkouts = [];
     
@@ -925,9 +934,7 @@ class AnalyticsService {
                 final sets = await _firestoreService.getSets(
                   userId, program.id, week.id, workout.id, exercise.id).first;
 
-                // Filter sets by date range
-                final filteredSets = sets.where((s) => dateRange.contains(s.createdAt));
-                allSets.addAll(filteredSets);
+                allSets.addAll(sets);
               }
             }
           }

--- a/fittrack/test/services/analytics_service_test.dart
+++ b/fittrack/test/services/analytics_service_test.dart
@@ -617,6 +617,64 @@ void main() {
         expect(heatmapData.currentStreak, equals(0));
         expect(heatmapData.longestStreak, equals(0));
       });
+
+      test('groups sets by completedAt when available', () async {
+        /// Test Purpose: Verify heatmap uses completedAt for grouping, not createdAt
+
+        final now = DateTime.now();
+        final day3Ago = DateTime(now.year, now.month, now.day).subtract(const Duration(days: 3));
+        final day1Ago = DateTime(now.year, now.month, now.day).subtract(const Duration(days: 1));
+        final dateRange = DateRange(
+          start: day3Ago,
+          end: DateTime(now.year, now.month, now.day, 23, 59, 59),
+        );
+
+        final sets = [
+          // Set created 3 days ago but completed 1 day ago — should be counted on day 1 ago
+          ExerciseSet(
+            id: 's1',
+            setNumber: 1,
+            reps: 10,
+            checked: true,
+            completedAt: day1Ago,
+            createdAt: day3Ago,
+            updatedAt: day3Ago,
+            userId: 'test_user',
+            exerciseId: 'ex1',
+            workoutId: 'w1',
+            weekId: 'wk1',
+            programId: 'p1',
+          ),
+          // Set with no completedAt — should fall back to updatedAt (day3Ago)
+          ExerciseSet(
+            id: 's2',
+            setNumber: 2,
+            reps: 10,
+            checked: true,
+            completedAt: null,
+            createdAt: day3Ago,
+            updatedAt: day3Ago,
+            userId: 'test_user',
+            exerciseId: 'ex1',
+            workoutId: 'w1',
+            weekId: 'wk1',
+            programId: 'p1',
+          ),
+        ];
+
+        _mockSetBasedHeatmapData(mockFirestoreService, sets, 'p1');
+
+        final heatmapData = await analyticsService.generateSetBasedHeatmapData(
+          userId: 'test_user',
+          dateRange: dateRange,
+          programId: 'p1',
+        );
+
+        expect(heatmapData.totalSets, equals(2));
+        // s1 should be on day1Ago, s2 (no completedAt) falls back to updatedAt = day3Ago
+        expect(heatmapData.dailySetCounts[day1Ago], equals(1));
+        expect(heatmapData.dailySetCounts[day3Ago], equals(1));
+      });
     });
 
     group('Personal Records Detection', () {
@@ -1140,6 +1198,42 @@ void main() {
         expect(decData.month, equals(12));
         expect(febData.year, equals(2024));
         expect(febData.month, equals(2));
+      });
+
+      test('groups sets by completedAt day when available', () async {
+        /// Test Purpose: Verify getMonthHeatmapData uses completedAt for day grouping
+
+        final mockService = MockFirestoreService();
+        final analyticsService = AnalyticsService.withFirestoreService(mockService);
+
+        final testSets = [
+          // Created Dec 1, completed Dec 15 — should count on day 15
+          _createTestSet(
+            id: 's1',
+            createdAt: DateTime(2024, 12, 1),
+            checked: true,
+            completedAt: DateTime(2024, 12, 15),
+          ),
+          // Created Dec 5, no completedAt — falls back to updatedAt = Dec 5 → day 5
+          _createTestSet(
+            id: 's2',
+            createdAt: DateTime(2024, 12, 5),
+            checked: true,
+          ),
+        ];
+
+        _setupMockFirestore(mockService, sets: testSets);
+
+        final monthData = await analyticsService.getMonthHeatmapData(
+          userId: 'test_user',
+          year: 2024,
+          month: 12,
+        );
+
+        expect(monthData.totalSets, equals(2));
+        expect(monthData.getSetCountForDay(15), equals(1)); // s1 grouped by completedAt
+        expect(monthData.getSetCountForDay(5), equals(1));  // s2 grouped by updatedAt fallback
+        expect(monthData.getSetCountForDay(1), equals(0));  // s1's createdAt day — should NOT be used
       });
     });
 
@@ -2024,6 +2118,7 @@ ExerciseSet _createTestSet({
   String programId = 'p1',
   int? reps,
   double? weight,
+  DateTime? completedAt,
 }) {
   return ExerciseSet(
     id: id,
@@ -2031,6 +2126,7 @@ ExerciseSet _createTestSet({
     reps: reps ?? 10,
     weight: weight,
     checked: checked,
+    completedAt: completedAt,
     createdAt: createdAt,
     updatedAt: createdAt,
     userId: 'test_user',


### PR DESCRIPTION
## Summary
- Adds private `_completionDate(ExerciseSet set) => set.completedAt ?? set.updatedAt` helper to `AnalyticsService`
- Updates `generateSetBasedHeatmapData` to group completed sets by `_completionDate` instead of `createdAt`
- Updates `getMonthHeatmapData` to group sets by `_completionDate().day` instead of `createdAt.day`
- Removes inner set-level `createdAt` filter from `_getAllUserSets` (sets are already scoped by workout date range; per-set date filtering would incorrectly exclude sets completed on a different day)
- Adds tests for `completedAt` grouping behavior in both heatmap methods

## Test plan
- [ ] Sets with `completedAt` are grouped by that date in the heatmap
- [ ] Sets without `completedAt` fall back to `updatedAt` for grouping
- [ ] Existing heatmap tests still pass (they use `createdAt == updatedAt`)

Closes #373
Part of #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)