### PR TITLE
feat: Use completedAt for exercise progress and weekly trends (#374)

### DIFF
--- a/fittrack/lib/services/analytics_service.dart
+++ b/fittrack/lib/services/analytics_service.dart
@@ -449,9 +449,9 @@ class AnalyticsService {
       final workoutSets = entry.value;
       final workoutId = entry.key;
 
-      // Use earliest set's createdAt as the session date
-      workoutSets.sort((a, b) => a.createdAt.compareTo(b.createdAt));
-      final sessionDate = workoutSets.first.createdAt;
+      // Use earliest set's completion date as the session date
+      workoutSets.sort((a, b) => _completionDate(a).compareTo(_completionDate(b)));
+      final sessionDate = _completionDate(workoutSets.first);
 
       // Compute per-session aggregates
       double? maxWeight;
@@ -641,10 +641,10 @@ class AnalyticsService {
       workoutsByWeek.putIfAbsent(weekStart, () => {}).add(workout.id);
     }
 
-    // Group sets by week and compute volume
+    // Group sets by week using completion date and compute volume
     final Map<DateTime, double> volumeByWeek = {};
     for (final set in allSets) {
-      final weekStart = getWeekStart(set.createdAt);
+      final weekStart = getWeekStart(_completionDate(set));
       double setVolume = 0;
       if (set.weight != null && set.reps != null) {
         setVolume = set.weight! * set.reps!;

--- a/fittrack/test/services/analytics_service_test.dart
+++ b/fittrack/test/services/analytics_service_test.dart
@@ -1444,6 +1444,58 @@ void main() {
         expect(result.dataPoints.first.totalDuration, equals(2700));
         expect(result.dataPoints.first.totalDistance, equals(7500.0));
       });
+
+      test('uses completedAt as session date when available', () async {
+        /// Test Purpose: Verify session date is based on completedAt, not createdAt
+
+        final now = DateTime.now();
+        final createdDate = now.subtract(const Duration(days: 7));
+        final completedDate = now.subtract(const Duration(days: 3));
+        final dateRange = DateRange(
+          start: now.subtract(const Duration(days: 30)),
+          end: now,
+        );
+
+        final testSets = [
+          ExerciseSet(
+            id: 's1',
+            setNumber: 1,
+            reps: 10,
+            weight: 100.0,
+            checked: true,
+            completedAt: completedDate,
+            createdAt: createdDate,
+            updatedAt: createdDate,
+            userId: 'test_user',
+            exerciseId: 'ex1',
+            workoutId: 'w1',
+            weekId: 'wk1',
+            programId: 'p1',
+          ),
+        ];
+
+        _setupMockFirestoreWithSetsAndExercises(
+          mockFirestoreService,
+          sets: testSets,
+          exercises: [_createTestExercise(id: 'ex1', exerciseType: ExerciseType.strength)],
+          workouts: [_createTestWorkout(id: 'w1', createdAt: createdDate)],
+        );
+
+        final result = await analyticsService.getExerciseProgress(
+          userId: 'test_user',
+          exerciseId: 'ex1',
+          exerciseName: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          dateRange: dateRange,
+        );
+
+        expect(result.dataPoints.length, equals(1));
+        // Session date should be completedAt, not createdAt
+        final sessionDate = result.dataPoints.first.date;
+        expect(sessionDate.year, equals(completedDate.year));
+        expect(sessionDate.month, equals(completedDate.month));
+        expect(sessionDate.day, equals(completedDate.day));
+      });
     });
 
     group('getMuscleGroupVolume', () {
@@ -1704,6 +1756,58 @@ void main() {
         expect(result.length, equals(2));
         // Should be sorted: Jan 6 week before Jan 20 week
         expect(result[0].weekStart.isBefore(result[1].weekStart), isTrue);
+      });
+
+      test('groups set volume by completedAt week when available', () async {
+        /// Test Purpose: Verify weekly volume uses completedAt for week grouping
+
+        // Monday Jan 6, 2025 = week 1; Monday Jan 13, 2025 = week 2
+        final week1Monday = DateTime(2025, 1, 6);
+        final week2Monday = DateTime(2025, 1, 13);
+        final dateRange = DateRange(
+          start: week1Monday,
+          end: week2Monday.add(const Duration(days: 6, hours: 23, minutes: 59, seconds: 59)),
+        );
+
+        final testSets = [
+          // Set created in week 1, but completed in week 2 — volume should be in week 2
+          ExerciseSet(
+            id: 's1',
+            setNumber: 1,
+            reps: 10,
+            weight: 100.0,
+            checked: true,
+            completedAt: DateTime(2025, 1, 14), // Tuesday of week 2
+            createdAt: DateTime(2025, 1, 7),    // Tuesday of week 1
+            updatedAt: DateTime(2025, 1, 7),
+            userId: 'test_user',
+            exerciseId: 'ex1',
+            workoutId: 'w1',
+            weekId: 'wk1',
+            programId: 'p1',
+          ),
+        ];
+
+        _setupMockFirestoreWithSetsAndExercises(
+          mockFirestoreService,
+          sets: testSets,
+          exercises: [_createTestExercise(id: 'ex1')],
+          workouts: [_createTestWorkout(id: 'w1', createdAt: DateTime(2025, 1, 7))],
+        );
+
+        final result = await analyticsService.getWeeklyTrends(
+          userId: 'test_user',
+          dateRange: dateRange,
+        );
+
+        // Volume should appear in week 2 (week of Jan 13), not week 1 (week of Jan 6)
+        final week2 = result.firstWhere((t) => t.weekStart == week2Monday, orElse: () =>
+          WeeklyTrendPoint(weekStart: week2Monday, totalVolume: 0, workoutCount: 0));
+        final week1 = result.firstWhere((t) => t.weekStart == week1Monday, orElse: () =>
+          WeeklyTrendPoint(weekStart: week1Monday, totalVolume: 0, workoutCount: 0));
+
+        expect(week2.totalVolume, equals(1000.0)); // 100 * 10 = 1000
+        expect(week1.totalVolume, equals(0.0));    // completedAt was in week 2
       });
     });
 


### PR DESCRIPTION
## Summary
- Updates `getExerciseProgress` to sort sets by `_completionDate` and use it as the session date for chart data points
- Updates `getWeeklyTrends` to group set volume by the ISO week of `_completionDate` rather than `createdAt`
- Both methods fall back to `updatedAt` for historical sets without `completedAt`
- Adds tests verifying `completedAt` is used for grouping when available

## Test plan
- [ ] Exercise progress session date reflects `completedAt` when set, not `createdAt`
- [ ] Weekly trends volume is grouped by `completedAt` week
- [ ] Existing tests still pass (they use `createdAt == updatedAt`)

Closes #374
Part of #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)