### PR TITLE
[Task] Exercise model + converter: add supersetGroupId field (#390)

### DIFF
--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -283,7 +283,9 @@ service cloud.firestore {
         && (data.userId != null && isString(data.userId))
         && (data.workoutId != null && isString(data.workoutId))
         && (data.weekId != null && isString(data.weekId))
-        && (data.programId != null && isString(data.programId));
+        && (data.programId != null && isString(data.programId))
+        && (data.supersetGroupId == null || isString(data.supersetGroupId))
+        && (data.groupOrderIndex == null || isNumber(data.groupOrderIndex));
     }
 
     function validSet(data) {

--- a/fittrack/lib/converters/exercise_converter.dart
+++ b/fittrack/lib/converters/exercise_converter.dart
@@ -16,6 +16,8 @@ class ExerciseConverter {
       'workoutId': exercise.workoutId,
       'weekId': exercise.weekId,
       'programId': exercise.programId,
+      'supersetGroupId': exercise.supersetGroupId,
+      'groupOrderIndex': exercise.groupOrderIndex,
     };
   }
 
@@ -39,6 +41,8 @@ class ExerciseConverter {
       workoutId: workoutId,
       weekId: weekId,
       programId: programId,
+      supersetGroupId: data['supersetGroupId'] as String?,
+      groupOrderIndex: data['groupOrderIndex'] as int?,
     );
   }
 }

--- a/fittrack/lib/models/exercise.dart
+++ b/fittrack/lib/models/exercise.dart
@@ -66,6 +66,8 @@ class Exercise {
   final String workoutId;
   final String weekId;
   final String programId;
+  final String? supersetGroupId; // UUID shared by all exercises in a group; null = standalone
+  final int? groupOrderIndex;   // Position within the group (0-based); null for standalone
 
   Exercise({
     required this.id,
@@ -79,6 +81,8 @@ class Exercise {
     required this.workoutId,
     required this.weekId,
     required this.programId,
+    this.supersetGroupId,
+    this.groupOrderIndex,
   });
 
   /// Convert Exercise to basic Map format (Firebase conversion handled by converter)
@@ -94,6 +98,8 @@ class Exercise {
       'workoutId': workoutId,
       'weekId': weekId,
       'programId': programId,
+      'supersetGroupId': supersetGroupId,
+      'groupOrderIndex': groupOrderIndex,
     };
   }
 
@@ -103,6 +109,9 @@ class Exercise {
     int? orderIndex,
     String? notes,
     DateTime? updatedAt,
+    String? supersetGroupId,
+    int? groupOrderIndex,
+    bool clearSupersetGroup = false, // when true, sets supersetGroupId and groupOrderIndex to null
   }) {
     return Exercise(
       id: id,
@@ -116,6 +125,8 @@ class Exercise {
       workoutId: workoutId,
       weekId: weekId,
       programId: programId,
+      supersetGroupId: clearSupersetGroup ? null : (supersetGroupId ?? this.supersetGroupId),
+      groupOrderIndex: clearSupersetGroup ? null : (groupOrderIndex ?? this.groupOrderIndex),
     );
   }
 
@@ -165,7 +176,9 @@ class Exercise {
         other.userId == userId &&
         other.workoutId == workoutId &&
         other.weekId == weekId &&
-        other.programId == programId;
+        other.programId == programId &&
+        other.supersetGroupId == supersetGroupId &&
+        other.groupOrderIndex == groupOrderIndex;
   }
 
   @override
@@ -182,6 +195,8 @@ class Exercise {
       workoutId,
       weekId,
       programId,
+      supersetGroupId,
+      groupOrderIndex,
     );
   }
 }

--- a/fittrack/test/models/enhanced_exercise_test.dart
+++ b/fittrack/test/models/enhanced_exercise_test.dart
@@ -414,6 +414,163 @@ void main() {
       });
     });
 
+    group('Superset Group Fields', () {
+      test('supersetGroupId and groupOrderIndex are null by default', () {
+        /// Test Purpose: Verify new superset fields default to null for backward compatibility
+        final exercise = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+
+        expect(exercise.supersetGroupId, isNull);
+        expect(exercise.groupOrderIndex, isNull);
+      });
+
+      test('toMap includes supersetGroupId and groupOrderIndex', () {
+        /// Test Purpose: Verify serialization includes superset fields
+        final exercise = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+          supersetGroupId: 'group-uuid-123',
+          groupOrderIndex: 0,
+        );
+
+        final mapData = exercise.toMap();
+        expect(mapData['supersetGroupId'], 'group-uuid-123');
+        expect(mapData['groupOrderIndex'], 0);
+      });
+
+      test('toMap serializes null superset fields correctly', () {
+        /// Test Purpose: Verify null superset fields are serialized as null (not omitted)
+        final exercise = Exercise(
+          id: 'exercise-1',
+          name: 'Squat',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+
+        final mapData = exercise.toMap();
+        expect(mapData.containsKey('supersetGroupId'), isTrue);
+        expect(mapData['supersetGroupId'], isNull);
+        expect(mapData.containsKey('groupOrderIndex'), isTrue);
+        expect(mapData['groupOrderIndex'], isNull);
+      });
+
+      test('copyWith preserves supersetGroupId when not specified', () {
+        /// Test Purpose: Verify copyWith does not inadvertently clear superset fields
+        final original = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+          supersetGroupId: 'group-uuid-123',
+          groupOrderIndex: 1,
+        );
+
+        final updated = original.copyWith(name: 'Updated Name');
+        expect(updated.supersetGroupId, 'group-uuid-123');
+        expect(updated.groupOrderIndex, 1);
+      });
+
+      test('copyWith with clearSupersetGroup sets both fields to null', () {
+        /// Test Purpose: Verify clearSupersetGroup flag nullifies both superset fields
+        final original = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+          supersetGroupId: 'group-uuid-123',
+          groupOrderIndex: 0,
+        );
+
+        final cleared = original.copyWith(clearSupersetGroup: true);
+        expect(cleared.supersetGroupId, isNull);
+        expect(cleared.groupOrderIndex, isNull);
+      });
+
+      test('copyWith can update supersetGroupId and groupOrderIndex', () {
+        /// Test Purpose: Verify copyWith can assign new superset group values
+        final original = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+        );
+
+        final grouped = original.copyWith(
+          supersetGroupId: 'new-group-uuid',
+          groupOrderIndex: 2,
+        );
+        expect(grouped.supersetGroupId, 'new-group-uuid');
+        expect(grouped.groupOrderIndex, 2);
+      });
+
+      test('equality considers supersetGroupId and groupOrderIndex', () {
+        /// Test Purpose: Verify that superset fields are included in equality check
+        final exercise1 = Exercise(
+          id: 'exercise-1',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 1,
+          createdAt: testDate,
+          updatedAt: testDate,
+          userId: 'user-123',
+          workoutId: 'workout-1',
+          weekId: 'week-1',
+          programId: 'program-1',
+          supersetGroupId: 'group-uuid-123',
+          groupOrderIndex: 0,
+        );
+
+        final exercise2 = exercise1.copyWith(); // identical copy
+        final exercise3 = exercise1.copyWith(supersetGroupId: 'different-group');
+
+        expect(exercise1, equals(exercise2));
+        expect(exercise1.hashCode, equals(exercise2.hashCode));
+        expect(exercise1, isNot(equals(exercise3)));
+      });
+    });
+
     group('Edge Cases and Error Conditions', () {
       test('handles extremely long exercise names gracefully', () {
         /// Test Purpose: Test boundary conditions for exercise name validation


### PR DESCRIPTION
## Summary

- Adds `supersetGroupId: String?` and `groupOrderIndex: int?` to the `Exercise` model (null by default — fully backwards compatible)
- Updates `copyWith` with `clearSupersetGroup` flag to explicitly null out both fields
- Updates `==` and `hashCode` to include both new fields
- Updates `ExerciseConverter.toFirestore` and `fromFirestore` to read/write both fields
- Updates `firestore.rules` `validExercise` function to allow both optional fields
- Adds comprehensive tests covering null defaults, serialization, copyWith, and equality

## Test plan

- [ ] All existing exercise tests still pass (backwards-compatible null defaults)
- [ ] New superset group tests pass: null defaults, toMap, copyWith preserve/clear, equality

Closes #390
Part of #261