### PR TITLE
fix(e2e): resolve TextFormField timing race and cascade delete PERMISSION_DENIED (#419)

### DIFF
--- a/fittrack/integration_test/analytics_integration_test.dart
+++ b/fittrack/integration_test/analytics_integration_test.dart
@@ -343,22 +343,30 @@ void main() {
 // Helper methods for integration testing
 
 Future<void> _signInWithTestAccount(WidgetTester tester) async {
+  // Wait for the sign-in form to fully render before accessing fields.
+  // On slow emulators the "Sign In" button text becomes visible before the
+  // TextFormField widgets are laid out, causing finder.first to throw
+  // "Bad state: No element".
+  await tester.pumpAndSettle(const Duration(seconds: 2));
+  expect(find.byType(TextFormField), findsWidgets,
+      reason: 'Sign-in form must be visible before entering credentials');
+
   // Enter test email
   await tester.enterText(
-    find.byType(TextFormField).first, 
+    find.byType(TextFormField).first,
     'test@fittrack.com'
   );
-  
+
   // Enter test password
   await tester.enterText(
-    find.byType(TextFormField).last, 
+    find.byType(TextFormField).last,
     'testpassword123'
   );
-  
+
   // Tap sign in
   await tester.tap(find.text('Sign In'));
   await tester.pumpAndSettle();
-  
+
   // Wait for sign in to complete
   await tester.pump(const Duration(seconds: 3));
 }

--- a/fittrack/integration_test/firestore_cascade_delete_integration_test.dart
+++ b/fittrack/integration_test/firestore_cascade_delete_integration_test.dart
@@ -12,18 +12,11 @@
 library;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fittrack/services/firestore_service.dart';
 import 'package:fittrack/models/cascade_delete_counts.dart';
-
-/// Test configuration for Firebase emulators
-/// Must match the ports used in GitHub Actions workflow
-const String kAuthEmulatorHost = 'localhost';
-const int kAuthEmulatorPort = 9099;
-const String kFirestoreEmulatorHost = 'localhost';
-const int kFirestoreEmulatorPort = 8080;
+import 'firebase_emulator_setup.dart';
 
 void main() {
   group('Firestore Cascade Delete Count Integration Tests', () {
@@ -35,35 +28,10 @@ void main() {
     String? testExerciseId;
 
     setUpAll(() async {
-      // Initialize Flutter binding for Firebase
-      TestWidgetsFlutterBinding.ensureInitialized();
-
-      // Initialize Firebase for testing
-      try {
-        await Firebase.initializeApp(
-          options: const FirebaseOptions(
-            apiKey: 'test-api-key',
-            appId: 'test-app-id',
-            messagingSenderId: 'test-sender-id',
-            projectId: 'fitness-app-8505e',
-          ),
-        );
-      } catch (e) {
-        if (!e.toString().contains('duplicate-app')) {
-          rethrow;
-        }
-      }
-
-      // Configure emulators
-      try {
-        FirebaseAuth.instance.useAuthEmulator(kAuthEmulatorHost, kAuthEmulatorPort);
-        FirebaseFirestore.instance.useFirestoreEmulator(kFirestoreEmulatorHost, kFirestoreEmulatorPort);
-      } catch (e) {
-        // Already configured
-        print('Emulators already configured: $e');
-      }
-
-      print('✅ Firebase emulators configured for integration tests');
+      // Use the shared emulator setup helper to ensure Firebase is correctly
+      // initialised and emulators are reachable before each test suite,
+      // regardless of whether earlier suites already called Firebase.initializeApp.
+      await setupFirebaseEmulators();
     });
 
     setUp(() async {

--- a/fittrack/integration_test/workout_creation_integration_test.dart
+++ b/fittrack/integration_test/workout_creation_integration_test.dart
@@ -197,7 +197,11 @@ void main() {
           reason: 'Should show create workout title');
 
         // Step 8: Fill out workout form with all fields
-        
+        // Wait for form to fully render on slow emulators before accessing fields.
+        await tester.pumpAndSettle(const Duration(seconds: 2));
+        expect(find.byType(TextFormField), findsWidgets,
+            reason: 'Workout form must be rendered before entering data');
+
         // Fill workout name
         final nameField = find.widgetWithText(TextFormField, '').first;
         await tester.enterText(nameField, 'Upper Body Strength Training');
@@ -304,9 +308,11 @@ void main() {
         await tester.pumpAndSettle();
         
         await tester.tap(find.byType(FloatingActionButton));
-        await tester.pumpAndSettle();
+        await tester.pumpAndSettle(const Duration(seconds: 2));
 
         // Fill only the required name field
+        expect(find.byType(TextFormField), findsWidgets,
+            reason: 'Workout form must be rendered before entering data');
         final nameField = find.widgetWithText(TextFormField, '').first;
         await tester.enterText(nameField, 'Quick Workout');
 
@@ -387,6 +393,9 @@ void main() {
           reason: 'Should remain on create workout screen when validation fails');
 
         // Test name too long validation
+        await tester.pumpAndSettle(const Duration(seconds: 2));
+        expect(find.byType(TextFormField), findsWidgets,
+            reason: 'Workout form must be rendered before entering data');
         final nameField = find.widgetWithText(TextFormField, '').first;
         final tooLongName = 'A' * 201; // Exceeds 200 character limit
         await tester.enterText(nameField, tooLongName);
@@ -434,9 +443,11 @@ void main() {
           
           // Tap FAB to create workout
           await tester.tap(find.byType(FloatingActionButton));
-          await tester.pumpAndSettle();
+          await tester.pumpAndSettle(const Duration(seconds: 2));
 
           // Fill workout name
+          expect(find.byType(TextFormField), findsWidgets,
+              reason: 'Workout form must be rendered before entering data');
           final nameField = find.widgetWithText(TextFormField, '').first;
           await tester.enterText(nameField, workoutNames[i]);
 
@@ -493,9 +504,11 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.tap(find.byType(FloatingActionButton));
-        await tester.pumpAndSettle();
+        await tester.pumpAndSettle(const Duration(seconds: 2));
 
         const persistentWorkoutName = 'Persistent Test Workout';
+        expect(find.byType(TextFormField), findsWidgets,
+            reason: 'Workout form must be rendered before entering data');
         final nameField = find.widgetWithText(TextFormField, '').first;
         await tester.enterText(nameField, persistentWorkoutName);
 
@@ -587,9 +600,11 @@ void main() {
         await tester.pumpAndSettle();
 
         await tester.tap(find.byType(FloatingActionButton));
-        await tester.pumpAndSettle();
+        await tester.pumpAndSettle(const Duration(seconds: 2));
 
         const secondUserWorkout = 'Second User Workout';
+        expect(find.byType(TextFormField), findsWidgets,
+            reason: 'Workout form must be rendered before entering data');
         final nameField = find.widgetWithText(TextFormField, '').first;
         await tester.enterText(nameField, secondUserWorkout);
 


### PR DESCRIPTION
## Summary

- **TextFormField timing race** (analytics + workout creation): On slow emulators the Sign In button and screen titles render before `TextFormField` widgets are laid out. Calling `finder.first` on an empty result throws `Bad state: No element`. Fixed by adding `pumpAndSettle(2s)` + `expect(findsWidgets)` guard before every bare `.first`/`.last` TextFormField access in `_signInWithTestAccount()` and all workout form entry points.
- **Cascade delete PERMISSION_DENIED**: `firestore_cascade_delete_integration_test.dart` rolled its own Firebase init, silently swallowing `useFirestoreEmulator()` calls when a previous suite already initialised Firebase. Firestore then connected to the real endpoint and rejected emulator-issued auth tokens. Fixed by replacing the ad-hoc `setUpAll` with `setupFirebaseEmulators()` from the shared helper.

Fixes #419

## Test plan
- [ ] E2E Tests (Android Emulator) passes — analytics, workout creation, and cascade delete suites all green
- [ ] No regressions in other E2E flows
- [ ] All other CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)