### PR TITLE
[Task] ExercisePickerScreen multi-select mode (#393)

### DIFF
--- a/fittrack/lib/screens/exercises/exercise_picker_screen.dart
+++ b/fittrack/lib/screens/exercises/exercise_picker_screen.dart
@@ -26,14 +26,29 @@ enum ExerciseSource {
 }
 
 /// A screen for browsing and selecting exercises from the library or custom exercises.
-/// Returns the selected exercise data when the user taps "Add to Workout".
+///
+/// In single-select mode (default): tapping an exercise opens the detail bottom
+/// sheet and returns `Map<String, dynamic>` to the caller.
+///
+/// In multi-select mode (`isMultiSelect: true`): tapping an exercise toggles a
+/// checkbox. A bottom bar shows the selection count, a set count stepper, and
+/// an Add button that pops with `List<Map<String, dynamic>>`. The Add button is
+/// disabled until at least 2 exercises are selected.
 class ExercisePickerScreen extends StatefulWidget {
-  /// If true, show the "Create Custom" button for creating new exercises
+  /// If true, show the "Create Custom" button for creating new exercises (single-select only).
   final bool showCreateCustomButton;
+
+  /// When true, enables multi-select mode for superset creation.
+  final bool isMultiSelect;
+
+  /// Default set count used when adding exercises in multi-select mode.
+  final int initialSetCount;
 
   const ExercisePickerScreen({
     super.key,
     this.showCreateCustomButton = true,
+    this.isMultiSelect = false,
+    this.initialSetCount = 3,
   });
 
   @override
@@ -49,6 +64,16 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
   ExerciseType? _selectedExerciseType;
   ExerciseSource _selectedSource = ExerciseSource.all;
 
+  // Multi-select state
+  final Set<String> _selectedIds = {};
+  late int _multiSelectSetCount;
+
+  @override
+  void initState() {
+    super.initState();
+    _multiSelectSetCount = widget.initialSetCount;
+  }
+
   @override
   void dispose() {
     _searchController.dispose();
@@ -56,11 +81,51 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
     super.dispose();
   }
 
+  void _toggleSelection(String exerciseId) {
+    setState(() {
+      if (_selectedIds.contains(exerciseId)) {
+        _selectedIds.remove(exerciseId);
+      } else {
+        _selectedIds.add(exerciseId);
+      }
+    });
+  }
+
+  void _confirmMultiSelect(List<dynamic> allResults) {
+    final selected = allResults.where((e) {
+      final id = e is LibraryExercise ? e.id : (e as CustomExercise).id;
+      return _selectedIds.contains(id);
+    }).toList();
+
+    final result = selected.map((exercise) {
+      if (exercise is LibraryExercise) {
+        return {
+          'name': exercise.name,
+          'exerciseType': exercise.exerciseType,
+          'isLibrary': true,
+          'sourceId': exercise.id,
+          'setCount': _multiSelectSetCount,
+        };
+      } else {
+        final custom = exercise as CustomExercise;
+        return {
+          'name': custom.name,
+          'exerciseType': custom.exerciseType,
+          'isLibrary': false,
+          'sourceId': custom.id,
+          'setCount': _multiSelectSetCount,
+        };
+      }
+    }).toList();
+
+    Navigator.of(context).pop(result);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Exercise Library'),
+        title: Text(widget.isMultiSelect ? 'Select Exercises' : 'Exercise Library'),
         elevation: 0,
       ),
       body: Consumer<ExerciseLibraryProvider>(
@@ -126,6 +191,8 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
                 .where((e) => e is CustomExercise)
                 .toList();
           }
+
+          final canAdd = _selectedIds.length >= 2;
 
           return Column(
             children: [
@@ -198,22 +265,48 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
                 child: searchResults.isEmpty
                     ? _buildEmptyState()
                     : ListView.builder(
-                        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                        padding: EdgeInsets.only(
+                          left: 16.0,
+                          right: 16.0,
+                          bottom: widget.isMultiSelect ? 80 : 0,
+                        ),
                         itemCount: searchResults.length,
                         itemBuilder: (context, index) {
                           final exercise = searchResults[index];
+                          final exerciseId = exercise is LibraryExercise
+                              ? exercise.id
+                              : (exercise as CustomExercise).id;
                           return _ExerciseListTile(
                             exercise: exercise,
-                            onTap: () => _showExerciseDetails(context, exercise),
+                            isMultiSelect: widget.isMultiSelect,
+                            isSelected: _selectedIds.contains(exerciseId),
+                            onTap: widget.isMultiSelect
+                                ? () => _toggleSelection(exerciseId)
+                                : () => _showExerciseDetails(context, exercise),
                           );
                         },
                       ),
               ),
+
+              // Multi-select bottom bar
+              if (widget.isMultiSelect)
+                _MultiSelectBottomBar(
+                  selectedCount: _selectedIds.length,
+                  setCount: _multiSelectSetCount,
+                  canAdd: canAdd,
+                  onDecrement: _multiSelectSetCount > 1
+                      ? () => setState(() => _multiSelectSetCount--)
+                      : null,
+                  onIncrement: _multiSelectSetCount < 10
+                      ? () => setState(() => _multiSelectSetCount++)
+                      : null,
+                  onAdd: canAdd ? () => _confirmMultiSelect(searchResults) : null,
+                ),
             ],
           );
         },
       ),
-      floatingActionButton: widget.showCreateCustomButton
+      floatingActionButton: widget.showCreateCustomButton && !widget.isMultiSelect
           ? FloatingActionButton.extended(
               onPressed: () => _navigateToCreateCustom(context),
               icon: const Icon(Icons.add),
@@ -399,10 +492,14 @@ class _ExercisePickerScreenState extends State<ExercisePickerScreen> {
 class _ExerciseListTile extends StatelessWidget {
   final dynamic exercise;
   final VoidCallback onTap;
+  final bool isMultiSelect;
+  final bool isSelected;
 
   const _ExerciseListTile({
     required this.exercise,
     required this.onTap,
+    this.isMultiSelect = false,
+    this.isSelected = false,
   });
 
   @override
@@ -420,19 +517,27 @@ class _ExerciseListTile extends StatelessWidget {
 
     return Card(
       margin: const EdgeInsets.only(bottom: 8),
+      color: isMultiSelect && isSelected
+          ? Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3)
+          : null,
       child: ListTile(
         onTap: onTap,
-        leading: CircleAvatar(
-          backgroundColor: isLibrary
-              ? Theme.of(context).colorScheme.primaryContainer
-              : Theme.of(context).colorScheme.tertiaryContainer,
-          child: Icon(
-            Icons.fitness_center,
-            color: isLibrary
-                ? Theme.of(context).colorScheme.onPrimaryContainer
-                : Theme.of(context).colorScheme.onTertiaryContainer,
-          ),
-        ),
+        leading: isMultiSelect
+            ? Checkbox(
+                value: isSelected,
+                onChanged: (_) => onTap(),
+              )
+            : CircleAvatar(
+                backgroundColor: isLibrary
+                    ? Theme.of(context).colorScheme.primaryContainer
+                    : Theme.of(context).colorScheme.tertiaryContainer,
+                child: Icon(
+                  Icons.fitness_center,
+                  color: isLibrary
+                      ? Theme.of(context).colorScheme.onPrimaryContainer
+                      : Theme.of(context).colorScheme.onTertiaryContainer,
+                ),
+              ),
         title: Text(
           name,
           maxLines: 1,
@@ -447,22 +552,112 @@ class _ExerciseListTile extends StatelessWidget {
                     Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
               ),
         ),
-        trailing: isLibrary
+        trailing: isMultiSelect
             ? null
-            : Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.tertiaryContainer,
-                  borderRadius: BorderRadius.circular(8),
+            : isLibrary
+                ? null
+                : Container(
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.tertiaryContainer,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Text(
+                      'Custom',
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onTertiaryContainer,
+                          ),
+                    ),
+                  ),
+      ),
+    );
+  }
+}
+
+/// Bottom bar shown in multi-select mode with count, set stepper, and Add button.
+class _MultiSelectBottomBar extends StatelessWidget {
+  final int selectedCount;
+  final int setCount;
+  final bool canAdd;
+  final VoidCallback? onDecrement;
+  final VoidCallback? onIncrement;
+  final VoidCallback? onAdd;
+
+  const _MultiSelectBottomBar({
+    required this.selectedCount,
+    required this.setCount,
+    required this.canAdd,
+    required this.onDecrement,
+    required this.onIncrement,
+    required this.onAdd,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surface,
+        border: Border(
+          top: BorderSide(
+            color: theme.colorScheme.outlineVariant,
+          ),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            // Set count stepper
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                IconButton(
+                  onPressed: onDecrement,
+                  icon: const Icon(Icons.remove_circle_outline),
+                  color: theme.colorScheme.primary,
+                ),
+                Text(
+                  '$setCount',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                IconButton(
+                  onPressed: onIncrement,
+                  icon: const Icon(Icons.add_circle_outline),
+                  color: theme.colorScheme.primary,
+                ),
+                Text(
+                  'sets each',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+                ),
+              ],
+            ),
+
+            const Spacer(),
+
+            // Add button
+            Tooltip(
+              message: canAdd ? '' : 'Select at least 2 exercises',
+              child: ElevatedButton(
+                onPressed: onAdd,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: theme.colorScheme.primary,
+                  foregroundColor: theme.colorScheme.onPrimary,
                 ),
                 child: Text(
-                  'Custom',
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color:
-                            Theme.of(context).colorScheme.onTertiaryContainer,
-                      ),
+                  'Add $selectedCount exercise${selectedCount == 1 ? '' : 's'}',
                 ),
               ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/fittrack/test/screens/exercises/exercise_picker_screen_test.dart
+++ b/fittrack/test/screens/exercises/exercise_picker_screen_test.dart
@@ -357,4 +357,136 @@ void main() {
       expect(find.text('Number of Sets'), findsOneWidget);
     });
   });
+
+  group('ExercisePickerScreen — multi-select mode', () {
+    late List<LibraryExercise> twoExercises;
+
+    setUp(() {
+      twoExercises = const [
+        LibraryExercise(
+          id: 'lib_bench',
+          name: 'Bench Press',
+          exerciseType: ExerciseType.strength,
+          primaryMuscles: [MuscleGroup.chest],
+        ),
+        LibraryExercise(
+          id: 'lib_squat',
+          name: 'Squat',
+          exerciseType: ExerciseType.strength,
+          primaryMuscles: [MuscleGroup.legs],
+        ),
+      ];
+    });
+
+    Widget createMultiSelectWidget({int initialSetCount = 3}) {
+      return MaterialApp(
+        home: ChangeNotifierProvider<ExerciseLibraryProvider>.value(
+          value: mockProvider,
+          child: ExercisePickerScreen(
+            isMultiSelect: true,
+            initialSetCount: initialSetCount,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('shows "Select Exercises" as title in multi-select mode',
+        (tester) async {
+      /// Test Purpose: Verify AppBar title changes in multi-select mode
+      mockProvider.setLibraryExercises([]);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select Exercises'), findsOneWidget);
+    });
+
+    testWidgets('shows checkboxes instead of avatars in multi-select mode',
+        (tester) async {
+      /// Test Purpose: Verify list tiles show checkboxes in multi-select mode
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(Checkbox), findsNWidgets(2));
+    });
+
+    testWidgets('shows bottom bar in multi-select mode', (tester) async {
+      /// Test Purpose: Verify the multi-select bottom bar is rendered
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.text('sets each'), findsOneWidget);
+    });
+
+    testWidgets('Add button is disabled with fewer than 2 exercises selected',
+        (tester) async {
+      /// Test Purpose: Verify Add button disabled until 2+ exercises selected
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      // Initially 0 selected — button shows "Add 0 exercises"
+      final addButton = find.widgetWithText(ElevatedButton, 'Add 0 exercises');
+      expect(addButton, findsOneWidget);
+
+      // The button should be disabled (no onPressed)
+      final button = tester.widget<ElevatedButton>(addButton);
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('selecting 1 exercise keeps Add button disabled', (tester) async {
+      /// Test Purpose: Verify 1 selection is insufficient to enable Add
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      // Select first exercise
+      await tester.tap(find.text('Bench Press'));
+      await tester.pumpAndSettle();
+
+      final addButton = find.widgetWithText(ElevatedButton, 'Add 1 exercise');
+      expect(addButton, findsOneWidget);
+
+      final button = tester.widget<ElevatedButton>(addButton);
+      expect(button.onPressed, isNull);
+    });
+
+    testWidgets('selecting 2 exercises enables Add button', (tester) async {
+      /// Test Purpose: Verify 2+ selections enable the Add button
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      // Select both exercises
+      await tester.tap(find.text('Bench Press'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Squat'));
+      await tester.pumpAndSettle();
+
+      final addButton = find.widgetWithText(ElevatedButton, 'Add 2 exercises');
+      expect(addButton, findsOneWidget);
+
+      final button = tester.widget<ElevatedButton>(addButton);
+      expect(button.onPressed, isNotNull);
+    });
+
+    testWidgets('does not open bottom sheet when tapping in multi-select mode',
+        (tester) async {
+      /// Test Purpose: Verify tap toggles selection instead of opening detail sheet
+      mockProvider.setLibraryExercises(twoExercises);
+      await tester.pumpWidget(createMultiSelectWidget());
+      await tester.pumpAndSettle();
+
+      // Tap an exercise — should toggle checkbox, not open bottom sheet
+      await tester.tap(find.text('Bench Press'));
+      await tester.pumpAndSettle();
+
+      // No bottom sheet content (like "Number of Sets" from single-select sheet)
+      expect(find.text('Number of Sets'), findsNothing);
+      // Checkbox should be checked
+      final checkboxes = tester.widgetList<Checkbox>(find.byType(Checkbox));
+      expect(checkboxes.any((c) => c.value == true), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Adds `isMultiSelect: bool` and `initialSetCount: int` params to `ExercisePickerScreen`
- Multi-select mode: checkboxes on tiles, tapping toggles selection, no bottom sheet
- Bottom bar: selection count, set count stepper (1–10), Add button (disabled until ≥ 2 selected)
- Pops with `List<Map<String, dynamic>>` — one entry per selected exercise
- Single-select mode unchanged
- FAB hidden in multi-select mode

## Test plan

- [ ] "Select Exercises" title in multi-select mode
- [ ] Checkboxes visible for each exercise
- [ ] Bottom bar with "sets each" label visible
- [ ] Add button disabled with 0 and 1 selections
- [ ] Add button enabled with 2+ selections
- [ ] Tapping exercise toggles checkbox (no bottom sheet opens)

Closes #393
Part of #261