### PR TITLE
[Task] Implement smart in-app review prompt (#449)

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -18,6 +18,7 @@ import 'providers/exercise_library_provider.dart';
 import 'providers/template_provider.dart';
 import 'screens/auth/auth_wrapper.dart';
 import 'services/app_analytics_service.dart';
+import 'services/app_review_service.dart';
 import 'services/firestore_service.dart';
 import 'services/notification_service.dart';
 import 'services/onboarding_service.dart';
@@ -78,6 +79,9 @@ void main() async {
   // Initialize onboarding state service (must be before runApp)
   OnboardingService.initialize(prefs);
 
+  // Initialize review service — records first-launch date on first run
+  AppReviewService.initialize(prefs);
+
   runZonedGuarded(
     () => runApp(OverloadApp(prefs: prefs)),
     (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack, fatal: true),
@@ -91,9 +95,10 @@ class OverloadApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Initialize OnboardingService here so E2E tests that pump OverloadApp
+    // Initialize services here so E2E tests that pump OverloadApp
     // directly (bypassing main()) still get proper initialization.
     OnboardingService.initialize(prefs);
+    AppReviewService.initialize(prefs);
 
     return MultiProvider(
       providers: [

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -446,7 +446,7 @@ class _WeeksScreenState extends State<WeeksScreen> {
     );
     // User has returned from the workout screen — a good moment to prompt for
     // a review. The service checks eligibility and guards against repetition.
-    AppReviewService.instance.maybeRequestReview();
+    AppReviewService.tryMaybeRequestReview();
   }
 
   void _handleMenuAction(BuildContext context, String action) async {

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -7,6 +7,7 @@ import '../../models/week.dart';
 import '../../models/workout.dart';
 import '../../models/navigation_section.dart';
 import '../../models/templates/templates.dart';
+import '../../services/app_review_service.dart';
 import '../../services/firestore_service.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
@@ -433,8 +434,8 @@ class _WeeksScreenState extends State<WeeksScreen> {
     );
   }
 
-  void _navigateToWorkout(BuildContext context, Workout workout) {
-    Navigator.of(context).push(
+  Future<void> _navigateToWorkout(BuildContext context, Workout workout) async {
+    await Navigator.of(context).push(
       MaterialPageRoute(
         builder: (context) => ConsolidatedWorkoutScreen(
           program: widget.program,
@@ -443,6 +444,9 @@ class _WeeksScreenState extends State<WeeksScreen> {
         ),
       ),
     );
+    // User has returned from the workout screen — a good moment to prompt for
+    // a review. The service checks eligibility and guards against repetition.
+    AppReviewService.instance.maybeRequestReview();
   }
 
   void _handleMenuAction(BuildContext context, String action) async {

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/program_provider.dart';
 import '../../services/app_analytics_service.dart';
+import '../../services/app_review_service.dart';
 import '../../providers/template_provider.dart';
 import '../../models/program.dart';
 import '../../models/week.dart';
@@ -47,6 +48,7 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     AppAnalyticsService.instance.logWorkoutStarted();
+    AppReviewService.instance.recordWorkoutStarted();
     // Load exercises and all sets when screen opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadWorkoutData();

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -48,7 +48,7 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
     super.initState();
     WidgetsBinding.instance.addObserver(this);
     AppAnalyticsService.instance.logWorkoutStarted();
-    AppReviewService.instance.recordWorkoutStarted();
+    AppReviewService.tryRecordWorkoutStarted();
     // Load exercises and all sets when screen opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadWorkoutData();

--- a/fittrack/lib/services/app_analytics_service.dart
+++ b/fittrack/lib/services/app_analytics_service.dart
@@ -86,6 +86,11 @@ class AppAnalyticsService {
   Future<void> logSetCompleted() =>
       _log(() => _analytics.logEvent(name: 'set_completed'));
 
+  /// Fired when review prompt eligibility conditions are met and the native
+  /// review request is about to be triggered.
+  Future<void> logReviewPromptTriggered() =>
+      _log(() => _analytics.logEvent(name: 'review_prompt_triggered'));
+
   // ---------------------------------------------------------------------------
   // Internal helper
   // ---------------------------------------------------------------------------

--- a/fittrack/lib/services/app_review_service.dart
+++ b/fittrack/lib/services/app_review_service.dart
@@ -43,6 +43,18 @@ class AppReviewService {
     _instance = AppReviewService._internal(prefs, InAppReview.instance);
   }
 
+  /// Null-safe wrapper for use in widget code.
+  ///
+  /// Widget tests that don't go through [main] or [OverloadApp] never call
+  /// [initialize], so [_instance] is null. These static helpers no-op
+  /// in that case instead of throwing.
+  static void tryRecordWorkoutStarted() => _instance?.recordWorkoutStarted();
+
+  /// Null-safe wrapper for use in widget code. See [tryRecordWorkoutStarted].
+  static void tryMaybeRequestReview() {
+    _instance?.maybeRequestReview();
+  }
+
   void _recordFirstLaunchIfNeeded() {
     if (_prefs.getString(_firstLaunchKey) == null) {
       _prefs.setString(_firstLaunchKey, DateTime.now().toIso8601String());

--- a/fittrack/lib/services/app_review_service.dart
+++ b/fittrack/lib/services/app_review_service.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/foundation.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'app_analytics_service.dart';
+
+/// Manages the in-app review prompt lifecycle.
+///
+/// Eligible if: workouts started ≥ 5 AND days since first launch ≥ 7
+/// AND review has not already been requested on this install.
+///
+/// The platform (iOS/Android) applies its own rate limiting on top —
+/// calling [requestReview] does not guarantee the dialog appears.
+class AppReviewService {
+  static const String _firstLaunchKey = 'overload_first_launch_date';
+  static const String _workoutCountKey = 'overload_workout_count';
+  static const String _reviewRequestedKey = 'overload_review_requested';
+
+  static const int _minWorkouts = 5;
+  static const int _minDaysSinceLaunch = 7;
+
+  static AppReviewService? _instance;
+  static AppReviewService get instance => _instance!;
+
+  final SharedPreferences _prefs;
+  final InAppReview _inAppReview;
+
+  // Guards against firing twice in one app session (e.g. navigating back from
+  // multiple workouts in the same session).
+  bool _requestedThisSession = false;
+
+  AppReviewService._internal(this._prefs, this._inAppReview) {
+    _recordFirstLaunchIfNeeded();
+  }
+
+  @visibleForTesting
+  AppReviewService.forTest(SharedPreferences prefs, InAppReview inAppReview)
+      : _prefs = prefs,
+        _inAppReview = inAppReview {
+    _recordFirstLaunchIfNeeded();
+  }
+
+  static void initialize(SharedPreferences prefs) {
+    _instance = AppReviewService._internal(prefs, InAppReview.instance);
+  }
+
+  void _recordFirstLaunchIfNeeded() {
+    if (_prefs.getString(_firstLaunchKey) == null) {
+      _prefs.setString(_firstLaunchKey, DateTime.now().toIso8601String());
+    }
+  }
+
+  /// Called each time the user opens a workout. Increments the counter used
+  /// for review eligibility.
+  void recordWorkoutStarted() {
+    final count = _prefs.getInt(_workoutCountKey) ?? 0;
+    _prefs.setInt(_workoutCountKey, count + 1);
+  }
+
+  int get workoutCount => _prefs.getInt(_workoutCountKey) ?? 0;
+
+  int get daysSinceFirstLaunch {
+    final stored = _prefs.getString(_firstLaunchKey);
+    if (stored == null) return 0;
+    return DateTime.now().difference(DateTime.parse(stored)).inDays;
+  }
+
+  bool get hasBeenRequested => _prefs.getBool(_reviewRequestedKey) ?? false;
+
+  bool get isEligible =>
+      workoutCount >= _minWorkouts &&
+      daysSinceFirstLaunch >= _minDaysSinceLaunch &&
+      !hasBeenRequested;
+
+  /// Checks eligibility and requests a review if conditions are met.
+  ///
+  /// Safe to call speculatively — returns immediately if ineligible.
+  /// Must NOT be called from within an active workout screen.
+  Future<void> maybeRequestReview() async {
+    if (!isEligible || _requestedThisSession) return;
+    _requestedThisSession = true;
+
+    try {
+      await AppAnalyticsService.instance.logReviewPromptTriggered();
+
+      final available = await _inAppReview.isAvailable();
+      if (available) {
+        await _prefs.setBool(_reviewRequestedKey, true);
+        await _inAppReview.requestReview();
+      }
+    } catch (e) {
+      _requestedThisSession = false;
+      debugPrint('[AppReview] Failed to request review: $e');
+    }
+  }
+
+  /// Resets persisted review state. For testing and debug use only.
+  @visibleForTesting
+  Future<void> resetForTesting() async {
+    await _prefs.remove(_reviewRequestedKey);
+    _requestedThisSession = false;
+  }
+}

--- a/fittrack/pubspec.lock
+++ b/fittrack/pubspec.lock
@@ -546,6 +546,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  in_app_review:
+    dependency: "direct main"
+    description:
+      name: in_app_review
+      sha256: ab26ac54dbd802896af78c670b265eaeab7ecddd6af4d0751e9604b60574817f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.11"
+  in_app_review_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_review_platform_interface
+      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -1108,6 +1124,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: cfde38aa257dae62ffe79c87fab20165dfdf6988c1d31b58ebf59b9106062aad
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.6"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1116,6 +1156,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
   url_launcher_platform_interface:
     dependency: transitive
     description:

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -33,6 +33,9 @@ dependencies:
   uuid: ^4.2.1
   shared_preferences: ^2.2.2
   
+  # In-app review
+  in_app_review: ^2.0.9
+
   # Export functionality
   csv: ^6.0.0
   path_provider: ^2.1.2

--- a/fittrack/test/services/app_analytics_service_test.dart
+++ b/fittrack/test/services/app_analytics_service_test.dart
@@ -68,6 +68,11 @@ void main() {
       verify(mockAnalytics.logEvent(name: 'set_completed')).called(1);
     });
 
+    test('logReviewPromptTriggered fires review_prompt_triggered event', () async {
+      await service.logReviewPromptTriggered();
+      verify(mockAnalytics.logEvent(name: 'review_prompt_triggered')).called(1);
+    });
+
     test('analytics failures are swallowed and do not throw', () async {
       when(mockAnalytics.logEvent(
               name: anyNamed('name'),

--- a/fittrack/test/services/app_review_service_integration_test.dart
+++ b/fittrack/test/services/app_review_service_integration_test.dart
@@ -1,0 +1,158 @@
+/// Integration tests for AppReviewService.
+///
+/// AppReviewService uses SharedPreferences only (no Firebase).
+/// These tests exercise real SharedPreferences lifecycle end-to-end —
+/// persistence across re-initialisation, workout count accumulation, and
+/// eligibility gate logic. Firebase emulators are not required.
+///
+/// InAppReview (platform channel) is mocked so tests run in CI without a
+/// device. The "integration" value is the SharedPreferences persistence
+/// lifecycle, not the platform review API.
+
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fittrack/services/app_review_service.dart';
+
+import 'app_review_service_integration_test.mocks.dart';
+
+@GenerateMocks([InAppReview])
+void main() {
+  late MockInAppReview mockReview;
+
+  const firstLaunchKey = 'overload_first_launch_date';
+  const workoutCountKey = 'overload_workout_count';
+
+  setUp(() {
+    mockReview = MockInAppReview();
+    when(mockReview.isAvailable()).thenAnswer((_) async => true);
+    when(mockReview.requestReview()).thenAnswer((_) async {});
+  });
+
+  Future<AppReviewService> makeService({
+    Map<String, Object> prefsValues = const {},
+  }) async {
+    SharedPreferences.setMockInitialValues(prefsValues);
+    final prefs = await SharedPreferences.getInstance();
+    return AppReviewService.forTest(prefs, mockReview);
+  }
+
+  group('AppReviewService - Integration (SharedPreferences lifecycle)', () {
+    test('first launch date is written and persists across re-initialisation',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      AppReviewService.forTest(prefs, mockReview);
+
+      // Re-initialise from same prefs (simulates app restart)
+      final prefs2 = await SharedPreferences.getInstance();
+      final s2 = AppReviewService.forTest(prefs2, mockReview);
+
+      expect(s2.daysSinceFirstLaunch, greaterThanOrEqualTo(0),
+          reason: 'Launch date should survive re-initialisation');
+      expect(prefs2.getString(firstLaunchKey), isNotNull);
+    });
+
+    test('workout count accumulates and persists across re-initialisation',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      var prefs = await SharedPreferences.getInstance();
+      final s1 = AppReviewService.forTest(prefs, mockReview);
+      s1.recordWorkoutStarted();
+      s1.recordWorkoutStarted();
+      s1.recordWorkoutStarted();
+
+      // Re-initialise — simulates app restart
+      prefs = await SharedPreferences.getInstance();
+      final s2 = AppReviewService.forTest(prefs, mockReview);
+
+      expect(s2.workoutCount, 3,
+          reason: 'Workout count must survive app restart');
+      expect(prefs.getInt(workoutCountKey), 3);
+    });
+
+    test('review is not requested when below workout count threshold', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: tenDaysAgo,
+        workoutCountKey: 4, // one short of threshold
+      });
+
+      await s.maybeRequestReview();
+
+      verifyNever(mockReview.requestReview());
+    });
+
+    test('review is not requested when below days-since-launch threshold',
+        () async {
+      final threeDaysAgo =
+          DateTime.now().subtract(const Duration(days: 3)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: threeDaysAgo,
+        workoutCountKey: 10,
+      });
+
+      await s.maybeRequestReview();
+
+      verifyNever(mockReview.requestReview());
+    });
+
+    test('hasBeenRequested flag persists after review is triggered', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      SharedPreferences.setMockInitialValues({
+        firstLaunchKey: tenDaysAgo,
+        workoutCountKey: 5,
+      });
+      var prefs = await SharedPreferences.getInstance();
+      final s1 = AppReviewService.forTest(prefs, mockReview);
+      await s1.maybeRequestReview();
+      expect(s1.hasBeenRequested, isTrue);
+
+      // Re-initialise — review should not fire again
+      prefs = await SharedPreferences.getInstance();
+      final s2 = AppReviewService.forTest(prefs, mockReview);
+      expect(s2.hasBeenRequested, isTrue,
+          reason: 'Requested flag must persist across app restarts');
+      expect(s2.isEligible, isFalse,
+          reason: 'Should not be eligible again once requested');
+    });
+
+    test('full review lifecycle: accumulate workouts → wait → prompt → not again',
+        () async {
+      // Simulate a user who has had the app for 10 days
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      SharedPreferences.setMockInitialValues({firstLaunchKey: tenDaysAgo});
+      var prefs = await SharedPreferences.getInstance();
+      var s = AppReviewService.forTest(prefs, mockReview);
+
+      // Log 5 workouts
+      for (int i = 0; i < 5; i++) {
+        s.recordWorkoutStarted();
+      }
+      expect(s.isEligible, isTrue);
+
+      // Review fires on first eligible call
+      await s.maybeRequestReview();
+      verify(mockReview.requestReview()).called(1);
+
+      // Re-initialise (next app session) — no longer eligible
+      prefs = await SharedPreferences.getInstance();
+      s = AppReviewService.forTest(prefs, mockReview);
+      expect(s.isEligible, isFalse,
+          reason: 'hasBeenRequested flag persists — should not be eligible again');
+
+      // Reset mock interactions, then confirm no second request
+      clearInteractions(mockReview);
+      await s.maybeRequestReview();
+      verifyNever(mockReview.requestReview());
+    });
+  });
+}

--- a/fittrack/test/services/app_review_service_test.dart
+++ b/fittrack/test/services/app_review_service_test.dart
@@ -1,0 +1,186 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fittrack/services/app_review_service.dart';
+
+import 'app_review_service_test.mocks.dart';
+
+/// Unit tests for AppReviewService.
+///
+/// Verifies eligibility logic, workout count persistence, first-launch tracking,
+/// and that the native review API is only called when all conditions are met.
+///
+/// AppAnalyticsService.instance is called inside maybeRequestReview() but its
+/// failures are silently swallowed — no Firebase setup required here.
+@GenerateMocks([InAppReview])
+void main() {
+  late MockInAppReview mockReview;
+
+  const firstLaunchKey = 'overload_first_launch_date';
+  const workoutCountKey = 'overload_workout_count';
+  const reviewRequestedKey = 'overload_review_requested';
+
+  setUp(() {
+    mockReview = MockInAppReview();
+    when(mockReview.isAvailable()).thenAnswer((_) async => true);
+    when(mockReview.requestReview()).thenAnswer((_) async {});
+  });
+
+  Future<AppReviewService> makeService({
+    Map<String, Object> prefsValues = const {},
+  }) async {
+    SharedPreferences.setMockInitialValues(prefsValues);
+    final prefs = await SharedPreferences.getInstance();
+    return AppReviewService.forTest(prefs, mockReview);
+  }
+
+  Future<AppReviewService> eligibleService() => makeService(prefsValues: {
+        firstLaunchKey: DateTime.now()
+            .subtract(const Duration(days: 10))
+            .toIso8601String(),
+        workoutCountKey: 5,
+      });
+
+  group('recordWorkoutStarted', () {
+    test('increments workout count from 0', () async {
+      final s = await makeService();
+      s.recordWorkoutStarted();
+      expect(s.workoutCount, 1);
+    });
+
+    test('increments cumulatively across multiple calls', () async {
+      final s = await makeService();
+      s.recordWorkoutStarted();
+      s.recordWorkoutStarted();
+      s.recordWorkoutStarted();
+      expect(s.workoutCount, 3);
+    });
+
+    test('persists count to SharedPreferences', () async {
+      final s = await makeService();
+      s.recordWorkoutStarted();
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getInt(workoutCountKey), 1,
+          reason: 'Count must survive app restart');
+    });
+  });
+
+  group('daysSinceFirstLaunch', () {
+    test('records first launch date on initialisation when absent', () async {
+      final s = await makeService();
+      expect(s.daysSinceFirstLaunch, 0);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(firstLaunchKey), isNotNull);
+    });
+
+    test('does not overwrite an existing first launch date', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      final s = await makeService(prefsValues: {firstLaunchKey: tenDaysAgo});
+      expect(s.daysSinceFirstLaunch, greaterThanOrEqualTo(10),
+          reason: 'Prior launch date must be preserved');
+    });
+  });
+
+  group('isEligible', () {
+    test('false when workout count is below threshold (5)', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: tenDaysAgo,
+        workoutCountKey: 4,
+      });
+      expect(s.isEligible, isFalse,
+          reason: 'Requires at least 5 workouts');
+    });
+
+    test('false when fewer than 7 days have passed since first launch', () async {
+      final threeDaysAgo =
+          DateTime.now().subtract(const Duration(days: 3)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: threeDaysAgo,
+        workoutCountKey: 10,
+      });
+      expect(s.isEligible, isFalse,
+          reason: 'Requires at least 7 days since first launch');
+    });
+
+    test('false when review has already been requested', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: tenDaysAgo,
+        workoutCountKey: 10,
+        reviewRequestedKey: true,
+      });
+      expect(s.isEligible, isFalse,
+          reason: 'Should not prompt again after first request');
+    });
+
+    test('true when all conditions met (>= 5 workouts, >= 7 days, not yet requested)',
+        () async {
+      final s = await eligibleService();
+      expect(s.isEligible, isTrue);
+    });
+
+    test('true at exactly the minimum thresholds (5 workouts, 7 days)', () async {
+      final sevenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 7)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        firstLaunchKey: sevenDaysAgo,
+        workoutCountKey: 5,
+      });
+      expect(s.isEligible, isTrue,
+          reason: 'Boundary values must be inclusive');
+    });
+  });
+
+  group('maybeRequestReview', () {
+    test('calls isAvailable and requestReview when eligible', () async {
+      final s = await eligibleService();
+      await s.maybeRequestReview();
+      verify(mockReview.isAvailable()).called(1);
+      verify(mockReview.requestReview()).called(1);
+    });
+
+    test('does not call requestReview when ineligible', () async {
+      final s = await makeService(); // 0 workouts, 0 days
+      await s.maybeRequestReview();
+      verifyNever(mockReview.requestReview());
+    });
+
+    test('does not call requestReview a second time in the same session', () async {
+      final s = await eligibleService();
+      await s.maybeRequestReview();
+      await s.maybeRequestReview();
+      verify(mockReview.requestReview()).called(1);
+    });
+
+    test('marks hasBeenRequested true and persists to SharedPreferences', () async {
+      final s = await eligibleService();
+      await s.maybeRequestReview();
+      expect(s.hasBeenRequested, isTrue);
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(reviewRequestedKey), isTrue);
+    });
+
+    test('does not call requestReview when platform is unavailable', () async {
+      when(mockReview.isAvailable()).thenAnswer((_) async => false);
+      final s = await eligibleService();
+      await s.maybeRequestReview();
+      verify(mockReview.isAvailable()).called(1);
+      verifyNever(mockReview.requestReview());
+    });
+
+    test('does not set hasBeenRequested flag when platform is unavailable',
+        () async {
+      when(mockReview.isAvailable()).thenAnswer((_) async => false);
+      final s = await eligibleService();
+      await s.maybeRequestReview();
+      expect(s.hasBeenRequested, isFalse,
+          reason: 'Flag should only be set after a successful request call');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `AppReviewService` singleton that gates the native in-app review prompt behind: **≥5 workout sessions started** AND **≥7 days since first launch**, with a single-lifetime guard so the platform API is never hammered
- Review is triggered when the user returns from a workout (in `weeks_screen.dart` after navigator pop) — satisfies the "not during or immediately after workout" requirement
- Fires `review_prompt_triggered` analytics event for funnel tracking
- iOS: `SKStoreReviewController.requestReview()` via `in_app_review ^2.0.9`; Android: Google Play In-App Review API — same package

## Files changed

- `pubspec.yaml` / `pubspec.lock` — adds `in_app_review: 2.0.11`
- `lib/services/app_review_service.dart` — new singleton service
- `lib/services/app_analytics_service.dart` — adds `logReviewPromptTriggered()`
- `lib/main.dart` — initializes `AppReviewService` alongside `OnboardingService`
- `lib/screens/workouts/consolidated_workout_screen.dart` — calls `recordWorkoutStarted()` in `initState`
- `lib/screens/weeks/weeks_screen.dart` — awaits workout navigation and triggers `maybeRequestReview()` on return
- `test/services/app_review_service_test.dart` — unit tests (eligibility, persistence, session guard, platform-unavailable path)
- `test/services/app_analytics_service_test.dart` — adds `logReviewPromptTriggered` test

## Acceptance criteria

- [x] Prompt only appears when both trigger conditions are met
- [x] Prompt never appears during an active workout
- [x] Prompt never appears immediately on workout completion screen
- [x] Prompt respects platform rate limiting (not shown repeatedly — `hasBeenRequested` flag + platform-level OS limiting)
- [x] Firebase Analytics event fired when prompt conditions are met

## Test plan

- [ ] All unit tests pass in CI
- [ ] `AppReviewService` eligibility tests cover boundary values (exactly 5/7)
- [ ] Session guard prevents double-fire within same session

🤖 Generated with [Claude Code](https://claude.com/claude-code)