### PR TITLE
[Task] #397 Add supersetGroupId to TemplateExercise model

### DIFF
--- a/fittrack/lib/models/templates/template_exercise.dart
+++ b/fittrack/lib/models/templates/template_exercise.dart
@@ -10,12 +10,17 @@ class TemplateExercise {
   final String? notes;
   final List<TemplateSet> sets;
 
+  /// Identifies exercises that belong to the same superset group.
+  /// Null means this is a standalone exercise.
+  final String? supersetGroupId;
+
   const TemplateExercise({
     required this.name,
     required this.exerciseType,
     required this.orderIndex,
     this.notes,
     required this.sets,
+    this.supersetGroupId,
   });
 
   /// Creates a TemplateExercise from a Map (JSON deserialization)
@@ -29,6 +34,7 @@ class TemplateExercise {
               ?.map((s) => TemplateSet.fromMap(s as Map<String, dynamic>))
               .toList() ??
           [],
+      supersetGroupId: map['supersetGroupId'] as String?,
     );
   }
 
@@ -48,6 +54,7 @@ class TemplateExercise {
       'orderIndex': orderIndex,
       if (notes != null) 'notes': notes,
       'sets': sets.map((s) => s.toMap()).toList(),
+      if (supersetGroupId != null) 'supersetGroupId': supersetGroupId,
     };
   }
 
@@ -58,6 +65,8 @@ class TemplateExercise {
     int? orderIndex,
     String? notes,
     List<TemplateSet>? sets,
+    String? supersetGroupId,
+    bool clearSupersetGroupId = false,
   }) {
     return TemplateExercise(
       name: name ?? this.name,
@@ -65,6 +74,9 @@ class TemplateExercise {
       orderIndex: orderIndex ?? this.orderIndex,
       notes: notes ?? this.notes,
       sets: sets ?? this.sets,
+      supersetGroupId: clearSupersetGroupId
+          ? null
+          : (supersetGroupId ?? this.supersetGroupId),
     );
   }
 
@@ -82,6 +94,7 @@ class TemplateExercise {
         other.exerciseType != exerciseType ||
         other.orderIndex != orderIndex ||
         other.notes != notes ||
+        other.supersetGroupId != supersetGroupId ||
         other.sets.length != sets.length) {
       return false;
     }
@@ -98,6 +111,7 @@ class TemplateExercise {
       exerciseType,
       orderIndex,
       notes,
+      supersetGroupId,
       Object.hashAll(sets),
     );
   }

--- a/fittrack/lib/screens/programs/program_detail_screen.dart
+++ b/fittrack/lib/screens/programs/program_detail_screen.dart
@@ -400,6 +400,7 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
               exerciseType: exercise.exerciseType,
               orderIndex: exercise.orderIndex,
               notes: exercise.notes,
+              supersetGroupId: exercise.supersetGroupId,
               sets: sets.map((set) => TemplateSet(
                 setNumber: set.setNumber,
                 reps: set.reps,

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -575,6 +575,7 @@ class _WeeksScreenState extends State<WeeksScreen> {
             exerciseType: exercise.exerciseType,
             orderIndex: exercise.orderIndex,
             notes: exercise.notes,
+            supersetGroupId: exercise.supersetGroupId,
             sets: sets.map((set) => TemplateSet(
               setNumber: set.setNumber,
               reps: set.reps,

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -600,6 +600,7 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
         exerciseType: exercise.exerciseType,
         orderIndex: exercise.orderIndex,
         notes: exercise.notes,
+        supersetGroupId: exercise.supersetGroupId,
         sets: sets.map((set) => TemplateSet(
           setNumber: set.setNumber,
           reps: set.reps,

--- a/fittrack/test/models/templates/template_exercise_test.dart
+++ b/fittrack/test/models/templates/template_exercise_test.dart
@@ -98,6 +98,33 @@ void main() {
         expect(exercise.sets, isEmpty);
       });
 
+      test('should parse supersetGroupId when present', () {
+        final map = {
+          'name': 'Squat',
+          'exerciseType': 'strength',
+          'orderIndex': 0,
+          'sets': <Map<String, dynamic>>[],
+          'supersetGroupId': 'group-abc-123',
+        };
+
+        final exercise = TemplateExercise.fromMap(map);
+
+        expect(exercise.supersetGroupId, 'group-abc-123');
+      });
+
+      test('should parse supersetGroupId as null when absent', () {
+        final map = {
+          'name': 'Squat',
+          'exerciseType': 'strength',
+          'orderIndex': 0,
+          'sets': <Map<String, dynamic>>[],
+        };
+
+        final exercise = TemplateExercise.fromMap(map);
+
+        expect(exercise.supersetGroupId, isNull);
+      });
+
       test('should use defaults for missing required fields', () {
         final map = <String, dynamic>{};
 
@@ -160,6 +187,31 @@ void main() {
         expect(map.containsKey('notes'), isFalse);
       });
 
+      test('should include supersetGroupId when set', () {
+        final exercise = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'group-xyz',
+        );
+        final map = exercise.toMap();
+
+        expect(map['supersetGroupId'], 'group-xyz');
+      });
+
+      test('should omit supersetGroupId when null', () {
+        final exercise = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+        );
+        final map = exercise.toMap();
+
+        expect(map.containsKey('supersetGroupId'), isFalse);
+      });
+
       test('fromMap and toMap should be inverses', () {
         final map = sampleExercise.toMap();
         final recreated = TemplateExercise.fromMap(map);
@@ -217,6 +269,45 @@ void main() {
         expect(copy.orderIndex, sampleExercise.orderIndex);
         expect(copy.notes, sampleExercise.notes);
         expect(copy.sets, sampleExercise.sets);
+      });
+
+      test('should copy with new supersetGroupId', () {
+        final exercise = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'original-group',
+        );
+        final updated = exercise.copyWith(supersetGroupId: 'new-group');
+
+        expect(updated.supersetGroupId, 'new-group');
+      });
+
+      test('should preserve supersetGroupId when not specified', () {
+        final exercise = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'existing-group',
+        );
+        final copy = exercise.copyWith(name: 'Updated');
+
+        expect(copy.supersetGroupId, 'existing-group');
+      });
+
+      test('clearSupersetGroupId should set supersetGroupId to null', () {
+        final exercise = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'group-to-clear',
+        );
+        final cleared = exercise.copyWith(clearSupersetGroupId: true);
+
+        expect(cleared.supersetGroupId, isNull);
       });
     });
 
@@ -319,6 +410,61 @@ void main() {
           exerciseType: ExerciseType.strength,
           orderIndex: 0,
           sets: const [TemplateSet(setNumber: 1, reps: 12)],
+        );
+
+        expect(exercise1, isNot(exercise2));
+      });
+
+      test('should not be equal when supersetGroupId differs', () {
+        final exercise1 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'group-a',
+        );
+        final exercise2 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'group-b',
+        );
+
+        expect(exercise1, isNot(exercise2));
+      });
+
+      test('should be equal when both supersetGroupIds are null', () {
+        final exercise1 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+        );
+        final exercise2 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+        );
+
+        expect(exercise1, exercise2);
+        expect(exercise1.hashCode, exercise2.hashCode);
+      });
+
+      test('should not be equal when supersetGroupId is null vs non-null', () {
+        final exercise1 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
+          supersetGroupId: 'group-a',
+        );
+        final exercise2 = TemplateExercise(
+          name: 'Test',
+          exerciseType: ExerciseType.strength,
+          orderIndex: 0,
+          sets: const [],
         );
 
         expect(exercise1, isNot(exercise2));


### PR DESCRIPTION
## Summary
- Adds `supersetGroupId: String?` field to `TemplateExercise` model with full serialization, `copyWith` (including `clearSupersetGroupId`), equality, and hashCode support
- Updates `TemplateExercise(...)` constructor call sites in `program_detail_screen.dart`, `weeks_screen.dart`, and `consolidated_workout_screen.dart` to pass `supersetGroupId` from the source exercise
- Adds unit tests covering fromMap/toMap round-trip, copyWith preservation/override/clear, and equality comparisons for the new field

## Test plan
- [ ] Unit tests pass: `TemplateExercise` fromMap with supersetGroupId, toMap omits null, copyWith preserves/overrides/clears, equality with same/different/null supersetGroupId
- [ ] No regressions in existing TemplateExercise tests

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)