### PR TITLE
feat(#444): block isProOverride client writes, allow subscription map

### DIFF
--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -40,10 +40,16 @@ service cloud.firestore {
       allow list: if isAdmin(); // admins may list users (support only)
 
       // Creation: only the authenticated user may create their own profile document
-      allow create: if isSignedIn() && request.auth.uid == userId && validUserProfile(request.resource.data);
+      // isProOverride is admin-only — clients cannot set it on create
+      allow create: if isSignedIn() && request.auth.uid == userId
+                    && validUserProfile(request.resource.data)
+                    && (isAdmin() || !request.resource.data.keys().hasAny(['isProOverride']));
 
       // Updates: owner or admin
-      allow update: if (isOwner(userId) || isAdmin()) && validUserProfile(request.resource.data);
+      // isProOverride is admin-only — clients cannot change it
+      allow update: if (isOwner(userId) || isAdmin())
+                    && validUserProfile(request.resource.data)
+                    && (isAdmin() || !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isProOverride']));
 
       // Deletion: admin only (safer than letting users delete their top-level node)
       allow delete: if isAdmin();
@@ -239,7 +245,8 @@ service cloud.firestore {
         && (data.email == null || isString(data.email))
         && (data.createdAt != null && isTimestamp(data.createdAt))
         && (data.lastLogin == null || isTimestamp(data.lastLogin))
-        && (data.settings == null || data.settings is map);
+        && (data.settings == null || data.settings is map)
+        && (data.subscription == null || data.subscription is map);
     }
 
     function validProgram(data) {


### PR DESCRIPTION
## Summary
- Adds `isProOverride` write protection to the user document — clients (including authenticated users) cannot set or change this field; only the Admin SDK can
- Uses `.keys().hasAny(['isProOverride'])` guard on `create` and `.diff().affectedKeys().hasAny(['isProOverride'])` guard on `update`
- Extends `validUserProfile` validator to accept the `subscription` map field, which the client-side IAP flow writes to persist purchase status

## Security rationale
`isProOverride` is used to grant developer/test Pro access without an IAP purchase. Without this rule, a malicious user could self-grant Pro by writing `isProOverride: true` via the client SDK. The guard ensures only the Firebase Admin SDK (used by the backend or Firebase Console) can set this flag.

## Test plan
- [ ] CI passes (Firestore rules unit tests if any, otherwise integration test suite)
- [ ] Confirm subscription map writes succeed for a normal owner update
- [ ] Confirm isProOverride write is rejected for a normal owner update (manually via Firestore emulator if needed)

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)