### PR TITLE
[Task #414] OnboardingCompletionScreen + ProInfoPlaceholderScreen

### DIFF
--- a/fittrack/lib/screens/onboarding/onboarding_completion_screen.dart
+++ b/fittrack/lib/screens/onboarding/onboarding_completion_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import '../home/home_screen.dart';
+import 'pro_info_placeholder_screen.dart';
+
+/// Shown after the user completes all 4 wizard steps.
+///
+/// The wizard (task #415) calls [OnboardingService.markComplete()] and then
+/// navigates here passing the created [programName].
+class OnboardingCompletionScreen extends StatelessWidget {
+  final String? programName;
+
+  const OnboardingCompletionScreen({super.key, this.programName});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.check_circle_outline,
+                  size: 80,
+                  color: colorScheme.primary,
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  "You're all set!",
+                  style: textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  "Your program '${programName ?? 'your program'}' is ready. Time to log your first workout.",
+                  style: textTheme.bodyMedium?.copyWith(
+                    color: colorScheme.onSurface.withValues(alpha: 0.7),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 48),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton(
+                    onPressed: () {
+                      Navigator.of(context).pushAndRemoveUntil(
+                        MaterialPageRoute(builder: (_) => const HomeScreen()),
+                        (route) => false,
+                      );
+                    },
+                    child: const Text('Go to My Programs'),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const ProInfoPlaceholderScreen(),
+                      ),
+                    );
+                  },
+                  child: Text(
+                    'Explore FitTrack Pro →',
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fittrack/lib/screens/onboarding/pro_info_placeholder_screen.dart
+++ b/fittrack/lib/screens/onboarding/pro_info_placeholder_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder destination for the "Explore FitTrack Pro →" link on the
+/// completion screen. Will be replaced when the monetization/paywall
+/// feature is implemented.
+class ProInfoPlaceholderScreen extends StatelessWidget {
+  const ProInfoPlaceholderScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('FitTrack Pro'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 32),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.lock_outline,
+                size: 64,
+                color: colorScheme.onSurface.withValues(alpha: 0.4),
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Coming Soon',
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'FitTrack Pro will unlock unlimited programs, full analytics history, and more.',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurface.withValues(alpha: 0.6),
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/fittrack/test/screens/onboarding/onboarding_completion_screen_test.dart
+++ b/fittrack/test/screens/onboarding/onboarding_completion_screen_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/screens/onboarding/onboarding_completion_screen.dart';
+import 'package:fittrack/screens/onboarding/pro_info_placeholder_screen.dart';
+
+/// Widget tests for OnboardingCompletionScreen and ProInfoPlaceholderScreen.
+///
+/// Test Coverage:
+/// - Completion screen renders program name
+/// - Completion screen renders heading
+/// - "Go to My Programs" button present
+/// - Pro text link present and uses subdued styling (TextButton, not ElevatedButton)
+/// - Null programName falls back to 'your program'
+/// - Pro link navigates to ProInfoPlaceholderScreen
+///
+/// No Firebase or OnboardingService dependency — screens are purely presentational.
+void main() {
+  Widget buildCompletion({String? programName}) {
+    return MaterialApp(
+      home: OnboardingCompletionScreen(programName: programName),
+    );
+  }
+
+  group('OnboardingCompletionScreen', () {
+    testWidgets('renders heading "You\'re all set!"', (WidgetTester tester) async {
+      /// Test Purpose: Verify celebration heading is displayed
+      /// Failure indicates heading text missing or changed
+
+      await tester.pumpWidget(buildCompletion(programName: 'Push Pull Legs'));
+      await tester.pump();
+
+      expect(find.text("You're all set!"), findsOneWidget,
+          reason: 'Heading should read "You\'re all set!"');
+    });
+
+    testWidgets('renders program name in body text', (WidgetTester tester) async {
+      /// Test Purpose: Verify program name is injected into body copy
+      /// Failure indicates programName parameter not used in display
+
+      await tester.pumpWidget(buildCompletion(programName: 'Push Pull Legs'));
+      await tester.pump();
+
+      expect(find.textContaining('Push Pull Legs'), findsOneWidget,
+          reason: 'Body text should contain the program name');
+    });
+
+    testWidgets('falls back to "your program" when programName is null', (WidgetTester tester) async {
+      /// Test Purpose: Verify null safety for programName parameter
+      /// Failure indicates missing null guard
+
+      await tester.pumpWidget(buildCompletion());
+      await tester.pump();
+
+      expect(find.textContaining('your program'), findsOneWidget,
+          reason: 'Should display fallback text when programName is null');
+    });
+
+    testWidgets('"Go to My Programs" ElevatedButton is present', (WidgetTester tester) async {
+      /// Test Purpose: Verify primary CTA is present
+      /// Failure indicates primary navigation button missing
+
+      await tester.pumpWidget(buildCompletion(programName: 'Test'));
+      await tester.pump();
+
+      expect(find.widgetWithText(ElevatedButton, 'Go to My Programs'), findsOneWidget,
+          reason: '"Go to My Programs" ElevatedButton should be present');
+    });
+
+    testWidgets('Pro link uses TextButton (not ElevatedButton or FilledButton)', (WidgetTester tester) async {
+      /// Test Purpose: Verify Pro link is styled as subdued footnote, not a primary action
+      /// Failure indicates incorrect button type — Pro link must look like a footnote
+
+      await tester.pumpWidget(buildCompletion(programName: 'Test'));
+      await tester.pump();
+
+      expect(find.widgetWithText(TextButton, 'Explore FitTrack Pro →'), findsOneWidget,
+          reason: 'Pro link must be a TextButton, not ElevatedButton or FilledButton');
+      expect(find.widgetWithText(ElevatedButton, 'Explore FitTrack Pro →'), findsNothing,
+          reason: 'Pro link must NOT be an ElevatedButton');
+    });
+
+    testWidgets('tapping Pro link navigates to ProInfoPlaceholderScreen', (WidgetTester tester) async {
+      /// Test Purpose: Verify Pro link destination
+      /// Failure indicates navigation wired to wrong screen
+
+      await tester.pumpWidget(buildCompletion(programName: 'Test'));
+      await tester.pump();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Explore FitTrack Pro →'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ProInfoPlaceholderScreen), findsOneWidget,
+          reason: 'Pro link should navigate to ProInfoPlaceholderScreen');
+    });
+
+    testWidgets('check circle icon is displayed', (WidgetTester tester) async {
+      /// Test Purpose: Verify celebration icon renders
+      /// Failure indicates icon widget missing
+
+      await tester.pumpWidget(buildCompletion(programName: 'Test'));
+      await tester.pump();
+
+      expect(find.byIcon(Icons.check_circle_outline), findsOneWidget,
+          reason: 'Check circle icon should be displayed');
+    });
+  });
+
+  group('ProInfoPlaceholderScreen', () {
+    testWidgets('renders AppBar with FitTrack Pro title', (WidgetTester tester) async {
+      /// Test Purpose: Verify placeholder screen has correct title
+      /// Failure indicates title missing or incorrect
+
+      await tester.pumpWidget(
+        const MaterialApp(home: ProInfoPlaceholderScreen()),
+      );
+      await tester.pump();
+
+      expect(find.text('FitTrack Pro'), findsOneWidget,
+          reason: 'AppBar should display "FitTrack Pro"');
+    });
+
+    testWidgets('renders coming soon message', (WidgetTester tester) async {
+      /// Test Purpose: Verify placeholder content is displayed
+      /// Failure indicates body text missing
+
+      await tester.pumpWidget(
+        const MaterialApp(home: ProInfoPlaceholderScreen()),
+      );
+      await tester.pump();
+
+      expect(find.textContaining('Coming Soon'), findsOneWidget,
+          reason: 'Should display "Coming Soon" text');
+      expect(find.textContaining('unlimited programs'), findsOneWidget,
+          reason: 'Should describe Pro features');
+    });
+
+    testWidgets('renders lock icon', (WidgetTester tester) async {
+      /// Test Purpose: Verify lock icon renders on placeholder screen
+      /// Failure indicates icon widget missing
+
+      await tester.pumpWidget(
+        const MaterialApp(home: ProInfoPlaceholderScreen()),
+      );
+      await tester.pump();
+
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget,
+          reason: 'Lock icon should be displayed');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `OnboardingCompletionScreen`: shown after wizard completes; displays success icon, "You're all set!" heading, program name, Go to My Programs button, and subtle Pro link
- `ProInfoPlaceholderScreen`: simple placeholder for future Pro feature info
- Widget tests covering: heading, programName display, null fallback, button types, Pro link navigation

## Changes
- `lib/screens/onboarding/onboarding_completion_screen.dart` — completion screen
- `lib/screens/onboarding/pro_info_placeholder_screen.dart` — Pro placeholder
- `test/screens/onboarding/onboarding_completion_screen_test.dart` — widget tests

## Test plan
- [ ] Widget tests pass via CI
- [ ] Go to My Programs clears stack and shows HomeScreen
- [ ] Pro link navigates to ProInfoPlaceholderScreen
- [ ] programName shown; null falls back to "your program"

Closes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)