### PR TITLE
fix(onboarding): mark complete after program saved to prevent carousel re-show on relaunch

### DIFF
--- a/fittrack/lib/screens/onboarding/onboarding_wizard_screen.dart
+++ b/fittrack/lib/screens/onboarding/onboarding_wizard_screen.dart
@@ -134,6 +134,12 @@ class _OnboardingWizardScreenState extends State<OnboardingWizardScreen> {
       return;
     }
 
+    // Mark onboarding complete as soon as a program exists. If the app is
+    // force-closed after this point, AuthWrapper will route to HomeScreen
+    // instead of re-showing the carousel (fixes bug #427).
+    await OnboardingService.instance.markComplete();
+    if (!mounted) return;
+
     setState(() {
       _programId = programId;
       _programName = _programNameController.text.trim();


### PR DESCRIPTION
## Summary

- Fixes bug #427: force-closing the app after Step 0 of the onboarding wizard (program created) but before Skip/Finish caused the carousel to re-appear on relaunch
- Calls `OnboardingService.instance.markComplete()` immediately after `_saveProgram()` succeeds — the onboarding goal is achieved once a program exists in Firestore
- Existing `markComplete()` calls in `_onSkip()` and `_saveExerciseAndFinish()` are unchanged (calling it twice is harmless — it's idempotent)

## Test plan

- [ ] CI passes (all existing tests unaffected — no logic change to normal skip/finish flows)
- [ ] Manual verify: complete Step 0, force-close, relaunch → routes to HomeScreen/Programs (not carousel)
- [ ] Manual verify: skip at any step still routes to HomeScreen
- [ ] Manual verify: finish all 4 steps still routes to CompletionScreen

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)