### PR TITLE
feat(#452): returning user and churn reactivation UX

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -23,6 +23,7 @@ import 'services/firestore_service.dart';
 import 'services/lifecycle_notification_service.dart';
 import 'services/notification_service.dart';
 import 'services/onboarding_service.dart';
+import 'services/returning_user_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -88,6 +89,9 @@ void main() async {
   LifecycleNotificationService.tryOnAppLaunch().catchError((e) {
     debugPrint('Lifecycle notification onAppLaunch error: $e');
   });
+
+  // Initialize returning user service — detects 30+ day inactivity on home screen
+  ReturningUserService.initialize(prefs);
 
   runZonedGuarded(
     () => runApp(OverloadApp(prefs: prefs)),

--- a/fittrack/lib/providers/program_provider.dart
+++ b/fittrack/lib/providers/program_provider.dart
@@ -452,6 +452,40 @@ class ProgramProvider extends ChangeNotifier {
     }
   }
 
+  /// Creates the next week in [programId] without requiring it to be selected.
+  ///
+  /// Fetches the existing weeks via a one-shot Firestore read to determine the
+  /// correct order, then names the week "Week N". Returns the new week ID, or
+  /// null on failure.
+  Future<String?> createWeekForProgram({required String programId}) async {
+    if (_userId == null) return null;
+    try {
+      final existingWeeks =
+          await _firestoreService.getWeeksOnce(_userId!, programId);
+      final nextOrder = existingWeeks.isEmpty
+          ? 1
+          : existingWeeks
+                  .map((w) => w.order)
+                  .reduce((a, b) => a > b ? a : b) +
+              1;
+      final week = Week(
+        id: '',
+        name: 'Week $nextOrder',
+        order: nextOrder,
+        notes: null,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        userId: _userId!,
+        programId: programId,
+      );
+      return await _firestoreService.createWeek(week);
+    } catch (e) {
+      _programsError = 'Failed to create week: $e';
+      notifyListeners();
+      return null;
+    }
+  }
+
   /// Update a week
   Future<bool> updateWeek(Week week) async {
     try {

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -11,6 +11,7 @@ import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/create_options_sheet.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
+import '../../widgets/returning_user_banner.dart';
 import 'program_detail_screen.dart';
 import 'create_program_screen.dart';
 
@@ -88,21 +89,28 @@ class ProgramsScreen extends StatelessWidget {
             );
           }
 
-          return RefreshIndicator(
-            onRefresh: () async {
-              programProvider.loadPrograms();
-            },
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: programProvider.programs.length,
-              itemBuilder: (context, index) {
-                final program = programProvider.programs[index];
-                return _ProgramCard(
-                  program: program,
-                  onTap: () => _navigateToProgram(context, program),
-                );
-              },
-            ),
+          return Column(
+            children: [
+              const ReturningUserBanner(),
+              Expanded(
+                child: RefreshIndicator(
+                  onRefresh: () async {
+                    programProvider.loadPrograms();
+                  },
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(16),
+                    itemCount: programProvider.programs.length,
+                    itemBuilder: (context, index) {
+                      final program = programProvider.programs[index];
+                      return _ProgramCard(
+                        program: program,
+                        onTap: () => _navigateToProgram(context, program),
+                      );
+                    },
+                  ),
+                ),
+              ),
+            ],
           );
         },
       ),

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -5,6 +5,7 @@ import '../../providers/program_provider.dart';
 import '../../services/app_analytics_service.dart';
 import '../../services/app_review_service.dart';
 import '../../services/lifecycle_notification_service.dart';
+import '../../services/returning_user_service.dart';
 import '../../providers/template_provider.dart';
 import '../../models/program.dart';
 import '../../models/week.dart';
@@ -52,6 +53,7 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
     AppAnalyticsService.instance.logWorkoutStarted();
     AppReviewService.tryRecordWorkoutStarted();
     LifecycleNotificationService.tryRecordWorkoutLogged();
+    ReturningUserService.recordLastActiveProgram(widget.program.id);
     // Load exercises and all sets when screen opens
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadWorkoutData();

--- a/fittrack/lib/services/firestore_service.dart
+++ b/fittrack/lib/services/firestore_service.dart
@@ -307,6 +307,22 @@ class FirestoreService {
             .toList());
   }
 
+  /// One-shot fetch of all weeks for a program (no subscription).
+  /// Used when week order is needed without setting up a listener.
+  Future<List<Week>> getWeeksOnce(String userId, String programId) async {
+    final snapshot = await _firestore
+        .collection('users')
+        .doc(userId)
+        .collection('programs')
+        .doc(programId)
+        .collection('weeks')
+        .orderBy('order')
+        .get();
+    return snapshot.docs
+        .map((doc) => WeekConverter.fromFirestore(doc, programId: programId))
+        .toList();
+  }
+
   /// Get a specific week
   Stream<Week?> getWeek(String userId, String programId, String weekId) {
     return _firestore

--- a/fittrack/lib/services/returning_user_service.dart
+++ b/fittrack/lib/services/returning_user_service.dart
@@ -1,0 +1,72 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Detects when a user returns after 30+ days of inactivity and manages
+/// the state of the contextual "pick up where you left off" prompt.
+///
+/// Reads the last workout date written by [LifecycleNotificationService] so
+/// the two services stay in sync without coupling. ReturningUserService owns
+/// its own prefs keys for program tracking and dismissal state.
+class ReturningUserService {
+  // Read-only — key is written by LifecycleNotificationService.
+  static const _lastWorkoutDateKey = 'overload_lifecycle_last_workout_date';
+
+  static const _lastProgramIdKey = 'overload_returning_last_program_id';
+  static const _dismissedAtKey = 'overload_returning_dismissed_at';
+
+  static const int inactivityThresholdDays = 30;
+
+  static SharedPreferences? _prefs;
+
+  static void initialize(SharedPreferences prefs) => _prefs = prefs;
+
+  /// Records which program was active when a workout was logged.
+  /// Call from [ConsolidatedWorkoutScreen] on every workout open.
+  static void recordLastActiveProgram(String programId) =>
+      _prefs?.setString(_lastProgramIdKey, programId);
+
+  /// Returns true when the returning-user prompt should be shown:
+  ///   • A workout was previously logged
+  ///   • 30+ days have passed since that workout
+  ///   • A last-active program is on record
+  ///   • The prompt has not been dismissed since the last workout
+  static bool get shouldShowPrompt {
+    if (_prefs == null) return false;
+    final lastWorkout = _lastWorkoutDate;
+    if (lastWorkout == null) return false;
+    if (DateTime.now().difference(lastWorkout).inDays < inactivityThresholdDays) {
+      return false;
+    }
+    if (lastActiveProgramId == null) return false;
+
+    // Already dismissed during this inactivity cycle?
+    final dismissed = _dismissedAt;
+    if (dismissed != null && dismissed.isAfter(lastWorkout)) return false;
+
+    return true;
+  }
+
+  /// Suppress the prompt for the current inactivity cycle.
+  static void dismiss() =>
+      _prefs?.setString(_dismissedAtKey, DateTime.now().toIso8601String());
+
+  /// Program ID of the last program in which a workout was logged.
+  static String? get lastActiveProgramId =>
+      _prefs?.getString(_lastProgramIdKey);
+
+  /// Whole days since the last logged workout (0 if never logged).
+  static int get daysSinceLastWorkout {
+    final lastWorkout = _lastWorkoutDate;
+    if (lastWorkout == null) return 0;
+    return DateTime.now().difference(lastWorkout).inDays;
+  }
+
+  static DateTime? get _lastWorkoutDate {
+    final s = _prefs?.getString(_lastWorkoutDateKey);
+    return s == null ? null : DateTime.parse(s);
+  }
+
+  static DateTime? get _dismissedAt {
+    final s = _prefs?.getString(_dismissedAtKey);
+    return s == null ? null : DateTime.parse(s);
+  }
+}

--- a/fittrack/lib/widgets/returning_user_banner.dart
+++ b/fittrack/lib/widgets/returning_user_banner.dart
@@ -1,0 +1,165 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/program.dart';
+import '../providers/program_provider.dart';
+import '../screens/programs/program_detail_screen.dart';
+import '../services/returning_user_service.dart';
+
+/// Shown at the top of the programs list when a user returns after 30+ days
+/// of inactivity. Offers "Start Fresh Week" (creates the next week in their
+/// last active program) or "Pick Up Here" (navigates to the program).
+///
+/// Invisible (SizedBox.shrink) when conditions are not met.
+class ReturningUserBanner extends StatefulWidget {
+  const ReturningUserBanner({super.key});
+
+  @override
+  State<ReturningUserBanner> createState() => _ReturningUserBannerState();
+}
+
+class _ReturningUserBannerState extends State<ReturningUserBanner> {
+  bool _dismissed = false;
+  bool _isCreatingWeek = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed || !ReturningUserService.shouldShowPrompt) {
+      return const SizedBox.shrink();
+    }
+
+    final provider = Provider.of<ProgramProvider>(context, listen: false);
+    final programId = ReturningUserService.lastActiveProgramId;
+    final Program? program = programId == null
+        ? null
+        : provider.programs.cast<Program?>().firstWhere(
+              (p) => p?.id == programId,
+              orElse: () => null,
+            );
+
+    if (program == null) {
+      // Program was deleted — silently dismiss so the banner doesn't reappear.
+      ReturningUserService.dismiss();
+      return const SizedBox.shrink();
+    }
+
+    final days = ReturningUserService.daysSinceLastWorkout;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      color: colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.waving_hand_outlined,
+                    color: colorScheme.onPrimaryContainer, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Welcome back!',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  color: colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
+                  visualDensity: VisualDensity.compact,
+                  tooltip: 'Dismiss',
+                  onPressed: _dismiss,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'You last trained $days days ago. "${program.name}" is ready when you are.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer.withValues(alpha: 0.85),
+                  ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                Expanded(
+                  child: FilledButton(
+                    style: FilledButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                    ),
+                    onPressed: _isCreatingWeek
+                        ? null
+                        : () => _startFreshWeek(provider, program),
+                    child: _isCreatingWeek
+                        ? const SizedBox(
+                            width: 14,
+                            height: 14,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Start Fresh Week'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton(
+                    style: OutlinedButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      foregroundColor: colorScheme.onPrimaryContainer,
+                      side: BorderSide(
+                          color: colorScheme.onPrimaryContainer
+                              .withValues(alpha: 0.4)),
+                    ),
+                    onPressed: () => _pickUpHere(program),
+                    child: const Text('Pick Up Here'),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _dismiss() {
+    ReturningUserService.dismiss();
+    setState(() => _dismissed = true);
+  }
+
+  void _pickUpHere(Program program) {
+    _dismiss();
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => ProgramDetailScreen(program: program)),
+    );
+  }
+
+  Future<void> _startFreshWeek(
+    ProgramProvider provider,
+    Program program,
+  ) async {
+    setState(() => _isCreatingWeek = true);
+
+    final weekId =
+        await provider.createWeekForProgram(programId: program.id);
+
+    if (!mounted) return;
+    setState(() => _isCreatingWeek = false);
+
+    if (weekId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+            content: Text('Could not create week. Please try again.')),
+      );
+      return;
+    }
+
+    _dismiss();
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => ProgramDetailScreen(program: program)),
+    );
+  }
+}

--- a/fittrack/test/services/returning_user_service_integration_test.dart
+++ b/fittrack/test/services/returning_user_service_integration_test.dart
@@ -1,0 +1,111 @@
+/// Integration tests for ReturningUserService.
+///
+/// ReturningUserService relies solely on SharedPreferences for all state
+/// (last workout date, last active program ID, dismissal timestamp).
+/// These tests exercise the real SharedPreferences lifecycle end-to-end —
+/// recording a program, dismissing the prompt, and re-initialising across
+/// simulated app restarts — with no Firebase dependency.
+
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fittrack/services/returning_user_service.dart';
+
+void main() {
+  const lastWorkoutKey = 'overload_lifecycle_last_workout_date';
+  const lastProgramKey = 'overload_returning_last_program_id';
+  const dismissedKey = 'overload_returning_dismissed_at';
+
+  group('ReturningUserService - SharedPreferences lifecycle', () {
+    test('lastActiveProgramId persists across re-initialisation', () async {
+      SharedPreferences.setMockInitialValues({});
+      var prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+
+      ReturningUserService.recordLastActiveProgram('prog-xyz');
+      expect(ReturningUserService.lastActiveProgramId, 'prog-xyz');
+
+      // Simulate app restart with same prefs store
+      prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+      expect(ReturningUserService.lastActiveProgramId, 'prog-xyz',
+          reason: 'Program ID must survive re-initialisation');
+    });
+
+    test('dismissal persists across re-initialisation', () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      SharedPreferences.setMockInitialValues({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+      var prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+
+      expect(ReturningUserService.shouldShowPrompt, isTrue);
+      ReturningUserService.dismiss();
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+
+      // Simulate app restart
+      prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+      expect(ReturningUserService.shouldShowPrompt, isFalse,
+          reason: 'Dismissal must survive re-initialisation');
+      expect(prefs.getString(dismissedKey), isNotNull);
+    });
+
+    test('shouldShowPrompt state is consistent after re-initialisation', () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      SharedPreferences.setMockInitialValues({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+
+      var prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+      expect(ReturningUserService.shouldShowPrompt, isTrue);
+
+      // Re-initialise without dismissing — prompt remains
+      prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+      expect(ReturningUserService.shouldShowPrompt, isTrue,
+          reason: 'Undismissed prompt must still show after re-initialisation');
+    });
+
+    test('new workout resets inactivity cycle across re-initialisation',
+        () async {
+      // User was inactive 31 days, then logs a workout
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      final dismissedNow = DateTime.now().toIso8601String();
+      final workoutYesterday =
+          DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
+
+      SharedPreferences.setMockInitialValues({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+        dismissedKey: dismissedNow,
+      });
+      var prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+      expect(ReturningUserService.shouldShowPrompt, isFalse,
+          reason: 'Already dismissed for this cycle');
+
+      // New workout resets lastWorkoutDate to yesterday
+      SharedPreferences.setMockInitialValues({
+        lastWorkoutKey: workoutYesterday,
+        lastProgramKey: 'prog-1',
+        dismissedKey: dismissedNow, // dismissal is now before last workout
+      });
+      prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+
+      // Yesterday workout means < 30 days inactive — prompt still false
+      expect(ReturningUserService.shouldShowPrompt, isFalse,
+          reason: 'Only 1 day since last workout — below 30 day threshold');
+    });
+  });
+}

--- a/fittrack/test/services/returning_user_service_test.dart
+++ b/fittrack/test/services/returning_user_service_test.dart
@@ -1,0 +1,145 @@
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fittrack/services/returning_user_service.dart';
+
+void main() {
+  const lastWorkoutKey = 'overload_lifecycle_last_workout_date';
+  const lastProgramKey = 'overload_returning_last_program_id';
+  const dismissedKey = 'overload_returning_dismissed_at';
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    ReturningUserService.initialize(prefs);
+  });
+
+  Future<void> reinit(Map<String, Object> values) async {
+    SharedPreferences.setMockInitialValues(values);
+    final prefs = await SharedPreferences.getInstance();
+    ReturningUserService.initialize(prefs);
+  }
+
+  group('ReturningUserService - shouldShowPrompt', () {
+    test('returns false when no last workout date recorded', () async {
+      await reinit({lastProgramKey: 'prog-1'});
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+
+    test('returns false when inactive less than 30 days', () async {
+      final twentyDaysAgo =
+          DateTime.now().subtract(const Duration(days: 20)).toIso8601String();
+      await reinit({
+        lastWorkoutKey: twentyDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+
+    test('returns false when inactive exactly 29 days', () async {
+      final twentyNineDaysAgo =
+          DateTime.now().subtract(const Duration(days: 29)).toIso8601String();
+      await reinit({
+        lastWorkoutKey: twentyNineDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+
+    test('returns true when inactive 30+ days with program on record', () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      await reinit({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+      expect(ReturningUserService.shouldShowPrompt, isTrue);
+    });
+
+    test('returns false when inactive 30+ days but no program recorded',
+        () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      await reinit({lastWorkoutKey: thirtyOneDaysAgo});
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+
+    test('returns false after dismissal in the same inactivity cycle', () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      final dismissedNow = DateTime.now().toIso8601String();
+      await reinit({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+        dismissedKey: dismissedNow,
+      });
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+
+    test('returns true again after a new workout resets the cycle', () async {
+      // User dismissed, then came back and logged a workout yesterday —
+      // they're within 30 days now so prompt is false for a different reason,
+      // but the dismissal from the prior cycle is stale.
+      final dismissedTwoMonthsAgo =
+          DateTime.now().subtract(const Duration(days: 60)).toIso8601String();
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      // Last workout is AFTER the old dismissal — new inactivity cycle.
+      await reinit({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+        // dismissedAt is before lastWorkout → stale, should be ignored
+        dismissedKey: dismissedTwoMonthsAgo,
+      });
+      expect(ReturningUserService.shouldShowPrompt, isTrue);
+    });
+  });
+
+  group('ReturningUserService - dismiss', () {
+    test('dismiss suppresses the prompt', () async {
+      final thirtyOneDaysAgo =
+          DateTime.now().subtract(const Duration(days: 31)).toIso8601String();
+      await reinit({
+        lastWorkoutKey: thirtyOneDaysAgo,
+        lastProgramKey: 'prog-1',
+      });
+      expect(ReturningUserService.shouldShowPrompt, isTrue);
+      ReturningUserService.dismiss();
+      expect(ReturningUserService.shouldShowPrompt, isFalse);
+    });
+  });
+
+  group('ReturningUserService - recordLastActiveProgram', () {
+    test('persists program ID in prefs', () async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      ReturningUserService.initialize(prefs);
+
+      ReturningUserService.recordLastActiveProgram('prog-abc');
+      expect(ReturningUserService.lastActiveProgramId, 'prog-abc');
+      expect(prefs.getString(lastProgramKey), 'prog-abc');
+    });
+
+    test('overwrites previous program ID', () async {
+      await reinit({lastProgramKey: 'prog-old'});
+      ReturningUserService.recordLastActiveProgram('prog-new');
+      expect(ReturningUserService.lastActiveProgramId, 'prog-new');
+    });
+  });
+
+  group('ReturningUserService - daysSinceLastWorkout', () {
+    test('returns 0 when no workout logged', () async {
+      await reinit({});
+      expect(ReturningUserService.daysSinceLastWorkout, 0);
+    });
+
+    test('returns correct days since last workout', () async {
+      final tenDaysAgo =
+          DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
+      await reinit({lastWorkoutKey: tenDaysAgo});
+      expect(ReturningUserService.daysSinceLastWorkout, 10);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **ReturningUserService** — detects 30+ day inactivity using the last workout date already tracked by `LifecycleNotificationService`. Stores last-active program ID and per-cycle dismissal state in SharedPreferences.
- **ReturningUserBanner** — dismissible card shown above the program list on first return session. Offers "Start Fresh Week" (creates the next named week in the last active program via a one-shot Firestore fetch) or "Pick Up Here" (navigates to the program). The X button suppresses it for the current inactivity cycle.
- **`FirestoreService.getWeeksOnce`** — single `Future<List<Week>>` fetch used to determine correct week order without setting up a stream subscription.
- **`ProgramProvider.createWeekForProgram`** — creates the next week in any program without requiring it to be selected (uses `getWeeksOnce` internally).
- **`ConsolidatedWorkoutScreen`** — records last active program ID on every workout open so the banner always has the correct program.

## Notes
- Data persistence assurance (Firestore never deletes on inactivity) is already true by design — no code change needed.
- `ReturningUserService` reads `overload_lifecycle_last_workout_date` written by `LifecycleNotificationService` — no duplication of storage.

## Test plan
- [ ] Unit tests cover `shouldShowPrompt` for all conditions (no workout, < 30 days, ≥ 30 days, dismissed, stale dismissal)
- [ ] `dismiss()` suppresses prompt, `recordLastActiveProgram` persists ID
- [ ] `daysSinceLastWorkout` returns correct value
- [ ] CI passes

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)