### PR TITLE
[Task] Implement SubscriptionProvider and register in app (#437)

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -15,6 +15,7 @@ import 'providers/program_provider.dart';
 import 'providers/theme_provider.dart';
 import 'providers/weight_unit_provider.dart';
 import 'providers/exercise_library_provider.dart';
+import 'providers/subscription_provider.dart';
 import 'providers/template_provider.dart';
 import 'screens/auth/auth_wrapper.dart';
 import 'services/app_analytics_service.dart';
@@ -160,6 +161,10 @@ class OverloadApp extends StatelessWidget {
             // The provider constructor handles auto-loading data when userId is set
             return TemplateProvider(userId);
           },
+        ),
+        ChangeNotifierProxyProvider<app_auth.AuthProvider, SubscriptionProvider>(
+          create: (_) => SubscriptionProvider(),
+          update: (_, auth, sub) => sub!..update(auth),
         ),
       ],
       child: Consumer<ThemeProvider>(

--- a/fittrack/lib/providers/subscription_provider.dart
+++ b/fittrack/lib/providers/subscription_provider.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import '../models/subscription.dart';
+import '../providers/auth_provider.dart';
+import '../services/subscription_service.dart';
+
+/// Manages subscription state and exposes computed limits used throughout
+/// the app to gate premium features.
+///
+/// Registered as a [ChangeNotifierProxyProvider] so it reacts to auth state
+/// changes — resetting when the user signs out and re-initialising when they
+/// sign in.
+class SubscriptionProvider extends ChangeNotifier {
+  SubscriptionInfo _subscriptionInfo = SubscriptionInfo.free();
+  bool _isProOverride = false;
+  bool _isLoading = false;
+  String? _error;
+  StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
+  bool _disposed = false;
+
+  // --- Public getters ---
+
+  /// True when the user has an active Pro subscription or the developer bypass.
+  bool get isPro => _isProOverride || _subscriptionInfo.isPro;
+  bool get isFree => !isPro;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  SubscriptionInfo get subscriptionInfo => _subscriptionInfo;
+  bool get isProOverride => _isProOverride;
+
+  // Computed limits used by gating logic throughout the app.
+  int get maxPrograms => isPro ? 999 : 3;
+  int get maxCustomExercises => isPro ? 50 : 5;
+
+  List<ProductDetails> get products => SubscriptionService.instance.products;
+  ProductDetails? get monthlyProduct =>
+      SubscriptionService.instance.monthlyProduct;
+  ProductDetails? get annualProduct =>
+      SubscriptionService.instance.annualProduct;
+
+  // --- ProxyProvider update ---
+
+  void update(AuthProvider auth) {
+    final userId = auth.user?.uid;
+    final profile = auth.userProfile;
+    if (userId == null) {
+      _reset();
+      return;
+    }
+    _isProOverride = profile?.isProOverride ?? false;
+    _initialize(userId);
+  }
+
+  // --- Initialisation ---
+
+  Future<void> _initialize(String userId) async {
+    // Fast path: load cached Firestore status before IAP initialises.
+    final cached =
+        await SubscriptionService.instance.loadFromFirestore(userId);
+    if (cached != null) {
+      _subscriptionInfo = cached;
+      _safeNotify();
+    }
+
+    // Initialise IAP plugin and load store products.
+    await SubscriptionService.instance.initialize();
+
+    // Start listening to purchase stream.
+    _purchaseSubscription?.cancel();
+    _purchaseSubscription = SubscriptionService.instance.purchaseStream
+        .listen((purchases) => _handlePurchaseUpdates(purchases, userId));
+
+    // Silent restore to pick up any active subscriptions on sign-in / re-launch.
+    await SubscriptionService.instance.restorePurchases();
+  }
+
+  // --- Purchase stream handler ---
+
+  Future<void> _handlePurchaseUpdates(
+      List<PurchaseDetails> purchases, String userId) async {
+    for (final purchase in purchases) {
+      switch (purchase.status) {
+        case PurchaseStatus.purchased:
+        case PurchaseStatus.restored:
+          final info = SubscriptionInfo(
+            tier: SubscriptionTier.pro,
+            status: SubscriptionStatus.active,
+            productId: purchase.productID,
+            platform: Platform.isIOS ? 'ios' : 'android',
+          );
+          _subscriptionInfo = info;
+          await SubscriptionService.instance.syncToFirestore(userId, info);
+          await SubscriptionService.instance.completePurchase(purchase);
+          _isLoading = false;
+          _safeNotify();
+
+        case PurchaseStatus.error:
+          _error = purchase.error?.message ?? 'Purchase failed';
+          _isLoading = false;
+          _safeNotify();
+
+        case PurchaseStatus.pending:
+          _isLoading = true;
+          _safeNotify();
+
+        case PurchaseStatus.canceled:
+          _isLoading = false;
+          _safeNotify();
+      }
+    }
+  }
+
+  // --- Purchase actions ---
+
+  Future<void> purchaseMonthly() async {
+    final product = monthlyProduct;
+    if (product == null) return;
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.buySubscription(product);
+  }
+
+  Future<void> purchaseAnnual() async {
+    final product = annualProduct;
+    if (product == null) return;
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.buySubscription(product);
+  }
+
+  Future<void> restorePurchases() async {
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.restorePurchases();
+  }
+
+  void clearError() {
+    _error = null;
+    _safeNotify();
+  }
+
+  /// Sets subscription state directly without triggering IAP — for tests only.
+  @visibleForTesting
+  void setSubscriptionInfoForTest(SubscriptionInfo info) {
+    _subscriptionInfo = info;
+    _safeNotify();
+  }
+
+  /// Sets the pro override flag directly — for tests only.
+  @visibleForTesting
+  void setProOverrideForTest({required bool value}) {
+    _isProOverride = value;
+    _safeNotify();
+  }
+
+  // --- Reset on sign-out ---
+
+  void _reset() {
+    _subscriptionInfo = SubscriptionInfo.free();
+    _isProOverride = false;
+    _isLoading = false;
+    _error = null;
+    _purchaseSubscription?.cancel();
+    _purchaseSubscription = null;
+    _safeNotify();
+  }
+
+  void _safeNotify() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _purchaseSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -10,13 +10,17 @@ import '../models/subscription.dart';
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
 
-  final FirebaseFirestore _firestore;
+  // Null means "use FirebaseFirestore.instance" — resolved lazily so the
+  // static singleton can be constructed in tests without Firebase initialised.
+  final FirebaseFirestore? _injectedFirestore;
+  FirebaseFirestore get _firestore =>
+      _injectedFirestore ?? FirebaseFirestore.instance;
 
-  SubscriptionService._() : _firestore = FirebaseFirestore.instance;
+  SubscriptionService._() : _injectedFirestore = null;
 
   @visibleForTesting
   SubscriptionService.forTest(FirebaseFirestore firestore)
-      : _firestore = firestore;
+      : _injectedFirestore = firestore;
 
   static const String monthlyId = 'fittrack_pro_monthly';
   static const String annualId = 'fittrack_pro_annual';

--- a/fittrack/test/providers/subscription_provider_test.dart
+++ b/fittrack/test/providers/subscription_provider_test.dart
@@ -1,0 +1,193 @@
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
+
+void main() {
+  late SubscriptionProvider provider;
+
+  setUp(() {
+    provider = SubscriptionProvider();
+  });
+
+  tearDown(() {
+    provider.dispose();
+  });
+
+  group('SubscriptionProvider - initial state', () {
+    test('starts as free tier', () {
+      expect(provider.isPro, isFalse);
+      expect(provider.isFree, isTrue);
+      expect(provider.subscriptionInfo.tier, SubscriptionTier.free);
+      expect(provider.subscriptionInfo.status, SubscriptionStatus.free);
+    });
+
+    test('starts with no loading state', () {
+      expect(provider.isLoading, isFalse);
+    });
+
+    test('starts with no error', () {
+      expect(provider.error, isNull);
+    });
+
+    test('isProOverride starts false', () {
+      expect(provider.isProOverride, isFalse);
+    });
+
+    test('products list starts empty', () {
+      expect(provider.products, isEmpty);
+    });
+
+    test('monthlyProduct starts null', () {
+      expect(provider.monthlyProduct, isNull);
+    });
+
+    test('annualProduct starts null', () {
+      expect(provider.annualProduct, isNull);
+    });
+  });
+
+  group('SubscriptionProvider - computed limits (free tier)', () {
+    test('maxPrograms is 3 for free', () {
+      expect(provider.maxPrograms, 3);
+    });
+
+    test('maxCustomExercises is 5 for free', () {
+      expect(provider.maxCustomExercises, 5);
+    });
+  });
+
+  group('SubscriptionProvider - computed limits (pro tier)', () {
+    setUp(() {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+    });
+
+    test('maxPrograms is 999 for pro', () {
+      expect(provider.maxPrograms, 999);
+    });
+
+    test('maxCustomExercises is 50 for pro', () {
+      expect(provider.maxCustomExercises, 50);
+    });
+
+    test('isPro is true', () {
+      expect(provider.isPro, isTrue);
+      expect(provider.isFree, isFalse);
+    });
+  });
+
+  group('SubscriptionProvider - isProOverride', () {
+    test('isPro is true when isProOverride set, even with free subscription', () {
+      provider.setProOverrideForTest(value: true);
+      expect(provider.isPro, isTrue);
+      expect(provider.isFree, isFalse);
+      expect(provider.isProOverride, isTrue);
+      // Underlying subscription is still free
+      expect(provider.subscriptionInfo.tier, SubscriptionTier.free);
+    });
+
+    test('isPro correct when both override and active subscription', () {
+      provider.setProOverrideForTest(value: true);
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+    });
+
+    test('maxPrograms is unlimited when override is set', () {
+      provider.setProOverrideForTest(value: true);
+      expect(provider.maxPrograms, 999);
+      expect(provider.maxCustomExercises, 50);
+    });
+  });
+
+  group('SubscriptionProvider - clearError', () {
+    test('clearError removes the error message', () {
+      // Simulate an error state by checking clearError works
+      // (error is set internally via purchase stream in production)
+      provider.clearError();
+      expect(provider.error, isNull);
+    });
+  });
+
+  group('SubscriptionProvider - notify on state changes', () {
+    test('notifies listeners when subscription info changes', () {
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+
+      expect(notified, isTrue);
+    });
+
+    test('notifies listeners when pro override changes', () {
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.setProOverrideForTest(value: true);
+
+      expect(notified, isTrue);
+    });
+  });
+
+  group('SubscriptionProvider - subscription status transitions', () {
+    test('expired subscription is treated as free', () {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.free,
+          status: SubscriptionStatus.expired,
+        ),
+      );
+      expect(provider.isPro, isFalse);
+      expect(provider.maxPrograms, 3);
+    });
+
+    test('trial subscription is treated as pro', () {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.trial,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+      expect(provider.maxPrograms, 999);
+    });
+
+    test('cancelled subscription reverts to free limits', () {
+      // First go pro
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+
+      // Then cancel
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.free,
+          status: SubscriptionStatus.cancelled,
+        ),
+      );
+      expect(provider.isPro, isFalse);
+      expect(provider.maxPrograms, 3);
+      expect(provider.maxCustomExercises, 5);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Creates `lib/providers/subscription_provider.dart` — `ChangeNotifierProxyProvider<AuthProvider, SubscriptionProvider>` that reacts to auth state changes
- On sign-in: loads cached Firestore subscription, initialises IAP, starts purchase stream listener, and silently restores purchases
- On sign-out: resets all state to free defaults and cancels purchase stream
- Exposes `isPro`, `isFree`, `maxPrograms` (3/999), `maxCustomExercises` (5/50) used by all gating tasks
- `isProOverride` propagated from `UserProfile.isProOverride` for developer bypass
- Registered in `main.dart` as `ChangeNotifierProxyProvider<AuthProvider, SubscriptionProvider>` after `TemplateProvider`
- 18 unit tests covering initial state, limit computation, override logic, status transitions, and listener notifications

## Test plan
- [ ] `subscription_provider_test.dart` — all 18 cases pass
- [ ] No analyzer warnings

Closes #437
Part of #434