### PR TITLE
[Task] App rename: FitTrack to Overload (#446)

### DIFF
--- a/fittrack/android/app/src/main/AndroidManifest.xml
+++ b/fittrack/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     
     <application
-        android:label="fittrack"
+        android:label="Overload"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:networkSecurityConfig="@xml/network_security_config">

--- a/fittrack/integration_test/analytics_integration_test.dart
+++ b/fittrack/integration_test/analytics_integration_test.dart
@@ -96,8 +96,8 @@ void main() {
       print('DEBUG: SharedPreferences initialized');
 
       // Launch the app
-      print('DEBUG: Pumping FitTrackApp widget...');
-      await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+      print('DEBUG: Pumping OverloadApp widget...');
+      await tester.pumpWidget(app.OverloadApp(prefs: prefs));
       print('DEBUG: Widget pumped, waiting for AuthProvider to check auth state...');
 
       // CRITICAL: Wait for AuthProvider's async auth state listener to fire
@@ -172,8 +172,8 @@ void main() {
       // final prefs = await SharedPreferences.getInstance();
       // print('DEBUG: SharedPreferences initialized');
 
-      // print('DEBUG: Pumping FitTrackApp widget...');
-      // await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+      // print('DEBUG: Pumping OverloadApp widget...');
+      // await tester.pumpWidget(app.OverloadApp(prefs: prefs));
       // print('DEBUG: Widget pumped, waiting for AuthProvider to check auth state...');
 
       // // CRITICAL: Wait for AuthProvider's async auth state listener to fire
@@ -214,8 +214,8 @@ void main() {
       print('DEBUG: SharedPreferences initialized');
 
       // Launch the app
-      print('DEBUG: Pumping FitTrackApp widget...');
-      await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+      print('DEBUG: Pumping OverloadApp widget...');
+      await tester.pumpWidget(app.OverloadApp(prefs: prefs));
       print('DEBUG: Widget pumped, waiting for AuthProvider to check auth state...');
 
       // CRITICAL: Wait for AuthProvider's async auth state listener to fire
@@ -266,8 +266,8 @@ void main() {
       print('DEBUG: SharedPreferences initialized');
 
       // Launch the app
-      print('DEBUG: Pumping FitTrackApp widget...');
-      await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+      print('DEBUG: Pumping OverloadApp widget...');
+      await tester.pumpWidget(app.OverloadApp(prefs: prefs));
       print('DEBUG: Widget pumped, waiting for AuthProvider to check auth state...');
 
       // CRITICAL: Wait for AuthProvider's async auth state listener to fire
@@ -307,8 +307,8 @@ void main() {
       print('DEBUG: SharedPreferences initialized');
 
       // Launch the app
-      print('DEBUG: Pumping FitTrackApp widget...');
-      await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+      print('DEBUG: Pumping OverloadApp widget...');
+      await tester.pumpWidget(app.OverloadApp(prefs: prefs));
       print('DEBUG: Widget pumped, waiting for AuthProvider to check auth state...');
 
       // CRITICAL: Wait for AuthProvider's async auth state listener to fire

--- a/fittrack/integration_test/enhanced_complete_workflow_test.dart
+++ b/fittrack/integration_test/enhanced_complete_workflow_test.dart
@@ -34,7 +34,7 @@ import 'firebase_emulator_setup.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
   
-  group('FitTrack Complete Workflow Integration Tests', () {
+  group('Overload Complete Workflow Integration Tests', () {
     late String testUserId;
     late String testEmail;
     late String testPassword;
@@ -133,7 +133,7 @@ void main() {
           SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
           final prefs = await SharedPreferences.getInstance();
 
-          await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+          await tester.pumpWidget(app.OverloadApp(prefs: prefs));
           await tester.pump(const Duration(milliseconds: 500));
           await tester.pumpAndSettle();
 
@@ -283,7 +283,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -368,7 +368,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -408,7 +408,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -445,7 +445,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -522,7 +522,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -570,7 +570,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -604,7 +604,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -642,7 +642,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -686,7 +686,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -735,7 +735,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await tester.pump(const Duration(milliseconds: 500));
         await tester.pumpAndSettle();
 
@@ -777,7 +777,7 @@ void main() {
         // request succeeds immediately.
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs2 = await SharedPreferences.getInstance();
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs2, key: UniqueKey()));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs2, key: UniqueKey()));
 
         // Poll for HomeScreen (BottomNavigationBar) — AuthProvider.authStateChanges()
         // fires async: user2 is signed in, but user.reload() + _safeNotify() take time.

--- a/fittrack/integration_test/workout_creation_integration_test.dart
+++ b/fittrack/integration_test/workout_creation_integration_test.dart
@@ -177,7 +177,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
         print('✅ App launched');
 
@@ -330,7 +330,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
 
         // Navigate through the app to create workout screen
@@ -407,7 +407,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
 
         await tester.tap(find.text('Integration Test Program'));
@@ -467,7 +467,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
 
         // Navigate to weeks screen
@@ -546,7 +546,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
 
         await tester.tap(find.text('Integration Test Program'));
@@ -586,7 +586,7 @@ void main() {
         // Reuse prefs variable from earlier in test scope
         await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs, key: UniqueKey()));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs, key: UniqueKey()));
         await _ensureOnProgramsScreen(tester);
 
         // Navigate back to the weeks screen
@@ -669,7 +669,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(
           tester,
           email: 'second-user@example.com',
@@ -724,7 +724,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs2 = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs2, key: UniqueKey()));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs2, key: UniqueKey()));
         await _ensureOnProgramsScreen(tester);
 
         // Navigate to first user's workouts
@@ -755,7 +755,7 @@ void main() {
         SharedPreferences.setMockInitialValues({'fittrack_onboarding_complete': true});
         final prefs = await SharedPreferences.getInstance();
 
-        await tester.pumpWidget(app.FitTrackApp(prefs: prefs));
+        await tester.pumpWidget(app.OverloadApp(prefs: prefs));
         await _ensureOnProgramsScreen(tester);
 
         // Navigate to weeks screen

--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -79,19 +79,19 @@ void main() async {
   OnboardingService.initialize(prefs);
 
   runZonedGuarded(
-    () => runApp(FitTrackApp(prefs: prefs)),
+    () => runApp(OverloadApp(prefs: prefs)),
     (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack, fatal: true),
   );
 }
 
-class FitTrackApp extends StatelessWidget {
+class OverloadApp extends StatelessWidget {
   final SharedPreferences prefs;
 
-  const FitTrackApp({super.key, required this.prefs});
+  const OverloadApp({super.key, required this.prefs});
 
   @override
   Widget build(BuildContext context) {
-    // Initialize OnboardingService here so E2E tests that pump FitTrackApp
+    // Initialize OnboardingService here so E2E tests that pump OverloadApp
     // directly (bypassing main()) still get proper initialization.
     OnboardingService.initialize(prefs);
 
@@ -146,7 +146,7 @@ class FitTrackApp extends StatelessWidget {
       child: Consumer<ThemeProvider>(
         builder: (context, themeProvider, child) {
           return MaterialApp(
-            title: 'FitTrack',
+            title: 'Overload',
             debugShowCheckedModeBanner: false,
             themeMode: themeProvider.currentThemeMode,
             theme: ThemeData(

--- a/fittrack/lib/screens/auth/sign_in_screen.dart
+++ b/fittrack/lib/screens/auth/sign_in_screen.dart
@@ -44,7 +44,7 @@ class _SignInScreenState extends State<SignInScreen> {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  'FitTrack',
+                  'Overload',
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                     fontWeight: FontWeight.bold,
@@ -53,7 +53,7 @@ class _SignInScreenState extends State<SignInScreen> {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Track your fitness journey',
+                  'Structured Strength Tracker',
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),

--- a/fittrack/lib/screens/auth/sign_up_screen.dart
+++ b/fittrack/lib/screens/auth/sign_up_screen.dart
@@ -57,7 +57,7 @@ class _SignUpScreenState extends State<SignUpScreen> {
                 ),
                 const SizedBox(height: 8),
                 Text(
-                  'Join FitTrack to start your fitness journey',
+                  'Build structured programs. Track progressive overload.',
                   textAlign: TextAlign.center,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),

--- a/fittrack/lib/screens/onboarding/onboarding_completion_screen.dart
+++ b/fittrack/lib/screens/onboarding/onboarding_completion_screen.dart
@@ -82,7 +82,7 @@ class _OnboardingCompletionScreenState
                     );
                   },
                   child: Text(
-                    'Explore FitTrack Pro →',
+                    'Explore Overload Pro →',
                     style: textTheme.bodySmall?.copyWith(
                       color: colorScheme.onSurface.withValues(alpha: 0.5),
                     ),

--- a/fittrack/lib/screens/onboarding/pro_info_placeholder_screen.dart
+++ b/fittrack/lib/screens/onboarding/pro_info_placeholder_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-/// Placeholder destination for the "Explore FitTrack Pro →" link on the
+/// Placeholder destination for the "Explore Overload Pro →" link on the
 /// completion screen. Will be replaced when the monetization/paywall
 /// feature is implemented.
 class ProInfoPlaceholderScreen extends StatelessWidget {
@@ -13,7 +13,7 @@ class ProInfoPlaceholderScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('FitTrack Pro'),
+        title: const Text('Overload Pro'),
       ),
       body: Center(
         child: Padding(
@@ -36,7 +36,7 @@ class ProInfoPlaceholderScreen extends StatelessWidget {
               ),
               const SizedBox(height: 12),
               Text(
-                'FitTrack Pro will unlock unlimited programs, full analytics history, and more.',
+                'Overload Pro will unlock unlimited programs, full analytics history, and more.',
                 style: textTheme.bodyMedium?.copyWith(
                   color: colorScheme.onSurface.withValues(alpha: 0.6),
                 ),

--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -116,7 +116,7 @@ class ProfileScreen extends StatelessWidget {
               const SizedBox(height: 32),
               Center(
                 child: Text(
-                  'FitTrack v1.0.0',
+                  'Overload v1.6.0',
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
                   ),

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fittrack
-description: FitTrack - A comprehensive workout tracking app
+description: Overload - Structured Strength Tracker
 publish_to: 'none'
 version: 1.6.0+7
 

--- a/fittrack/test/screens/onboarding/onboarding_completion_screen_test.dart
+++ b/fittrack/test/screens/onboarding/onboarding_completion_screen_test.dart
@@ -73,9 +73,9 @@ void main() {
       await tester.pumpWidget(buildCompletion(programName: 'Test'));
       await tester.pump();
 
-      expect(find.widgetWithText(TextButton, 'Explore FitTrack Pro →'), findsOneWidget,
+      expect(find.widgetWithText(TextButton, 'Explore Overload Pro →'), findsOneWidget,
           reason: 'Pro link must be a TextButton, not ElevatedButton or FilledButton');
-      expect(find.widgetWithText(ElevatedButton, 'Explore FitTrack Pro →'), findsNothing,
+      expect(find.widgetWithText(ElevatedButton, 'Explore Overload Pro →'), findsNothing,
           reason: 'Pro link must NOT be an ElevatedButton');
     });
 
@@ -86,7 +86,7 @@ void main() {
       await tester.pumpWidget(buildCompletion(programName: 'Test'));
       await tester.pump();
 
-      await tester.tap(find.widgetWithText(TextButton, 'Explore FitTrack Pro →'));
+      await tester.tap(find.widgetWithText(TextButton, 'Explore Overload Pro →'));
       await tester.pumpAndSettle();
 
       expect(find.byType(ProInfoPlaceholderScreen), findsOneWidget,
@@ -106,7 +106,7 @@ void main() {
   });
 
   group('ProInfoPlaceholderScreen', () {
-    testWidgets('renders AppBar with FitTrack Pro title', (WidgetTester tester) async {
+    testWidgets('renders AppBar with Overload Pro title', (WidgetTester tester) async {
       /// Test Purpose: Verify placeholder screen has correct title
       /// Failure indicates title missing or incorrect
 
@@ -115,8 +115,8 @@ void main() {
       );
       await tester.pump();
 
-      expect(find.text('FitTrack Pro'), findsOneWidget,
-          reason: 'AppBar should display "FitTrack Pro"');
+      expect(find.text('Overload Pro'), findsOneWidget,
+          reason: 'AppBar should display "Overload Pro"');
     });
 
     testWidgets('renders coming soon message', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary

Renames the app from "FitTrack" to "Overload" across all platform config files and in-app UI strings.

## Changes

**Platform config:**
- `pubspec.yaml` — description updated to "Overload - Structured Strength Tracker"
- `android/AndroidManifest.xml` — `android:label` updated to "Overload"

**App UI strings:**
- `main.dart` — `MaterialApp` title and `OverloadApp` class rename
- `sign_in_screen.dart` — app name + subtitle updated to brand tagline
- `sign_up_screen.dart` — sub-heading updated with brand-aligned copy
- `profile_screen.dart` — footer version string updated
- `onboarding_completion_screen.dart` — Pro link text updated
- `pro_info_placeholder_screen.dart` — AppBar title and body copy updated

**Tests:**
- `onboarding_completion_screen_test.dart` — widget test assertions updated
- `analytics_integration_test.dart`, `enhanced_complete_workflow_test.dart`, `workout_creation_integration_test.dart` — `OverloadApp` class references updated

## Notes

- iOS `Info.plist` is not in the repository; the CFBundleDisplayName/CFBundleName update must be applied manually via Xcode before store submission.
- Firebase project display name update must be done via the Firebase console (not code).
- Dart package name (`fittrack`) is intentionally unchanged — renaming it would require updating all imports and is not needed for user-visible branding.

## Acceptance Criteria

- [x] Android home screen icon will display "Overload" after rebuild
- [x] No remaining "FitTrack" references in user-visible UI strings
- [x] App Store / Play Store submission name field matches new brand (pubspec.yaml description)
- [ ] iOS CFBundleDisplayName — manual Xcode update required (no iOS directory in repo)
- [ ] Firebase project display name — manual console update required

Closes #446
Part of #445