### PR TITLE
feat: Use completedAt for PR achievedAt and only count checked sets (#375)

### DIFF
--- a/fittrack/lib/models/analytics.dart
+++ b/fittrack/lib/models/analytics.dart
@@ -49,19 +49,21 @@ class WorkoutAnalytics {
           (typeBreakdown[exercise.exerciseType] ?? 0) + 1;
     }
 
-    // Calculate volume and duration
+    // Calculate volume and duration — only count completed (checked) sets
     double volume = 0.0;
     int duration = 0;
     int totalSetsCount = 0;
 
     for (final set in sets) {
+      if (!set.checked) continue;
+
       totalSetsCount++;
-      
+
       // Volume calculation (weight * reps)
       if (set.weight != null && set.reps != null) {
         volume += set.weight! * set.reps!;
       }
-      
+
       // Duration accumulation
       if (set.duration != null) {
         duration += set.duration!;

--- a/fittrack/lib/services/analytics_service.dart
+++ b/fittrack/lib/services/analytics_service.dart
@@ -962,8 +962,8 @@ class AnalyticsService {
       final exerciseSets = setsByExercise[exercise.id] ?? [];
       if (exerciseSets.isEmpty) continue;
 
-      // Sort sets by date to track progression
-      exerciseSets.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+      // Sort sets by completion date to track progression
+      exerciseSets.sort((a, b) => _completionDate(a).compareTo(_completionDate(b)));
 
       // Detect different types of PRs
       final exercisePRs = _findPRsForExercise(exercise, exerciseSets);
@@ -998,7 +998,7 @@ class AnalyticsService {
             prType: PRType.maxWeight,
             value: set.weight!,
             previousValue: maxWeight,
-            achievedAt: set.createdAt,
+            achievedAt: _completionDate(set),
             workoutId: set.workoutId,
             setId: set.id,
           ));
@@ -1018,7 +1018,7 @@ class AnalyticsService {
             prType: PRType.maxReps,
             value: set.reps!.toDouble(),
             previousValue: maxReps?.toDouble(),
-            achievedAt: set.createdAt,
+            achievedAt: _completionDate(set),
             workoutId: set.workoutId,
             setId: set.id,
           ));
@@ -1039,7 +1039,7 @@ class AnalyticsService {
             prType: PRType.maxVolume,
             value: volume,
             previousValue: maxVolume,
-            achievedAt: set.createdAt,
+            achievedAt: _completionDate(set),
             workoutId: set.workoutId,
             setId: set.id,
           ));
@@ -1059,7 +1059,7 @@ class AnalyticsService {
             prType: PRType.maxDuration,
             value: set.duration!.toDouble(),
             previousValue: maxDuration?.toDouble(),
-            achievedAt: set.createdAt,
+            achievedAt: _completionDate(set),
             workoutId: set.workoutId,
             setId: set.id,
           ));
@@ -1079,7 +1079,7 @@ class AnalyticsService {
             prType: PRType.maxDistance,
             value: set.distance!,
             previousValue: maxDistance,
-            achievedAt: set.createdAt,
+            achievedAt: _completionDate(set),
             workoutId: set.workoutId,
             setId: set.id,
           ));
@@ -1115,7 +1115,7 @@ class AnalyticsService {
               prType: PRType.maxWeight,
               value: newSet.weight!,
               previousValue: maxPreviousWeight,
-              achievedAt: newSet.createdAt,
+              achievedAt: _completionDate(newSet),
               workoutId: newSet.workoutId,
               setId: newSet.id,
             );
@@ -1142,7 +1142,7 @@ class AnalyticsService {
               prType: PRType.maxReps,
               value: newSet.reps!.toDouble(),
               previousValue: maxPreviousReps?.toDouble(),
-              achievedAt: newSet.createdAt,
+              achievedAt: _completionDate(newSet),
               workoutId: newSet.workoutId,
               setId: newSet.id,
             );
@@ -1170,7 +1170,7 @@ class AnalyticsService {
               prType: PRType.maxDuration,
               value: newSet.duration!.toDouble(),
               previousValue: maxPreviousDuration?.toDouble(),
-              achievedAt: newSet.createdAt,
+              achievedAt: _completionDate(newSet),
               workoutId: newSet.workoutId,
               setId: newSet.id,
             );
@@ -1200,7 +1200,7 @@ class AnalyticsService {
               prType: PRType.maxVolume,
               value: volume,
               previousValue: maxPreviousVolume,
-              achievedAt: newSet.createdAt,
+              achievedAt: _completionDate(newSet),
               workoutId: newSet.workoutId,
               setId: newSet.id,
             );

--- a/fittrack/test/services/analytics_service_test.dart
+++ b/fittrack/test/services/analytics_service_test.dart
@@ -89,6 +89,44 @@ void main() {
         expect(analytics.averageWorkoutDuration, equals(0.0));
       });
 
+      test('only counts checked sets for totalSets and totalVolume', () async {
+        /// Test Purpose: Verify WorkoutAnalytics only includes completed sets
+
+        final now = DateTime.now();
+        final dateRange = DateRange(
+          start: now.subtract(const Duration(days: 30)),
+          end: now,
+        );
+
+        final checkedSet = ExerciseSet(
+          id: 'cs1', setNumber: 1, reps: 10, weight: 100.0,
+          checked: true,
+          createdAt: now, updatedAt: now,
+          userId: 'test_user', exerciseId: 'ex1',
+          workoutId: 'w1', weekId: 'wk1', programId: 'p1',
+        );
+        final uncheckedSet = ExerciseSet(
+          id: 'us1', setNumber: 2, reps: 8, weight: 100.0,
+          checked: false,
+          createdAt: now, updatedAt: now,
+          userId: 'test_user', exerciseId: 'ex1',
+          workoutId: 'w1', weekId: 'wk1', programId: 'p1',
+        );
+
+        final analytics = WorkoutAnalytics.fromWorkoutData(
+          userId: 'test_user',
+          startDate: dateRange.start,
+          endDate: dateRange.end,
+          workouts: _createTestWorkouts(),
+          exercises: _createTestExercises(),
+          sets: [checkedSet, uncheckedSet],
+        );
+
+        // Only the checked set should be counted
+        expect(analytics.totalSets, equals(1));
+        expect(analytics.totalVolume, equals(1000.0)); // 100 * 10 = 1000, not 1800
+      });
+
       test('filters workouts by date range correctly', () async {
         final now = DateTime.now();
         final dateRange = DateRange(
@@ -817,6 +855,52 @@ void main() {
         );
 
         expect(pr.improvement, equals(300.0)); // 5 minutes = 300 seconds
+      });
+
+      test('PR achievedAt uses completedAt when available', () async {
+        /// Test Purpose: Verify PR detection uses _completionDate for achievedAt
+
+        final now = DateTime.now();
+        final createdDate = now.subtract(const Duration(days: 7));
+        final completedDate = now.subtract(const Duration(days: 2));
+
+        final prSet = ExerciseSet(
+          id: 's1',
+          setNumber: 1,
+          reps: 10,
+          weight: 150.0, // A PR weight
+          checked: true,
+          completedAt: completedDate,
+          createdAt: createdDate,
+          updatedAt: createdDate,
+          userId: 'test_user',
+          exerciseId: 'ex1',
+          workoutId: 'w1',
+          weekId: 'wk1',
+          programId: 'p1',
+        );
+
+        _setupMockFirestoreWithSetsAndExercises(
+          mockFirestoreService,
+          sets: [prSet],
+          exercises: [_createTestExercise(id: 'ex1', exerciseType: ExerciseType.strength)],
+          workouts: [_createTestWorkout(id: 'w1', createdAt: createdDate)],
+        );
+
+        final prs = await analyticsService.getPersonalRecords(
+          userId: 'test_user',
+        );
+
+        expect(prs, isNotEmpty);
+        final weightPR = prs.firstWhere(
+          (pr) => pr.prType == PRType.maxWeight,
+          orElse: () => throw StateError('No weight PR found'),
+        );
+
+        // achievedAt should use completedAt, not createdAt
+        expect(weightPR.achievedAt.year, equals(completedDate.year));
+        expect(weightPR.achievedAt.month, equals(completedDate.month));
+        expect(weightPR.achievedAt.day, equals(completedDate.day));
       });
     });
 


### PR DESCRIPTION
## Summary
- Updates `_detectPersonalRecords` to sort sets by `_completionDate` (completion progression)
- Updates all `achievedAt` in `_findPRsForExercise` and `_checkForPRInSet` to use `_completionDate(set)` instead of `set.createdAt`
- Updates `WorkoutAnalytics.fromWorkoutData` to only count `checked == true` sets for `totalSets` and `totalVolume`
- Adds tests verifying PR `achievedAt` reflects `completedAt` and that analytics counts only checked sets

## Test plan
- [ ] PR `achievedAt` uses `completedAt` when set, falls back to `updatedAt`
- [ ] `WorkoutAnalytics.totalSets` excludes unchecked sets
- [ ] `WorkoutAnalytics.totalVolume` excludes volume from unchecked sets
- [ ] Existing tests still pass

Closes #375
Part of #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)