### PR TITLE
fix: Reload workout sets when app returns from background

### DIFF
--- a/fittrack/lib/providers/program_provider.dart
+++ b/fittrack/lib/providers/program_provider.dart
@@ -777,11 +777,14 @@ class ProgramProvider extends ChangeNotifier {
   void loadExercises(String programId, String weekId, String workoutId) {
     if (_userId == null) return;
 
+    // Cancel previous subscription
+    _exercisesSubscription?.cancel();
+
     _isLoadingExercises = true;
     _programsError = null;
     notifyListeners();
 
-    _firestoreService.getExercises(_userId!, programId, weekId, workoutId).listen(
+    _exercisesSubscription = _firestoreService.getExercises(_userId!, programId, weekId, workoutId).listen(
       (exercises) {
         _exercises = exercises;
         _isLoadingExercises = false;

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -34,31 +34,50 @@ class ConsolidatedWorkoutScreen extends StatefulWidget {
   State<ConsolidatedWorkoutScreen> createState() => _ConsolidatedWorkoutScreenState();
 }
 
-class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen> {
+class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
+    with WidgetsBindingObserver {
   // Track which exercises are currently adding sets (for debouncing)
   final Set<String> _addingSetForExercise = {};
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     // Load exercises and all sets when screen opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final programProvider = Provider.of<ProgramProvider>(context, listen: false);
-
-      // First load exercises
-      programProvider.loadExercises(
-        widget.program.id,
-        widget.week.id,
-        widget.workout.id,
-      );
-
-      // Then load all sets for all exercises
-      programProvider.loadAllSetsForWorkout(
-        programId: widget.program.id,
-        weekId: widget.week.id,
-        workoutId: widget.workout.id,
-      );
+      _loadWorkoutData();
     });
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _loadWorkoutData();
+    }
+  }
+
+  void _loadWorkoutData() {
+    final programProvider = Provider.of<ProgramProvider>(context, listen: false);
+
+    // Load exercises (live stream)
+    programProvider.loadExercises(
+      widget.program.id,
+      widget.week.id,
+      widget.workout.id,
+    );
+
+    // Load all sets for all exercises
+    programProvider.loadAllSetsForWorkout(
+      programId: widget.program.id,
+      weekId: widget.week.id,
+      workoutId: widget.workout.id,
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

Fixes sets disappearing from the workout screen after the app is backgrounded and resumed.

- **ConsolidatedWorkoutScreen**: Added `WidgetsBindingObserver` to detect when the app resumes from the background and reload exercises + sets via `_loadWorkoutData()`
- **ProgramProvider.loadExercises()**: Fixed orphaned stream subscription — now properly assigns to `_exercisesSubscription` (with cancel-previous pattern, matching `loadWorkouts()` and other methods)

## Root Cause

`initState()` only runs once. `loadAllSetsForWorkout()` uses a one-shot `.first` Future that never refreshes. When the app resumed from the background, no code triggered a reload, so the sets remained stale (or empty if the exercises stream had re-emitted).

## Test plan

- [ ] Open a workout with multiple exercises and sets
- [ ] Background the app (home button / switch apps)
- [ ] Return to FitTrack
- [ ] Verify sets are still visible without needing to navigate away
- [ ] Verify this works after backgrounding multiple times
- [ ] Verify sets still save/update correctly after a resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)