### PR TITLE
feat(#451): GTM analytics instrumentation for activation and retention KPIs

### DIFF
--- a/fittrack/lib/screens/onboarding/onboarding_carousel_screen.dart
+++ b/fittrack/lib/screens/onboarding/onboarding_carousel_screen.dart
@@ -69,7 +69,13 @@ class _OnboardingCarouselScreenState extends State<OnboardingCarouselScreen> {
     );
   }
 
+  void _skipCarouselToWizard() {
+    AppAnalyticsService.instance.logOnboardingSkipped();
+    _navigateToWizard();
+  }
+
   Future<void> _skipToApp() async {
+    AppAnalyticsService.instance.logOnboardingSkipped();
     await OnboardingService.instance.markComplete();
     if (!mounted) return;
     Navigator.of(context).pushAndRemoveUntil(
@@ -98,7 +104,7 @@ class _OnboardingCarouselScreenState extends State<OnboardingCarouselScreen> {
         automaticallyImplyLeading: false,
         actions: [
           TextButton(
-            onPressed: _navigateToWizard,
+            onPressed: _skipCarouselToWizard,
             child: const Text('Skip'),
           ),
         ],

--- a/fittrack/lib/screens/onboarding/onboarding_wizard_screen.dart
+++ b/fittrack/lib/screens/onboarding/onboarding_wizard_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/exercise.dart';
 import '../../providers/program_provider.dart';
+import '../../services/app_analytics_service.dart';
 import '../../services/onboarding_service.dart';
 import '../home/home_screen.dart';
 import 'onboarding_completion_screen.dart';
@@ -81,6 +82,7 @@ class _OnboardingWizardScreenState extends State<OnboardingWizardScreen> {
   // ─── Navigation ────────────────────────────────────────────────────────────
 
   Future<void> _onSkip() async {
+    AppAnalyticsService.instance.logProgramSetupSkipped();
     await OnboardingService.instance.markComplete();
     if (!mounted) return;
     Navigator.of(context).pushAndRemoveUntil(

--- a/fittrack/lib/services/app_analytics_service.dart
+++ b/fittrack/lib/services/app_analytics_service.dart
@@ -92,6 +92,56 @@ class AppAnalyticsService {
       _log(() => _analytics.logEvent(name: 'review_prompt_triggered'));
 
   // ---------------------------------------------------------------------------
+  // Onboarding skip events
+  // ---------------------------------------------------------------------------
+
+  Future<void> logOnboardingSkipped() =>
+      _log(() => _analytics.logEvent(name: 'onboarding_skipped'));
+
+  Future<void> logProgramSetupSkipped() =>
+      _log(() => _analytics.logEvent(name: 'program_setup_skipped'));
+
+  // ---------------------------------------------------------------------------
+  // Activation milestone events
+  // ---------------------------------------------------------------------------
+
+  /// Fired the first time a user logs a workout.
+  /// [daysSinceInstall] allows cohort analysis (did they work out on day 0, 1, etc.)
+  Future<void> logFirstWorkoutLogged(int daysSinceInstall) =>
+      _log(() => _analytics.logEvent(
+            name: 'first_workout_logged',
+            parameters: {'days_since_install': daysSinceInstall},
+          ));
+
+  /// Fired when a workout count milestone is reached (e.g., 5th workout).
+  Future<void> logWorkoutMilestone(int count) =>
+      _log(() => _analytics.logEvent(
+            name: 'workout_milestone',
+            parameters: {'workout_count': count},
+          ));
+
+  // ---------------------------------------------------------------------------
+  // Retention cohort events
+  // ---------------------------------------------------------------------------
+
+  Future<void> logDayOneSession() =>
+      _log(() => _analytics.logEvent(name: 'day_1_session'));
+
+  Future<void> logDaySevenSession() =>
+      _log(() => _analytics.logEvent(name: 'day_7_session'));
+
+  Future<void> logDayThirtySession() =>
+      _log(() => _analytics.logEvent(name: 'day_30_session'));
+
+  /// Fired when a user logs a workout after 10+ days of inactivity.
+  /// [daysSinceLastWorkout] is captured before the new workout resets the clock.
+  Future<void> logUserReactivated(int daysSinceLastWorkout) =>
+      _log(() => _analytics.logEvent(
+            name: 'user_reactivated',
+            parameters: {'days_since_last_workout': daysSinceLastWorkout},
+          ));
+
+  // ---------------------------------------------------------------------------
   // Lifecycle notification events
   // ---------------------------------------------------------------------------
 

--- a/fittrack/lib/services/lifecycle_notification_service.dart
+++ b/fittrack/lib/services/lifecycle_notification_service.dart
@@ -27,6 +27,11 @@ class LifecycleNotificationService {
   static const String _permissionRequestedKey = 'overload_notif_permission_requested';
   static const String _fcmTokenKey = 'overload_fcm_token';
 
+  // Analytics dedup flags — set once so session events fire only on first qualifying launch.
+  static const String _d1FiredKey = 'overload_analytics_d1_session_fired';
+  static const String _d7FiredKey = 'overload_analytics_d7_session_fired';
+  static const String _d30FiredKey = 'overload_analytics_d30_session_fired';
+
   // Stable IDs — scheduling with the same ID replaces any existing notification
   // of that type so only one of each trigger is ever queued.
   static const int _day1NotifId = 1001;
@@ -148,6 +153,7 @@ class LifecycleNotificationService {
   Future<void> onAppLaunch() async {
     await _scheduleActivationNotifications();
     await _scheduleRetentionNotifications();
+    _logRetentionSessions();
   }
 
   /// Call when the user completes a workout session.
@@ -155,9 +161,23 @@ class LifecycleNotificationService {
   /// Increments the workout count, cancels activation nudges, and resets the
   /// inactivity window to today.
   void recordWorkoutLogged() {
+    // Capture inactivity window BEFORE updating last workout date.
+    final inactivityDays = daysSinceLastWorkout;
     final count = (_prefs.getInt(_workoutCountKey) ?? 0) + 1;
     _prefs.setInt(_workoutCountKey, count);
     _prefs.setString(_lastWorkoutDateKey, DateTime.now().toIso8601String());
+
+    // Activation milestone events.
+    if (count == 1) {
+      AppAnalyticsService.instance.logFirstWorkoutLogged(daysSinceInstall);
+    }
+    if (count == 5) {
+      AppAnalyticsService.instance.logWorkoutMilestone(5);
+    }
+    // Reactivation: only meaningful after the first workout (count > 1).
+    if (count > 1 && inactivityDays >= 10) {
+      AppAnalyticsService.instance.logUserReactivated(inactivityDays);
+    }
 
     // User has engaged — cancel first-workout activation nudges.
     _localNotifications.cancel(_day1NotifId);
@@ -227,6 +247,24 @@ class LifecycleNotificationService {
   }
 
   bool get permissionRequested => _prefs.getBool(_permissionRequestedKey) ?? false;
+
+  // ─── Retention session analytics ────────────────────────────────────────────
+
+  void _logRetentionSessions() {
+    final days = daysSinceInstall;
+    if (days >= 1 && !(_prefs.getBool(_d1FiredKey) ?? false)) {
+      _prefs.setBool(_d1FiredKey, true);
+      AppAnalyticsService.instance.logDayOneSession();
+    }
+    if (days >= 7 && !(_prefs.getBool(_d7FiredKey) ?? false)) {
+      _prefs.setBool(_d7FiredKey, true);
+      AppAnalyticsService.instance.logDaySevenSession();
+    }
+    if (days >= 30 && !(_prefs.getBool(_d30FiredKey) ?? false)) {
+      _prefs.setBool(_d30FiredKey, true);
+      AppAnalyticsService.instance.logDayThirtySession();
+    }
+  }
 
   // ─── Scheduling ─────────────────────────────────────────────────────────────
 

--- a/fittrack/pubspec.lock
+++ b/fittrack/pubspec.lock
@@ -401,6 +401,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.8.12"
+  firebase_messaging:
+    dependency: "direct main"
+    description:
+      name: firebase_messaging
+      sha256: aad5dcdea5698499b70d74d5a53b1f6a9972f85f97225e4b7ac006dd8d4f9bac
+      url: "https://pub.dev"
+    source: hosted
+    version: "16.0.1"
+  firebase_messaging_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_messaging_platform_interface
+      sha256: "825bc11767bf50a43dccf49b3026f847ec31d0f176139bfc48d662cc128b5014"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.7.1"
+  firebase_messaging_web:
+    dependency: transitive
+    description:
+      name: firebase_messaging_web
+      sha256: db8dbdd79921245c4de02407e33cae2d1868683be18a5ba948d2af5311e3ef5d
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   firebase_storage:
     dependency: "direct main"
     description:
@@ -1093,7 +1117,7 @@ packages:
     source: hosted
     version: "0.6.11"
   timezone:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: timezone
       sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1

--- a/fittrack/test/services/app_analytics_service_test.dart
+++ b/fittrack/test/services/app_analytics_service_test.dart
@@ -89,6 +89,55 @@ void main() {
       )).called(1);
     });
 
+    test('logOnboardingSkipped fires onboarding_skipped event', () async {
+      await service.logOnboardingSkipped();
+      verify(mockAnalytics.logEvent(name: 'onboarding_skipped')).called(1);
+    });
+
+    test('logProgramSetupSkipped fires program_setup_skipped event', () async {
+      await service.logProgramSetupSkipped();
+      verify(mockAnalytics.logEvent(name: 'program_setup_skipped')).called(1);
+    });
+
+    test('logFirstWorkoutLogged fires first_workout_logged with days_since_install', () async {
+      await service.logFirstWorkoutLogged(3);
+      verify(mockAnalytics.logEvent(
+        name: 'first_workout_logged',
+        parameters: {'days_since_install': 3},
+      )).called(1);
+    });
+
+    test('logWorkoutMilestone fires workout_milestone with count', () async {
+      await service.logWorkoutMilestone(5);
+      verify(mockAnalytics.logEvent(
+        name: 'workout_milestone',
+        parameters: {'workout_count': 5},
+      )).called(1);
+    });
+
+    test('logDayOneSession fires day_1_session event', () async {
+      await service.logDayOneSession();
+      verify(mockAnalytics.logEvent(name: 'day_1_session')).called(1);
+    });
+
+    test('logDaySevenSession fires day_7_session event', () async {
+      await service.logDaySevenSession();
+      verify(mockAnalytics.logEvent(name: 'day_7_session')).called(1);
+    });
+
+    test('logDayThirtySession fires day_30_session event', () async {
+      await service.logDayThirtySession();
+      verify(mockAnalytics.logEvent(name: 'day_30_session')).called(1);
+    });
+
+    test('logUserReactivated fires user_reactivated with days_since_last_workout', () async {
+      await service.logUserReactivated(14);
+      verify(mockAnalytics.logEvent(
+        name: 'user_reactivated',
+        parameters: {'days_since_last_workout': 14},
+      )).called(1);
+    });
+
     test('analytics failures are swallowed and do not throw', () async {
       when(mockAnalytics.logEvent(
               name: anyNamed('name'),

--- a/fittrack/test/services/lifecycle_notification_service_test.dart
+++ b/fittrack/test/services/lifecycle_notification_service_test.dart
@@ -241,17 +241,13 @@ void main() {
     test('sets d1 flag on first launch at day >= 1', () async {
       final oneDayAgo =
           DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
-      final s = await makeService(
-          prefsValues: {'overload_lifecycle_install_date': oneDayAgo});
       SharedPreferences.setMockInitialValues(
           {'overload_lifecycle_install_date': oneDayAgo});
       final prefs = await SharedPreferences.getInstance();
-      LifecycleNotificationService.forTest(prefs, mockNotifications, mockMessaging)
-          .onAppLaunch();
-      // Allow async prefs write to complete
-      await Future.microtask(() {});
+      final s = LifecycleNotificationService.forTest(
+          prefs, mockNotifications, mockMessaging);
+      await s.onAppLaunch();
       expect(prefs.getBool(d1Key), isTrue);
-      s.toString(); // suppress unused warning
     });
 
     test('does not set d1 flag when install is today', () async {

--- a/fittrack/test/services/lifecycle_notification_service_test.dart
+++ b/fittrack/test/services/lifecycle_notification_service_test.dart
@@ -233,6 +233,125 @@ void main() {
     });
   });
 
+  group('LifecycleNotificationService - retention session tracking', () {
+    const d1Key = 'overload_analytics_d1_session_fired';
+    const d7Key = 'overload_analytics_d7_session_fired';
+    const d30Key = 'overload_analytics_d30_session_fired';
+
+    test('sets d1 flag on first launch at day >= 1', () async {
+      final oneDayAgo =
+          DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
+      final s = await makeService(
+          prefsValues: {'overload_lifecycle_install_date': oneDayAgo});
+      SharedPreferences.setMockInitialValues(
+          {'overload_lifecycle_install_date': oneDayAgo});
+      final prefs = await SharedPreferences.getInstance();
+      LifecycleNotificationService.forTest(prefs, mockNotifications, mockMessaging)
+          .onAppLaunch();
+      // Allow async prefs write to complete
+      await Future.microtask(() {});
+      expect(prefs.getBool(d1Key), isTrue);
+      s.toString(); // suppress unused warning
+    });
+
+    test('does not set d1 flag when install is today', () async {
+      final s = await makeService();
+      await s.onAppLaunch();
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool(d1Key), isNull);
+    });
+
+    test('d1 flag not re-set on subsequent launch', () async {
+      final oneDayAgo =
+          DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
+      SharedPreferences.setMockInitialValues({
+        'overload_lifecycle_install_date': oneDayAgo,
+        d1Key: true,
+      });
+      final prefs = await SharedPreferences.getInstance();
+      final s = LifecycleNotificationService.forTest(
+          prefs, mockNotifications, mockMessaging);
+      await s.onAppLaunch();
+      // Flag was already true — value unchanged
+      expect(prefs.getBool(d1Key), isTrue);
+    });
+
+    test('sets d7 flag on launch at day >= 7', () async {
+      final sevenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 7)).toIso8601String();
+      SharedPreferences.setMockInitialValues(
+          {'overload_lifecycle_install_date': sevenDaysAgo});
+      final prefs = await SharedPreferences.getInstance();
+      final s = LifecycleNotificationService.forTest(
+          prefs, mockNotifications, mockMessaging);
+      await s.onAppLaunch();
+      expect(prefs.getBool(d7Key), isTrue);
+      s.toString();
+    });
+
+    test('sets d30 flag on launch at day >= 30', () async {
+      final thirtyDaysAgo =
+          DateTime.now().subtract(const Duration(days: 30)).toIso8601String();
+      SharedPreferences.setMockInitialValues(
+          {'overload_lifecycle_install_date': thirtyDaysAgo});
+      final prefs = await SharedPreferences.getInstance();
+      final s = LifecycleNotificationService.forTest(
+          prefs, mockNotifications, mockMessaging);
+      await s.onAppLaunch();
+      expect(prefs.getBool(d30Key), isTrue);
+      s.toString();
+    });
+
+    test('does not set d7 or d30 flags on day 1', () async {
+      final oneDayAgo =
+          DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
+      SharedPreferences.setMockInitialValues(
+          {'overload_lifecycle_install_date': oneDayAgo});
+      final prefs = await SharedPreferences.getInstance();
+      final s = LifecycleNotificationService.forTest(
+          prefs, mockNotifications, mockMessaging);
+      await s.onAppLaunch();
+      expect(prefs.getBool(d7Key), isNull);
+      expect(prefs.getBool(d30Key), isNull);
+      s.toString();
+    });
+  });
+
+  group('LifecycleNotificationService - activation analytics', () {
+    test('recordWorkoutLogged sets first_workout prefs indirectly via count=1',
+        () async {
+      final s = await makeService();
+      expect(s.workoutCount, 0);
+      s.recordWorkoutLogged();
+      expect(s.workoutCount, 1);
+    });
+
+    test('recordWorkoutLogged accumulates to 5 for milestone', () async {
+      final s = await makeService();
+      for (var i = 0; i < 5; i++) {
+        s.recordWorkoutLogged();
+      }
+      expect(s.workoutCount, 5);
+    });
+
+    test('daysSinceLastWorkout is captured before update in recordWorkoutLogged',
+        () async {
+      final twoDaysAgo =
+          DateTime.now().subtract(const Duration(days: 2)).toIso8601String();
+      final s = await makeService(prefsValues: {
+        'overload_lifecycle_install_date':
+            DateTime.now().subtract(const Duration(days: 10)).toIso8601String(),
+        'overload_lifecycle_last_workout_date': twoDaysAgo,
+        'overload_lifecycle_workout_count': 2,
+      });
+      expect(s.daysSinceLastWorkout, 2);
+      s.recordWorkoutLogged();
+      // After logging, last workout date is today so daysSinceLastWorkout = 0
+      expect(s.daysSinceLastWorkout, 0);
+    });
+  });
+
   group('LifecycleNotificationService - PR notification', () {
     test('recordPRAchieved calls show with exercise name and value', () async {
       final s = await makeService();


### PR DESCRIPTION
## Summary
- Adds 8 new analytics events to `AppAnalyticsService`: `logOnboardingSkipped`, `logProgramSetupSkipped`, `logFirstWorkoutLogged(daysSinceInstall)`, `logWorkoutMilestone(count)`, `logDayOneSession`, `logDaySevenSession`, `logDayThirtySession`, `logUserReactivated(daysSinceLastWorkout)`
- Wires activation events in `LifecycleNotificationService.recordWorkoutLogged`: first workout (count=1), 5th-workout milestone, reactivation after 10+ day inactivity
- Fires D1/D7/D30 retention session events in `onAppLaunch` with SharedPreferences dedup flags so each milestone fires exactly once per device
- Fires `logOnboardingSkipped` from carousel AppBar Skip and Skip-to-App paths; `logProgramSetupSkipped` from wizard Skip button

## Notes
- Monetisation KPIs (paywall, trial, plan selection) are BLOCKED on #448 and not included
- Session events (D1/D7/D30) are deduplicated via prefs flags — they fire on the first qualifying launch only

## Test plan
- [ ] All 8 new `AppAnalyticsService` methods have unit tests verifying the correct event name and parameters
- [ ] Session tracking tests verify prefs flags are set on first qualifying `onAppLaunch` and not re-set on subsequent launches
- [ ] Activation analytics tests verify `workoutCount` and `daysSinceLastWorkout` state before/after `recordWorkoutLogged`
- [ ] CI passes on this PR

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)