### PR TITLE
feat: paywall brand copy, savings callout, and legal links (#448, #473)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,5 @@ key.properties
 
 # Private business documents (not for public repo)
 Docs/SecurityReports/
-Docs/Monetization_Strategy.md
+Docs/Monetization*.md
 Docs/ProductionReadiness.md

--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -40,10 +40,16 @@ service cloud.firestore {
       allow list: if isAdmin(); // admins may list users (support only)
 
       // Creation: only the authenticated user may create their own profile document
-      allow create: if isSignedIn() && request.auth.uid == userId && validUserProfile(request.resource.data);
+      // isProOverride is admin-only — clients cannot set it on create
+      allow create: if isSignedIn() && request.auth.uid == userId
+                    && validUserProfile(request.resource.data)
+                    && (isAdmin() || !request.resource.data.keys().hasAny(['isProOverride']));
 
       // Updates: owner or admin
-      allow update: if (isOwner(userId) || isAdmin()) && validUserProfile(request.resource.data);
+      // isProOverride is admin-only — clients cannot change it
+      allow update: if (isOwner(userId) || isAdmin())
+                    && validUserProfile(request.resource.data)
+                    && (isAdmin() || !request.resource.data.diff(resource.data).affectedKeys().hasAny(['isProOverride']));
 
       // Deletion: admin only (safer than letting users delete their top-level node)
       allow delete: if isAdmin();
@@ -239,7 +245,8 @@ service cloud.firestore {
         && (data.email == null || isString(data.email))
         && (data.createdAt != null && isTimestamp(data.createdAt))
         && (data.lastLogin == null || isTimestamp(data.lastLogin))
-        && (data.settings == null || data.settings is map);
+        && (data.settings == null || data.settings is map)
+        && (data.subscription == null || data.subscription is map);
     }
 
     function validProgram(data) {

--- a/fittrack/lib/converters/user_profile_converter.dart
+++ b/fittrack/lib/converters/user_profile_converter.dart
@@ -22,8 +22,12 @@ class UserProfileConverter {
       displayName: data['displayName'],
       email: data['email'],
       createdAt: (data['createdAt'] as Timestamp).toDate(),
-      lastLogin: data['lastLogin'] != null ? (data['lastLogin'] as Timestamp).toDate() : null,
+      lastLogin: data['lastLogin'] != null
+          ? (data['lastLogin'] as Timestamp).toDate()
+          : null,
       settings: data['settings'],
+      // isProOverride is read-only from client — never written back to Firestore
+      isProOverride: (data['isProOverride'] as bool?) ?? false,
     );
   }
 }

--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -15,6 +15,7 @@ import 'providers/program_provider.dart';
 import 'providers/theme_provider.dart';
 import 'providers/weight_unit_provider.dart';
 import 'providers/exercise_library_provider.dart';
+import 'providers/subscription_provider.dart';
 import 'providers/template_provider.dart';
 import 'screens/auth/auth_wrapper.dart';
 import 'services/app_analytics_service.dart';
@@ -160,6 +161,10 @@ class OverloadApp extends StatelessWidget {
             // The provider constructor handles auto-loading data when userId is set
             return TemplateProvider(userId);
           },
+        ),
+        ChangeNotifierProxyProvider<app_auth.AuthProvider, SubscriptionProvider>(
+          create: (_) => SubscriptionProvider(),
+          update: (_, auth, sub) => sub!..update(auth),
         ),
       ],
       child: Consumer<ThemeProvider>(

--- a/fittrack/lib/models/subscription.dart
+++ b/fittrack/lib/models/subscription.dart
@@ -1,0 +1,54 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+enum SubscriptionTier { free, pro }
+
+enum SubscriptionStatus { unknown, free, trial, active, expired, cancelled }
+
+class SubscriptionInfo {
+  final SubscriptionTier tier;
+  final SubscriptionStatus status;
+  final DateTime? expiresAt;
+  final String? productId;
+  final String? platform;
+
+  const SubscriptionInfo({
+    required this.tier,
+    required this.status,
+    this.expiresAt,
+    this.productId,
+    this.platform,
+  });
+
+  bool get isPro => tier == SubscriptionTier.pro;
+
+  factory SubscriptionInfo.free() => const SubscriptionInfo(
+        tier: SubscriptionTier.free,
+        status: SubscriptionStatus.free,
+      );
+
+  Map<String, dynamic> toFirestore() => {
+        'status': status.name,
+        'productId': productId,
+        'platform': platform,
+        'expiresAt':
+            expiresAt != null ? Timestamp.fromDate(expiresAt!) : null,
+        'updatedAt': FieldValue.serverTimestamp(),
+      };
+
+  factory SubscriptionInfo.fromFirestore(Map<String, dynamic> data) {
+    final statusStr = data['status'] as String? ?? 'free';
+    final status = SubscriptionStatus.values.firstWhere(
+      (s) => s.name == statusStr,
+      orElse: () => SubscriptionStatus.unknown,
+    );
+    final isActive = status == SubscriptionStatus.active ||
+        status == SubscriptionStatus.trial;
+    return SubscriptionInfo(
+      tier: isActive ? SubscriptionTier.pro : SubscriptionTier.free,
+      status: status,
+      productId: data['productId'] as String?,
+      platform: data['platform'] as String?,
+      expiresAt: (data['expiresAt'] as Timestamp?)?.toDate(),
+    );
+  }
+}

--- a/fittrack/lib/models/user_profile.dart
+++ b/fittrack/lib/models/user_profile.dart
@@ -7,6 +7,8 @@ class UserProfile {
   final DateTime createdAt;
   final DateTime? lastLogin;
   final Map<String, dynamic>? settings;
+  // Read-only from client — set via Firebase Console only. Blocked by Firestore rules on client write.
+  final bool isProOverride;
 
   UserProfile({
     required this.id,
@@ -15,6 +17,7 @@ class UserProfile {
     required this.createdAt,
     this.lastLogin,
     this.settings,
+    this.isProOverride = false,
   });
 
   factory UserProfile.fromFirestore(DocumentSnapshot doc) {
@@ -24,10 +27,11 @@ class UserProfile {
       displayName: data['displayName'],
       email: data['email'],
       createdAt: (data['createdAt'] as Timestamp).toDate(),
-      lastLogin: data['lastLogin'] != null 
-          ? (data['lastLogin'] as Timestamp).toDate() 
+      lastLogin: data['lastLogin'] != null
+          ? (data['lastLogin'] as Timestamp).toDate()
           : null,
       settings: data['settings'] as Map<String, dynamic>?,
+      isProOverride: (data['isProOverride'] as bool?) ?? false,
     );
   }
 
@@ -54,6 +58,7 @@ class UserProfile {
       createdAt: createdAt,
       lastLogin: lastLogin ?? this.lastLogin,
       settings: settings ?? this.settings,
+      isProOverride: isProOverride,
     );
   }
 }

--- a/fittrack/lib/providers/subscription_provider.dart
+++ b/fittrack/lib/providers/subscription_provider.dart
@@ -1,0 +1,182 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import '../models/subscription.dart';
+import '../providers/auth_provider.dart';
+import '../services/subscription_service.dart';
+
+/// Manages subscription state and exposes computed limits used throughout
+/// the app to gate premium features.
+///
+/// Registered as a [ChangeNotifierProxyProvider] so it reacts to auth state
+/// changes — resetting when the user signs out and re-initialising when they
+/// sign in.
+class SubscriptionProvider extends ChangeNotifier {
+  SubscriptionInfo _subscriptionInfo = SubscriptionInfo.free();
+  bool _isProOverride = false;
+  bool _isLoading = false;
+  String? _error;
+  StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
+  bool _disposed = false;
+
+  // --- Public getters ---
+
+  /// True when the user has an active Pro subscription or the developer bypass.
+  bool get isPro => _isProOverride || _subscriptionInfo.isPro;
+  bool get isFree => !isPro;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  SubscriptionInfo get subscriptionInfo => _subscriptionInfo;
+  bool get isProOverride => _isProOverride;
+
+  // Computed limits used by gating logic throughout the app.
+  int get maxPrograms => isPro ? 999 : 3;
+  int get maxCustomExercises => isPro ? 50 : 5;
+
+  List<ProductDetails> get products => SubscriptionService.instance.products;
+  ProductDetails? get monthlyProduct =>
+      SubscriptionService.instance.monthlyProduct;
+  ProductDetails? get annualProduct =>
+      SubscriptionService.instance.annualProduct;
+
+  // --- ProxyProvider update ---
+
+  void update(AuthProvider auth) {
+    final userId = auth.user?.uid;
+    final profile = auth.userProfile;
+    if (userId == null) {
+      _reset();
+      return;
+    }
+    _isProOverride = profile?.isProOverride ?? false;
+    _initialize(userId);
+  }
+
+  // --- Initialisation ---
+
+  Future<void> _initialize(String userId) async {
+    // Fast path: load cached Firestore status before IAP initialises.
+    final cached =
+        await SubscriptionService.instance.loadFromFirestore(userId);
+    if (cached != null) {
+      _subscriptionInfo = cached;
+      _safeNotify();
+    }
+
+    // Initialise IAP plugin and load store products.
+    await SubscriptionService.instance.initialize();
+
+    // Start listening to purchase stream.
+    _purchaseSubscription?.cancel();
+    _purchaseSubscription = SubscriptionService.instance.purchaseStream
+        .listen((purchases) => _handlePurchaseUpdates(purchases, userId));
+
+    // Silent restore to pick up any active subscriptions on sign-in / re-launch.
+    await SubscriptionService.instance.restorePurchases();
+  }
+
+  // --- Purchase stream handler ---
+
+  Future<void> _handlePurchaseUpdates(
+      List<PurchaseDetails> purchases, String userId) async {
+    for (final purchase in purchases) {
+      switch (purchase.status) {
+        case PurchaseStatus.purchased:
+        case PurchaseStatus.restored:
+          final info = SubscriptionInfo(
+            tier: SubscriptionTier.pro,
+            status: SubscriptionStatus.active,
+            productId: purchase.productID,
+            platform: Platform.isIOS ? 'ios' : 'android',
+          );
+          _subscriptionInfo = info;
+          await SubscriptionService.instance.syncToFirestore(userId, info);
+          await SubscriptionService.instance.completePurchase(purchase);
+          _isLoading = false;
+          _safeNotify();
+
+        case PurchaseStatus.error:
+          _error = purchase.error?.message ?? 'Purchase failed';
+          _isLoading = false;
+          _safeNotify();
+
+        case PurchaseStatus.pending:
+          _isLoading = true;
+          _safeNotify();
+
+        case PurchaseStatus.canceled:
+          _isLoading = false;
+          _safeNotify();
+      }
+    }
+  }
+
+  // --- Purchase actions ---
+
+  Future<void> purchaseMonthly() async {
+    final product = monthlyProduct;
+    if (product == null) return;
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.buySubscription(product);
+  }
+
+  Future<void> purchaseAnnual() async {
+    final product = annualProduct;
+    if (product == null) return;
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.buySubscription(product);
+  }
+
+  Future<void> restorePurchases() async {
+    _isLoading = true;
+    _safeNotify();
+    await SubscriptionService.instance.restorePurchases();
+  }
+
+  void clearError() {
+    _error = null;
+    _safeNotify();
+  }
+
+  /// Sets subscription state directly without triggering IAP — for tests only.
+  @visibleForTesting
+  void setSubscriptionInfoForTest(SubscriptionInfo info) {
+    _subscriptionInfo = info;
+    _safeNotify();
+  }
+
+  /// Sets the pro override flag directly — for tests only.
+  @visibleForTesting
+  void setProOverrideForTest({required bool value}) {
+    _isProOverride = value;
+    _safeNotify();
+  }
+
+  // --- Reset on sign-out ---
+
+  void _reset() {
+    _subscriptionInfo = SubscriptionInfo.free();
+    _isProOverride = false;
+    _isLoading = false;
+    _error = null;
+    _purchaseSubscription?.cancel();
+    _purchaseSubscription = null;
+    _safeNotify();
+  }
+
+  void _safeNotify() {
+    if (!_disposed) notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _purchaseSubscription?.cancel();
+    super.dispose();
+  }
+}

--- a/fittrack/lib/screens/analytics/analytics_screen.dart
+++ b/fittrack/lib/screens/analytics/analytics_screen.dart
@@ -117,11 +117,13 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
               children: [
                 OverviewTab(analyticsService: widget.analyticsService),
                 const ProGateWidget(
-                  paywallHeadline: 'Track every rep\'s progress',
+                  paywallHeadline: 'Every rep tells a story.',
+                  paywallSubtext: 'Track exercise progress, 1RM trends, and volume over time.',
                   child: ExerciseTab(),
                 ),
                 const ProGateWidget(
-                  paywallHeadline: 'See your full training history',
+                  paywallHeadline: 'Your PR history is in there.',
+                  paywallSubtext: 'Unlock your full training history — all time.',
                   child: TrendsTab(),
                 ),
               ],

--- a/fittrack/lib/screens/analytics/analytics_screen.dart
+++ b/fittrack/lib/screens/analytics/analytics_screen.dart
@@ -5,6 +5,7 @@ import '../../providers/program_provider.dart';
 import '../../services/analytics_service.dart';
 import '../../widgets/error_display.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
+import '../../widgets/pro_gate_widget.dart';
 import 'components/overview_tab.dart';
 import 'components/exercise_tab.dart';
 import 'components/trends_tab.dart';
@@ -115,8 +116,14 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
             body: TabBarView(
               children: [
                 OverviewTab(analyticsService: widget.analyticsService),
-                const ExerciseTab(),
-                const TrendsTab(),
+                const ProGateWidget(
+                  paywallHeadline: 'Track every rep\'s progress',
+                  child: ExerciseTab(),
+                ),
+                const ProGateWidget(
+                  paywallHeadline: 'See your full training history',
+                  child: TrendsTab(),
+                ),
               ],
             ),
             bottomNavigationBar: const GlobalBottomNavBar(

--- a/fittrack/lib/screens/profile/my_exercises_screen.dart
+++ b/fittrack/lib/screens/profile/my_exercises_screen.dart
@@ -181,7 +181,11 @@ class MyExercisesScreen extends StatelessWidget {
     final sub = context.read<SubscriptionProvider>();
     final provider = context.read<ExerciseLibraryProvider>();
     if (sub.isFree && provider.customExerciseCount >= sub.maxCustomExercises) {
-      PaywallScreen.show(context, headline: 'Create up to 50 custom exercises');
+      PaywallScreen.show(
+        context,
+        headline: 'Build your full exercise library.',
+        subtext: 'Create up to 50 custom exercises with Pro.',
+      );
       return;
     }
     Navigator.of(context).push(

--- a/fittrack/lib/screens/profile/my_exercises_screen.dart
+++ b/fittrack/lib/screens/profile/my_exercises_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/exercise_library_provider.dart';
+import '../../providers/subscription_provider.dart';
 import '../../models/custom_exercise.dart';
 import '../exercises/custom_exercise_form_screen.dart';
+import '../subscription/paywall_screen.dart';
 
 /// Screen for managing the user's custom exercises.
 /// Accessible from the Profile/Settings screen.
@@ -16,8 +18,10 @@ class MyExercisesScreen extends StatelessWidget {
         title: const Text('My Exercises'),
         elevation: 0,
       ),
-      body: Consumer<ExerciseLibraryProvider>(
-        builder: (context, provider, child) {
+      body: Consumer2<ExerciseLibraryProvider, SubscriptionProvider>(
+        builder: (context, provider, sub, child) {
+          final limit = sub.maxCustomExercises;
+          final atLimit = provider.customExerciseCount >= limit;
           if (provider.isLoading) {
             return const Center(
               child: CircularProgressIndicator(),
@@ -71,7 +75,7 @@ class MyExercisesScreen extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     Text(
-                      '${provider.customExerciseCount}/$maxCustomExercises exercises',
+                      '${provider.customExerciseCount}/$limit exercises',
                       style: Theme.of(context).textTheme.bodyMedium?.copyWith(
                             color: Theme.of(context)
                                 .colorScheme
@@ -79,7 +83,7 @@ class MyExercisesScreen extends StatelessWidget {
                                 .withValues(alpha: 0.6),
                           ),
                     ),
-                    if (provider.canCreateCustomExercise)
+                    if (!atLimit)
                       TextButton.icon(
                         onPressed: () => _navigateToCreate(context),
                         icon: const Icon(Icons.add, size: 18),
@@ -108,11 +112,10 @@ class MyExercisesScreen extends StatelessWidget {
           );
         },
       ),
-      floatingActionButton: Consumer<ExerciseLibraryProvider>(
-        builder: (context, provider, child) {
-          if (!provider.canCreateCustomExercise) {
-            return const SizedBox.shrink();
-          }
+      floatingActionButton: Consumer2<ExerciseLibraryProvider, SubscriptionProvider>(
+        builder: (context, provider, sub, child) {
+          final atLimit = provider.customExerciseCount >= sub.maxCustomExercises;
+          if (atLimit) return const SizedBox.shrink();
           return FloatingActionButton(
             onPressed: () => _navigateToCreate(context),
             child: const Icon(Icons.add),
@@ -175,6 +178,12 @@ class MyExercisesScreen extends StatelessWidget {
   }
 
   void _navigateToCreate(BuildContext context) {
+    final sub = context.read<SubscriptionProvider>();
+    final provider = context.read<ExerciseLibraryProvider>();
+    if (sub.isFree && provider.customExerciseCount >= sub.maxCustomExercises) {
+      PaywallScreen.show(context, headline: 'Create up to 50 custom exercises');
+      return;
+    }
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (_) => const CustomExerciseFormScreen(),

--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -95,7 +95,7 @@ class ProfileScreen extends StatelessWidget {
                     onTap: () => PaywallScreen.show(
                       context,
                       headline: 'Unlock Overload Pro',
-                      subtext: 'Everything you need to train smarter.',
+                      subtext: 'Unlimited programs. Full analytics. \$39.99/year.',
                     ),
                   );
                 },

--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../providers/subscription_provider.dart';
 import '../../models/navigation_section.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
+import '../subscription/paywall_screen.dart';
+import '../subscription/subscription_management_screen.dart';
 import 'settings_screen.dart';
 
 class ProfileScreen extends StatelessWidget {
@@ -68,8 +71,37 @@ class ProfileScreen extends StatelessWidget {
                 ),
               ),
               
-              // Menu Items
+              // Subscription entry
               const SizedBox(height: 16),
+              Consumer<SubscriptionProvider>(
+                builder: (context, sub, _) {
+                  if (sub.isPro) {
+                    return _MenuItem(
+                      icon: Icons.workspace_premium,
+                      title: 'Overload Pro',
+                      subtitle: sub.isProOverride ? 'Developer access' : 'Active subscription',
+                      onTap: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => const SubscriptionManagementScreen(),
+                        ),
+                      ),
+                    );
+                  }
+                  return _MenuItem(
+                    icon: Icons.workspace_premium_outlined,
+                    title: 'Upgrade to Overload Pro',
+                    subtitle: 'Unlimited programs, full analytics & more',
+                    onTap: () => PaywallScreen.show(
+                      context,
+                      headline: 'Unlock Overload Pro',
+                      subtext: 'Everything you need to train smarter.',
+                    ),
+                  );
+                },
+              ),
+
+              // Menu Items
               _MenuItem(
                 icon: Icons.person_outline,
                 title: 'Edit Profile',
@@ -164,6 +196,7 @@ class ProfileScreen extends StatelessWidget {
 class _MenuItem extends StatelessWidget {
   final IconData icon;
   final String title;
+  final String? subtitle;
   final VoidCallback onTap;
   final Color? textColor;
   final Color? iconColor;
@@ -172,6 +205,7 @@ class _MenuItem extends StatelessWidget {
     required this.icon,
     required this.title,
     required this.onTap,
+    this.subtitle,
     this.textColor,
     this.iconColor,
   });
@@ -190,6 +224,14 @@ class _MenuItem extends StatelessWidget {
           fontWeight: FontWeight.w500,
         ),
       ),
+      subtitle: subtitle != null
+          ? Text(
+              subtitle!,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6),
+                  ),
+            )
+          : null,
       trailing: Icon(
         Icons.chevron_right,
         color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.3),

--- a/fittrack/lib/screens/programs/program_detail_screen.dart
+++ b/fittrack/lib/screens/programs/program_detail_screen.dart
@@ -338,7 +338,11 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
   void _saveProgramAsTemplate(BuildContext context) async {
     final sub = context.read<SubscriptionProvider>();
     if (sub.isFree) {
-      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      PaywallScreen.show(
+        context,
+        headline: 'That workout\'s good enough to save.',
+        subtext: 'Pro gives you unlimited custom templates.',
+      );
       return;
     }
 

--- a/fittrack/lib/screens/programs/program_detail_screen.dart
+++ b/fittrack/lib/screens/programs/program_detail_screen.dart
@@ -7,9 +7,11 @@ import '../../models/week.dart';
 import '../../models/navigation_section.dart';
 import '../../models/templates/templates.dart';
 import '../../services/firestore_service.dart';
+import '../../providers/subscription_provider.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/create_options_sheet.dart';
+import '../subscription/paywall_screen.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
 import '../weeks/weeks_screen.dart';
@@ -334,6 +336,12 @@ class _ProgramDetailScreenState extends State<ProgramDetailScreen> {
   }
 
   void _saveProgramAsTemplate(BuildContext context) async {
+    final sub = context.read<SubscriptionProvider>();
+    if (sub.isFree) {
+      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      return;
+    }
+
     final programProvider = Provider.of<ProgramProvider>(context, listen: false);
     final templateProvider = Provider.of<TemplateProvider>(context, listen: false);
     final firestoreService = FirestoreService.instance;

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -132,8 +132,8 @@ class ProgramsScreen extends StatelessWidget {
     if (sub.isFree && programCount >= sub.maxPrograms) {
       PaywallScreen.show(
         context,
-        headline: 'Unlock unlimited programs',
-        subtext: 'You\'ve reached the free plan limit of ${sub.maxPrograms} programs.',
+        headline: 'You\'ve built 3 programs. Serious lifters run more.',
+        subtext: 'Unlock unlimited programs with Pro.',
       );
       return;
     }
@@ -209,7 +209,8 @@ class ProgramsScreen extends StatelessWidget {
                 if (sub.isFree && template.isPrebuilt) {
                   PaywallScreen.show(
                     context,
-                    headline: 'Access 6+ expert program templates',
+                    headline: 'Start with an expert-built program.',
+                    subtext: '6+ structured programs included with Pro.',
                   );
                   return;
                 }

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -12,6 +12,8 @@ import '../../widgets/create_options_sheet.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
 import '../../widgets/returning_user_banner.dart';
+import '../../providers/subscription_provider.dart';
+import '../subscription/paywall_screen.dart';
 import 'program_detail_screen.dart';
 import 'create_program_screen.dart';
 
@@ -125,6 +127,17 @@ class ProgramsScreen extends StatelessWidget {
   }
 
   void _navigateToCreateProgram(BuildContext context) async {
+    final sub = context.read<SubscriptionProvider>();
+    final programCount = context.read<ProgramProvider>().programs.length;
+    if (sub.isFree && programCount >= sub.maxPrograms) {
+      PaywallScreen.show(
+        context,
+        headline: 'Unlock unlimited programs',
+        subtext: 'You\'ve reached the free plan limit of ${sub.maxPrograms} programs.',
+      );
+      return;
+    }
+
     final option = await CreateOptionsSheet.show(
       context,
       itemType: 'Program',

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -205,6 +205,14 @@ class ProgramsScreen extends StatelessWidget {
                 trailing: const Icon(Icons.chevron_right),
               ),
               onSelect: (template) async {
+                final sub = context.read<SubscriptionProvider>();
+                if (sub.isFree && template.isPrebuilt) {
+                  PaywallScreen.show(
+                    context,
+                    headline: 'Access 6+ expert program templates',
+                  );
+                  return;
+                }
                 // Show preview sheet
                 final confirmed = await ProgramTemplatePreviewSheet.show(
                   context,

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../../providers/subscription_provider.dart';
 
 /// Paywall modal bottom sheet shown when a user hits a feature gate.
@@ -116,6 +117,7 @@ class PaywallScreen extends StatelessWidget {
                   _PlanCard(
                     label: 'Annual',
                     badge: 'RECOMMENDED',
+                    savings: 'Save 52% vs monthly',
                     price: sub.annualProduct?.price ?? '\$39.99/year',
                     detail: 'Billed annually · 14-day free trial',
                     isRecommended: true,
@@ -162,13 +164,49 @@ class PaywallScreen extends StatelessWidget {
                   child: const Text('Already subscribed? Restore purchases'),
                 ),
 
-                // Legal footnote
-                Text(
-                  'By subscribing you agree to our Terms of Service and Privacy Policy.',
-                  style: textTheme.bodySmall?.copyWith(
-                    color: colorScheme.onSurface.withValues(alpha: 0.5),
-                  ),
-                  textAlign: TextAlign.center,
+                // Legal footnote with tappable links
+                Wrap(
+                  alignment: WrapAlignment.center,
+                  children: [
+                    Text(
+                      'By subscribing you agree to our ',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () => _launchUrl('https://overloadapp.com/terms'),
+                      child: Text(
+                        'Terms of Service',
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.primary,
+                          decoration: TextDecoration.underline,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      ' and ',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () => _launchUrl('https://overloadapp.com/privacy'),
+                      child: Text(
+                        'Privacy Policy',
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.primary,
+                          decoration: TextDecoration.underline,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      '.',
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurface.withValues(alpha: 0.7),
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),
@@ -176,6 +214,13 @@ class PaywallScreen extends StatelessWidget {
         );
       },
     );
+  }
+}
+
+Future<void> _launchUrl(String url) async {
+  final uri = Uri.parse(url);
+  if (await canLaunchUrl(uri)) {
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
   }
 }
 
@@ -193,6 +238,7 @@ const List<String> _benefits = [
 class _PlanCard extends StatelessWidget {
   final String label;
   final String? badge;
+  final String? savings;
   final String price;
   final String detail;
   final bool isRecommended;
@@ -201,6 +247,7 @@ class _PlanCard extends StatelessWidget {
   const _PlanCard({
     required this.label,
     this.badge,
+    this.savings,
     required this.price,
     required this.detail,
     required this.isRecommended,
@@ -262,6 +309,16 @@ class _PlanCard extends StatelessWidget {
                       ],
                     ],
                   ),
+                  if (savings != null) ...[
+                    const SizedBox(height: 2),
+                    Text(
+                      savings!,
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colorScheme.primary,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                   const SizedBox(height: 4),
                   Text(
                     detail,

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -1,0 +1,287 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/subscription_provider.dart';
+
+/// Paywall modal bottom sheet shown when a user hits a feature gate.
+///
+/// Display via [PaywallScreen.show] — never push directly as a route.
+class PaywallScreen extends StatelessWidget {
+  final String headline;
+  final String? subtext;
+
+  const PaywallScreen({
+    super.key,
+    required this.headline,
+    this.subtext,
+  });
+
+  static Future<void> show(
+    BuildContext context, {
+    required String headline,
+    String? subtext,
+  }) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => PaywallScreen(headline: headline, subtext: subtext),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sub = context.watch<SubscriptionProvider>();
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.92,
+      minChildSize: 0.5,
+      maxChildSize: 0.95,
+      builder: (context, scrollController) {
+        return SingleChildScrollView(
+          controller: scrollController,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 12, 24, 32),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // Drag handle
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: colorScheme.onSurface.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 20),
+
+                // Title
+                Text(
+                  'Overload Pro',
+                  style: textTheme.titleMedium?.copyWith(
+                    color: colorScheme.primary,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+
+                // Context headline
+                Text(
+                  headline,
+                  style: textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                if (subtext != null) ...[
+                  const SizedBox(height: 8),
+                  Text(
+                    subtext!,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+                const SizedBox(height: 24),
+
+                // Benefits list
+                ..._benefits.map(
+                  (b) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Row(
+                      children: [
+                        Icon(Icons.check_circle,
+                            color: colorScheme.primary, size: 20),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(b, style: textTheme.bodyMedium),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 24),
+
+                if (sub.isLoading)
+                  const Center(child: CircularProgressIndicator())
+                else ...[
+                  // Annual plan card (recommended)
+                  _PlanCard(
+                    label: 'Annual',
+                    badge: 'RECOMMENDED',
+                    price: sub.annualProduct?.price ?? '\$39.99/year',
+                    detail: 'Billed annually · 14-day free trial',
+                    isRecommended: true,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      sub.purchaseAnnual();
+                    },
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Monthly plan card
+                  _PlanCard(
+                    label: 'Monthly',
+                    price: sub.monthlyProduct?.price ?? '\$6.99/month',
+                    detail: '14-day free trial',
+                    isRecommended: false,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      sub.purchaseMonthly();
+                    },
+                  ),
+                ],
+
+                if (sub.error != null) ...[
+                  const SizedBox(height: 12),
+                  Text(
+                    sub.error!,
+                    style: textTheme.bodySmall
+                        ?.copyWith(color: colorScheme.error),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+
+                const SizedBox(height: 20),
+
+                // Restore purchases
+                TextButton(
+                  onPressed: sub.isLoading
+                      ? null
+                      : () {
+                          Navigator.of(context).pop();
+                          sub.restorePurchases();
+                        },
+                  child: const Text('Already subscribed? Restore purchases'),
+                ),
+
+                // Legal footnote
+                Text(
+                  'By subscribing you agree to our Terms of Service and Privacy Policy.',
+                  style: textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onSurface.withValues(alpha: 0.5),
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+const List<String> _benefits = [
+  'Unlimited programs',
+  'Full analytics history — all time',
+  'Exercise progress charts & 1RM trends',
+  'Muscle group volume breakdown',
+  'Training trend charts',
+  'Access all pre-built program templates',
+  'Save unlimited custom templates',
+  'Up to 50 custom exercises',
+];
+
+class _PlanCard extends StatelessWidget {
+  final String label;
+  final String? badge;
+  final String price;
+  final String detail;
+  final bool isRecommended;
+  final VoidCallback onTap;
+
+  const _PlanCard({
+    required this.label,
+    this.badge,
+    required this.price,
+    required this.detail,
+    required this.isRecommended,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isRecommended
+                ? colorScheme.primary
+                : colorScheme.outline.withValues(alpha: 0.5),
+            width: isRecommended ? 2 : 1,
+          ),
+          color: isRecommended
+              ? colorScheme.primaryContainer.withValues(alpha: 0.3)
+              : null,
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        label,
+                        style: textTheme.titleMedium
+                            ?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      if (badge != null) ...[
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: colorScheme.primary,
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Text(
+                            badge!,
+                            style: textTheme.labelSmall?.copyWith(
+                              color: colorScheme.onPrimary,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    detail,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.6),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Text(
+              price,
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: colorScheme.primary,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fittrack/lib/screens/subscription/subscription_management_screen.dart
+++ b/fittrack/lib/screens/subscription/subscription_management_screen.dart
@@ -1,0 +1,140 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../models/subscription.dart';
+import '../../providers/subscription_provider.dart';
+
+class SubscriptionManagementScreen extends StatelessWidget {
+  const SubscriptionManagementScreen({super.key});
+
+  static const _iosManageUrl = 'https://apps.apple.com/account/subscriptions';
+  static const _androidManageUrl =
+      'https://play.google.com/store/account/subscriptions';
+
+  @override
+  Widget build(BuildContext context) {
+    final sub = context.watch<SubscriptionProvider>();
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Subscription'),
+        elevation: 0,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          // Plan header card
+          Container(
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: colorScheme.primaryContainer.withValues(alpha: 0.3),
+              borderRadius: BorderRadius.circular(16),
+              border: Border.all(color: colorScheme.primary.withValues(alpha: 0.3)),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.workspace_premium, color: colorScheme.primary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Overload Pro',
+                      style: textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: colorScheme.primary,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                if (sub.isProOverride) ...[
+                  Text('Developer access', style: textTheme.bodyMedium),
+                ] else ...[
+                  Text(
+                    _planLabel(sub.subscriptionInfo),
+                    style: textTheme.bodyMedium,
+                  ),
+                  if (sub.subscriptionInfo.expiresAt != null) ...[
+                    const SizedBox(height: 4),
+                    Text(
+                      _expiryLabel(sub.subscriptionInfo),
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurface.withValues(alpha: 0.6),
+                      ),
+                    ),
+                  ],
+                ],
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 32),
+
+          if (!sub.isProOverride) ...[
+            FilledButton.icon(
+              onPressed: () => _openManageSubscription(),
+              icon: const Icon(Icons.open_in_new, size: 18),
+              label: const Text('Manage subscription'),
+              style: FilledButton.styleFrom(
+                minimumSize: const Size.fromHeight(48),
+              ),
+            ),
+            const SizedBox(height: 12),
+          ],
+
+          OutlinedButton(
+            onPressed: sub.isLoading
+                ? null
+                : () {
+                    Navigator.of(context).pop();
+                    sub.restorePurchases();
+                  },
+            style: OutlinedButton.styleFrom(
+              minimumSize: const Size.fromHeight(48),
+            ),
+            child: sub.isLoading
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Restore purchases'),
+          ),
+
+          if (sub.error != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              sub.error!,
+              style: textTheme.bodySmall?.copyWith(color: colorScheme.error),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _planLabel(SubscriptionInfo info) {
+    if (info.productId?.contains('annual') == true) return 'Annual plan';
+    if (info.productId?.contains('monthly') == true) return 'Monthly plan';
+    return 'Active subscription';
+  }
+
+  String _expiryLabel(SubscriptionInfo info) {
+    if (info.expiresAt == null) return '';
+    final d = info.expiresAt!;
+    return 'Renews ${d.day}/${d.month}/${d.year}';
+  }
+
+  Future<void> _openManageSubscription() async {
+    final url = Platform.isIOS ? _iosManageUrl : _androidManageUrl;
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+}

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -10,9 +10,11 @@ import '../../models/templates/templates.dart';
 import '../../services/app_review_service.dart';
 import '../../services/lifecycle_notification_service.dart';
 import '../../services/firestore_service.dart';
+import '../../providers/subscription_provider.dart';
 import '../../widgets/delete_confirmation_dialog.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/create_options_sheet.dart';
+import '../subscription/paywall_screen.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
 import '../workouts/create_workout_screen.dart';
@@ -525,6 +527,12 @@ class _WeeksScreenState extends State<WeeksScreen> {
   }
 
   void _saveWeekAsTemplate(BuildContext context) async {
+    final sub = context.read<SubscriptionProvider>();
+    if (sub.isFree) {
+      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      return;
+    }
+
     final programProvider = Provider.of<ProgramProvider>(context, listen: false);
     final templateProvider = Provider.of<TemplateProvider>(context, listen: false);
 

--- a/fittrack/lib/screens/weeks/weeks_screen.dart
+++ b/fittrack/lib/screens/weeks/weeks_screen.dart
@@ -529,7 +529,11 @@ class _WeeksScreenState extends State<WeeksScreen> {
   void _saveWeekAsTemplate(BuildContext context) async {
     final sub = context.read<SubscriptionProvider>();
     if (sub.isFree) {
-      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      PaywallScreen.show(
+        context,
+        headline: 'That workout\'s good enough to save.',
+        subtext: 'Pro gives you unlimited custom templates.',
+      );
       return;
     }
 

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -19,9 +19,11 @@ import '../../widgets/delete_confirmation_dialog.dart';
 import '../../widgets/exercise_card.dart';
 import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/pr_notification_banner.dart';
+import '../../providers/subscription_provider.dart';
 import '../../widgets/save_as_template_menu_item.dart';
 import '../../widgets/superset_group_card.dart';
 import '../exercises/exercise_picker_screen.dart';
+import '../subscription/paywall_screen.dart';
 
 /// Consolidated workout screen that displays all exercises and their sets inline
 /// Replaces the separate WorkoutDetailScreen and ExerciseDetailScreen with a single unified view
@@ -753,6 +755,12 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
   }
 
   void _saveAsTemplate(BuildContext context) {
+    final sub = context.read<SubscriptionProvider>();
+    if (sub.isFree) {
+      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      return;
+    }
+
     final programProvider = Provider.of<ProgramProvider>(context, listen: false);
     final exercises = programProvider.exercises;
 

--- a/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
+++ b/fittrack/lib/screens/workouts/consolidated_workout_screen.dart
@@ -757,7 +757,11 @@ class _ConsolidatedWorkoutScreenState extends State<ConsolidatedWorkoutScreen>
   void _saveAsTemplate(BuildContext context) {
     final sub = context.read<SubscriptionProvider>();
     if (sub.isFree) {
-      PaywallScreen.show(context, headline: 'Save your best workouts as templates');
+      PaywallScreen.show(
+        context,
+        headline: 'That workout\'s good enough to save.',
+        subtext: 'Pro gives you unlimited custom templates.',
+      );
       return;
     }
 

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -10,13 +10,17 @@ import '../models/subscription.dart';
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
 
-  final FirebaseFirestore _firestore;
+  // Null means "use FirebaseFirestore.instance" — resolved lazily so the
+  // static singleton can be constructed in tests without Firebase initialised.
+  final FirebaseFirestore? _injectedFirestore;
+  FirebaseFirestore get _firestore =>
+      _injectedFirestore ?? FirebaseFirestore.instance;
 
-  SubscriptionService._() : _firestore = FirebaseFirestore.instance;
+  SubscriptionService._() : _injectedFirestore = null;
 
   @visibleForTesting
   SubscriptionService.forTest(FirebaseFirestore firestore)
-      : _firestore = firestore;
+      : _injectedFirestore = firestore;
 
   static const String monthlyId = 'fittrack_pro_monthly';
   static const String annualId = 'fittrack_pro_annual';

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -1,0 +1,86 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import '../models/subscription.dart';
+
+/// Singleton that wraps InAppPurchase for product queries, purchase flow,
+/// and syncing subscription status to/from Firestore.
+///
+/// Purchase stream handling and state management live in [SubscriptionProvider].
+class SubscriptionService {
+  static final SubscriptionService instance = SubscriptionService._();
+
+  final FirebaseFirestore _firestore;
+
+  SubscriptionService._() : _firestore = FirebaseFirestore.instance;
+
+  @visibleForTesting
+  SubscriptionService.forTest(FirebaseFirestore firestore)
+      : _firestore = firestore;
+
+  static const String monthlyId = 'fittrack_pro_monthly';
+  static const String annualId = 'fittrack_pro_annual';
+  static const Set<String> productIds = {monthlyId, annualId};
+
+  List<ProductDetails> _products = [];
+
+  List<ProductDetails> get products => List.unmodifiable(_products);
+
+  ProductDetails? get monthlyProduct =>
+      _products.cast<ProductDetails?>().firstWhere(
+            (p) => p?.id == monthlyId,
+            orElse: () => null,
+          );
+
+  ProductDetails? get annualProduct =>
+      _products.cast<ProductDetails?>().firstWhere(
+            (p) => p?.id == annualId,
+            orElse: () => null,
+          );
+
+  Stream<List<PurchaseDetails>> get purchaseStream =>
+      InAppPurchase.instance.purchaseStream;
+
+  /// Initialises the IAP plugin and loads product details from the store.
+  /// Returns false if the store is unavailable (e.g. no network, simulator).
+  Future<bool> initialize() async {
+    final available = await InAppPurchase.instance.isAvailable();
+    if (!available) return false;
+    final response =
+        await InAppPurchase.instance.queryProductDetails(productIds);
+    _products = response.productDetails;
+    return true;
+  }
+
+  Future<void> buySubscription(ProductDetails product) async {
+    final param = PurchaseParam(productDetails: product);
+    await InAppPurchase.instance.buyNonConsumable(purchaseParam: param);
+  }
+
+  Future<void> restorePurchases() async {
+    await InAppPurchase.instance.restorePurchases();
+  }
+
+  Future<void> completePurchase(PurchaseDetails purchase) async {
+    if (purchase.pendingCompletePurchase) {
+      await InAppPurchase.instance.completePurchase(purchase);
+    }
+  }
+
+  /// Writes the subscription map to the user's Firestore document.
+  Future<void> syncToFirestore(String userId, SubscriptionInfo info) async {
+    await _firestore
+        .collection('users')
+        .doc(userId)
+        .update({'subscription': info.toFirestore()});
+  }
+
+  /// Loads the subscription map from the user's Firestore document.
+  /// Returns null if no subscription data exists yet.
+  Future<SubscriptionInfo?> loadFromFirestore(String userId) async {
+    final doc = await _firestore.collection('users').doc(userId).get();
+    final data = doc.data()?['subscription'] as Map<String, dynamic>?;
+    if (data == null) return null;
+    return SubscriptionInfo.fromFirestore(data);
+  }
+}

--- a/fittrack/lib/widgets/pro_gate_widget.dart
+++ b/fittrack/lib/widgets/pro_gate_widget.dart
@@ -1,0 +1,76 @@
+import 'dart:ui';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/subscription_provider.dart';
+import '../screens/subscription/paywall_screen.dart';
+
+/// Wraps a widget with a blur overlay and upgrade prompt when the user is on
+/// the free tier. Renders the child directly for Pro subscribers.
+class ProGateWidget extends StatelessWidget {
+  final Widget child;
+  final String paywallHeadline;
+  final String? paywallSubtext;
+
+  const ProGateWidget({
+    super.key,
+    required this.child,
+    required this.paywallHeadline,
+    this.paywallSubtext,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isPro = context.watch<SubscriptionProvider>().isPro;
+    if (isPro) return child;
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Stack(
+      children: [
+        ImageFiltered(
+          imageFilter: ImageFilter.blur(sigmaX: 6, sigmaY: 6),
+          child: IgnorePointer(child: child),
+        ),
+        Center(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 32),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.lock_outline, size: 48, color: colorScheme.primary),
+                const SizedBox(height: 12),
+                Text(
+                  paywallHeadline,
+                  style: textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                if (paywallSubtext != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    paywallSubtext!,
+                    style: textTheme.bodySmall?.copyWith(
+                      color: colorScheme.onSurface.withValues(alpha: 0.7),
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+                const SizedBox(height: 16),
+                FilledButton(
+                  onPressed: () => PaywallScreen.show(
+                    context,
+                    headline: paywallHeadline,
+                    subtext: paywallSubtext,
+                  ),
+                  child: const Text('Upgrade to Pro'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -38,6 +38,12 @@ dependencies:
   # In-app review
   in_app_review: ^2.0.9
 
+  # In-app purchases
+  in_app_purchase: ^3.2.0
+
+  # URL launcher (subscription management deep links)
+  url_launcher: ^6.2.0
+
   # Export functionality
   csv: ^6.0.0
   path_provider: ^2.1.2

--- a/fittrack/test/models/subscription_test.dart
+++ b/fittrack/test/models/subscription_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fittrack/models/subscription.dart';
+
+void main() {
+  group('SubscriptionInfo', () {
+    group('free() factory', () {
+      test('creates free tier with free status', () {
+        final info = SubscriptionInfo.free();
+        expect(info.tier, SubscriptionTier.free);
+        expect(info.status, SubscriptionStatus.free);
+        expect(info.isPro, isFalse);
+        expect(info.expiresAt, isNull);
+        expect(info.productId, isNull);
+        expect(info.platform, isNull);
+      });
+    });
+
+    group('isPro getter', () {
+      test('returns true for pro tier', () {
+        const info = SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        );
+        expect(info.isPro, isTrue);
+      });
+
+      test('returns false for free tier', () {
+        expect(SubscriptionInfo.free().isPro, isFalse);
+      });
+    });
+
+    group('fromFirestore', () {
+      test('deserializes active subscription correctly', () {
+        final expiry = DateTime(2026, 12, 31);
+        final data = <String, dynamic>{
+          'status': 'active',
+          'productId': 'fittrack_pro_annual',
+          'platform': 'ios',
+          'expiresAt': Timestamp.fromDate(expiry),
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+
+        expect(info.status, SubscriptionStatus.active);
+        expect(info.tier, SubscriptionTier.pro);
+        expect(info.isPro, isTrue);
+        expect(info.productId, 'fittrack_pro_annual');
+        expect(info.platform, 'ios');
+        expect(info.expiresAt, expiry);
+      });
+
+      test('deserializes trial subscription as pro', () {
+        final data = <String, dynamic>{
+          'status': 'trial',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'android',
+          'expiresAt': null,
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+
+        expect(info.status, SubscriptionStatus.trial);
+        expect(info.tier, SubscriptionTier.pro);
+        expect(info.isPro, isTrue);
+      });
+
+      test('deserializes expired subscription as free tier', () {
+        final data = <String, dynamic>{
+          'status': 'expired',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'ios',
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+
+        expect(info.status, SubscriptionStatus.expired);
+        expect(info.tier, SubscriptionTier.free);
+        expect(info.isPro, isFalse);
+      });
+
+      test('deserializes cancelled subscription as free tier', () {
+        final data = <String, dynamic>{
+          'status': 'cancelled',
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+
+        expect(info.status, SubscriptionStatus.cancelled);
+        expect(info.tier, SubscriptionTier.free);
+        expect(info.isPro, isFalse);
+      });
+
+      test('defaults to unknown status for unrecognized value', () {
+        final data = <String, dynamic>{
+          'status': 'something_new',
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+
+        expect(info.status, SubscriptionStatus.unknown);
+        expect(info.tier, SubscriptionTier.free);
+      });
+
+      test('defaults to free status when status field is absent', () {
+        final info = SubscriptionInfo.fromFirestore({});
+        expect(info.status, SubscriptionStatus.free);
+        expect(info.tier, SubscriptionTier.free);
+        expect(info.isPro, isFalse);
+      });
+
+      test('handles null expiresAt gracefully', () {
+        final data = <String, dynamic>{
+          'status': 'active',
+          'expiresAt': null,
+        };
+
+        final info = SubscriptionInfo.fromFirestore(data);
+        expect(info.expiresAt, isNull);
+      });
+    });
+
+    group('toFirestore', () {
+      test('serializes all fields correctly', () {
+        final expiry = DateTime(2026, 12, 31);
+        final info = SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+          productId: 'fittrack_pro_annual',
+          platform: 'ios',
+          expiresAt: expiry,
+        );
+
+        final map = info.toFirestore();
+
+        expect(map['status'], 'active');
+        expect(map['productId'], 'fittrack_pro_annual');
+        expect(map['platform'], 'ios');
+        expect((map['expiresAt'] as Timestamp).toDate(), expiry);
+        expect(map['updatedAt'], isA<FieldValue>());
+      });
+
+      test('serializes null expiresAt correctly', () {
+        const info = SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        );
+
+        final map = info.toFirestore();
+        expect(map['expiresAt'], isNull);
+      });
+
+      test('round-trips key fields through map serialization', () {
+        // Tests toFirestore → fromFirestore parity without writing to Firestore,
+        // because FieldValue.serverTimestamp() is a server-only sentinel that
+        // cannot be stored in FakeFirebaseFirestore in unit tests.
+        final expiry = DateTime(2026, 6, 15);
+        final original = SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+          productId: 'fittrack_pro_monthly',
+          platform: 'android',
+          expiresAt: expiry,
+        );
+
+        final map = original.toFirestore();
+        // Replace server timestamp sentinel with a real Timestamp for fromFirestore
+        final roundTripMap = Map<String, dynamic>.from(map)
+          ..['updatedAt'] = Timestamp.fromDate(DateTime.now())
+          ..['expiresAt'] = Timestamp.fromDate(expiry);
+
+        final restored = SubscriptionInfo.fromFirestore(roundTripMap);
+
+        expect(restored.status, original.status);
+        expect(restored.tier, original.tier);
+        expect(restored.productId, original.productId);
+        expect(restored.platform, original.platform);
+        expect(restored.expiresAt, expiry);
+      });
+    });
+  });
+
+  group('SubscriptionTier enum', () {
+    test('has free and pro values', () {
+      expect(SubscriptionTier.values, hasLength(2));
+      expect(SubscriptionTier.values, contains(SubscriptionTier.free));
+      expect(SubscriptionTier.values, contains(SubscriptionTier.pro));
+    });
+  });
+
+  group('SubscriptionStatus enum', () {
+    test('has expected status values', () {
+      expect(
+        SubscriptionStatus.values,
+        containsAll([
+          SubscriptionStatus.unknown,
+          SubscriptionStatus.free,
+          SubscriptionStatus.trial,
+          SubscriptionStatus.active,
+          SubscriptionStatus.expired,
+          SubscriptionStatus.cancelled,
+        ]),
+      );
+    });
+  });
+}

--- a/fittrack/test/providers/subscription_provider_test.dart
+++ b/fittrack/test/providers/subscription_provider_test.dart
@@ -1,0 +1,193 @@
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
+
+void main() {
+  late SubscriptionProvider provider;
+
+  setUp(() {
+    provider = SubscriptionProvider();
+  });
+
+  tearDown(() {
+    provider.dispose();
+  });
+
+  group('SubscriptionProvider - initial state', () {
+    test('starts as free tier', () {
+      expect(provider.isPro, isFalse);
+      expect(provider.isFree, isTrue);
+      expect(provider.subscriptionInfo.tier, SubscriptionTier.free);
+      expect(provider.subscriptionInfo.status, SubscriptionStatus.free);
+    });
+
+    test('starts with no loading state', () {
+      expect(provider.isLoading, isFalse);
+    });
+
+    test('starts with no error', () {
+      expect(provider.error, isNull);
+    });
+
+    test('isProOverride starts false', () {
+      expect(provider.isProOverride, isFalse);
+    });
+
+    test('products list starts empty', () {
+      expect(provider.products, isEmpty);
+    });
+
+    test('monthlyProduct starts null', () {
+      expect(provider.monthlyProduct, isNull);
+    });
+
+    test('annualProduct starts null', () {
+      expect(provider.annualProduct, isNull);
+    });
+  });
+
+  group('SubscriptionProvider - computed limits (free tier)', () {
+    test('maxPrograms is 3 for free', () {
+      expect(provider.maxPrograms, 3);
+    });
+
+    test('maxCustomExercises is 5 for free', () {
+      expect(provider.maxCustomExercises, 5);
+    });
+  });
+
+  group('SubscriptionProvider - computed limits (pro tier)', () {
+    setUp(() {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+    });
+
+    test('maxPrograms is 999 for pro', () {
+      expect(provider.maxPrograms, 999);
+    });
+
+    test('maxCustomExercises is 50 for pro', () {
+      expect(provider.maxCustomExercises, 50);
+    });
+
+    test('isPro is true', () {
+      expect(provider.isPro, isTrue);
+      expect(provider.isFree, isFalse);
+    });
+  });
+
+  group('SubscriptionProvider - isProOverride', () {
+    test('isPro is true when isProOverride set, even with free subscription', () {
+      provider.setProOverrideForTest(value: true);
+      expect(provider.isPro, isTrue);
+      expect(provider.isFree, isFalse);
+      expect(provider.isProOverride, isTrue);
+      // Underlying subscription is still free
+      expect(provider.subscriptionInfo.tier, SubscriptionTier.free);
+    });
+
+    test('isPro correct when both override and active subscription', () {
+      provider.setProOverrideForTest(value: true);
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+    });
+
+    test('maxPrograms is unlimited when override is set', () {
+      provider.setProOverrideForTest(value: true);
+      expect(provider.maxPrograms, 999);
+      expect(provider.maxCustomExercises, 50);
+    });
+  });
+
+  group('SubscriptionProvider - clearError', () {
+    test('clearError removes the error message', () {
+      // Simulate an error state by checking clearError works
+      // (error is set internally via purchase stream in production)
+      provider.clearError();
+      expect(provider.error, isNull);
+    });
+  });
+
+  group('SubscriptionProvider - notify on state changes', () {
+    test('notifies listeners when subscription info changes', () {
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+
+      expect(notified, isTrue);
+    });
+
+    test('notifies listeners when pro override changes', () {
+      var notified = false;
+      provider.addListener(() => notified = true);
+
+      provider.setProOverrideForTest(value: true);
+
+      expect(notified, isTrue);
+    });
+  });
+
+  group('SubscriptionProvider - subscription status transitions', () {
+    test('expired subscription is treated as free', () {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.free,
+          status: SubscriptionStatus.expired,
+        ),
+      );
+      expect(provider.isPro, isFalse);
+      expect(provider.maxPrograms, 3);
+    });
+
+    test('trial subscription is treated as pro', () {
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.trial,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+      expect(provider.maxPrograms, 999);
+    });
+
+    test('cancelled subscription reverts to free limits', () {
+      // First go pro
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+      expect(provider.isPro, isTrue);
+
+      // Then cancel
+      provider.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.free,
+          status: SubscriptionStatus.cancelled,
+        ),
+      );
+      expect(provider.isPro, isFalse);
+      expect(provider.maxPrograms, 3);
+      expect(provider.maxCustomExercises, 5);
+    });
+  });
+}

--- a/fittrack/test/screens/profile/my_exercises_screen_test.dart
+++ b/fittrack/test/screens/profile/my_exercises_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 import 'package:fittrack/screens/profile/my_exercises_screen.dart';
 import 'package:fittrack/providers/exercise_library_provider.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
 import 'package:fittrack/models/custom_exercise.dart';
 import 'package:fittrack/models/library_exercise.dart';
 import 'package:fittrack/models/muscle_group.dart';
@@ -103,16 +104,28 @@ class MockExerciseLibraryProvider extends ChangeNotifier
 
 void main() {
   late MockExerciseLibraryProvider mockProvider;
+  late SubscriptionProvider subProvider;
 
   setUp(() {
     mockProvider = MockExerciseLibraryProvider();
+    subProvider = SubscriptionProvider();
+  });
+
+  tearDown(() {
+    mockProvider.dispose();
+    subProvider.dispose();
   });
 
   Widget createTestWidget() {
-    return MaterialApp(
-      home: ChangeNotifierProvider<ExerciseLibraryProvider>.value(
-        value: mockProvider,
-        child: const MyExercisesScreen(),
+    // SubscriptionProvider wraps MaterialApp so any paywall modal bottom sheets
+    // can access it through the root navigator's overlay.
+    return ChangeNotifierProvider<SubscriptionProvider>.value(
+      value: subProvider,
+      child: MaterialApp(
+        home: ChangeNotifierProvider<ExerciseLibraryProvider>.value(
+          value: mockProvider,
+          child: const MyExercisesScreen(),
+        ),
       ),
     );
   }
@@ -191,7 +204,9 @@ void main() {
       await tester.pumpWidget(createTestWidget());
       await tester.pumpAndSettle();
 
-      expect(find.text('2/$maxCustomExercises exercises'), findsOneWidget);
+      // Limit comes from SubscriptionProvider (5 for free tier), not the old
+      // ExerciseLibraryProvider constant.
+      expect(find.text('2/${subProvider.maxCustomExercises} exercises'), findsOneWidget);
     });
 
     testWidgets('should display FAB when can create more', (tester) async {

--- a/fittrack/test/screens/programs/programs_screen_gating_test.dart
+++ b/fittrack/test/screens/programs/programs_screen_gating_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:fittrack/screens/programs/programs_screen.dart';
+import 'package:fittrack/providers/program_provider.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
+import 'package:fittrack/models/program.dart';
+import 'package:fittrack/models/subscription.dart';
+
+import 'programs_screen_gating_test.mocks.dart';
+
+Program _makeProgram(String id) => Program(
+      id: id,
+      name: 'Program $id',
+      createdAt: DateTime(2024, 1, 1),
+      updatedAt: DateTime(2024, 1, 1),
+      userId: 'user1',
+    );
+
+@GenerateMocks([ProgramProvider])
+void main() {
+  late MockProgramProvider mockProgramProvider;
+  late SubscriptionProvider sub;
+
+  setUpAll(() async {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  setUp(() {
+    mockProgramProvider = MockProgramProvider();
+    sub = SubscriptionProvider();
+
+    when(mockProgramProvider.isLoadingPrograms).thenReturn(false);
+    when(mockProgramProvider.error).thenReturn(null);
+    when(mockProgramProvider.programs).thenReturn([]);
+    when(mockProgramProvider.isLoading).thenReturn(false);
+    when(mockProgramProvider.isLoadingAnalytics).thenReturn(false);
+    when(mockProgramProvider.monthHeatmapData).thenReturn(null);
+    when(mockProgramProvider.currentAnalytics).thenReturn(null);
+    when(mockProgramProvider.keyStatistics).thenReturn(null);
+    when(mockProgramProvider.recentPRs).thenReturn(null);
+    when(mockProgramProvider.userId).thenReturn('user1');
+    when(mockProgramProvider.selectedProgram).thenReturn(null);
+  });
+
+  tearDown(() {
+    sub.dispose();
+  });
+
+  Widget buildSubject() {
+    return MultiProvider(
+      providers: [
+        ChangeNotifierProvider<ProgramProvider>.value(value: mockProgramProvider),
+        ChangeNotifierProvider<SubscriptionProvider>.value(value: sub),
+      ],
+      child: const MaterialApp(home: ProgramsScreen()),
+    );
+  }
+
+  group('ProgramsScreen - FAB gating (free tier)', () {
+    testWidgets('shows paywall when free user has reached program limit', (tester) async {
+      final programs = List.generate(3, (i) => _makeProgram('p$i'));
+      when(mockProgramProvider.programs).thenReturn(programs);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsOneWidget);
+      expect(find.text('Unlock unlimited programs'), findsOneWidget);
+    });
+
+    testWidgets('paywall subtext shows free limit', (tester) async {
+      final programs = List.generate(3, (i) => _makeProgram('p$i'));
+      when(mockProgramProvider.programs).thenReturn(programs);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('free plan limit of 3 programs'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('does not show paywall when free user is under the limit', (tester) async {
+      final programs = List.generate(2, (i) => _makeProgram('p$i'));
+      when(mockProgramProvider.programs).thenReturn(programs);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsNothing);
+    });
+
+    testWidgets('empty state create button also gates at limit', (tester) async {
+      // programs is empty — shows the empty state with Create Program button
+      when(mockProgramProvider.programs).thenReturn([]);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      // Empty state shows the Create Program button — but limit is 3 so no gate yet
+      // (0 programs < 3 limit). Verify no paywall appears.
+      await tester.tap(find.text('Create Program'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsNothing);
+    });
+  });
+
+  group('ProgramsScreen - FAB gating (pro tier)', () {
+    setUp(() {
+      sub.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+    });
+
+    testWidgets('pro user with 3+ programs sees no paywall', (tester) async {
+      final programs = List.generate(5, (i) => _makeProgram('p$i'));
+      when(mockProgramProvider.programs).thenReturn(programs);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsNothing);
+    });
+  });
+
+  group('ProgramsScreen - FAB gating (isProOverride)', () {
+    testWidgets('override user with 3+ programs sees no paywall', (tester) async {
+      sub.setProOverrideForTest(value: true);
+      final programs = List.generate(4, (i) => _makeProgram('p$i'));
+      when(mockProgramProvider.programs).thenReturn(programs);
+
+      await tester.pumpWidget(buildSubject());
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsNothing);
+    });
+  });
+}

--- a/fittrack/test/screens/programs/programs_screen_gating_test.dart
+++ b/fittrack/test/screens/programs/programs_screen_gating_test.dart
@@ -72,7 +72,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Overload Pro'), findsOneWidget);
-      expect(find.text('Unlock unlimited programs'), findsOneWidget);
+      expect(find.textContaining('Serious lifters run more'), findsOneWidget);
     });
 
     testWidgets('paywall subtext shows free limit', (tester) async {
@@ -86,7 +86,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.textContaining('free plan limit of 3 programs'),
+        find.textContaining('Unlock unlimited programs with Pro'),
         findsOneWidget,
       );
     });

--- a/fittrack/test/screens/subscription/paywall_screen_test.dart
+++ b/fittrack/test/screens/subscription/paywall_screen_test.dart
@@ -1,0 +1,251 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
+import 'package:fittrack/screens/subscription/paywall_screen.dart';
+
+Widget _buildSubject({
+  required SubscriptionProvider sub,
+  required Widget child,
+}) {
+  return MaterialApp(
+    home: ChangeNotifierProvider<SubscriptionProvider>.value(
+      value: sub,
+      child: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  late SubscriptionProvider sub;
+
+  setUp(() {
+    sub = SubscriptionProvider();
+  });
+
+  tearDown(() {
+    sub.dispose();
+  });
+
+  group('PaywallScreen', () {
+    testWidgets('renders Overload Pro title', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Overload Pro'), findsOneWidget);
+    });
+
+    testWidgets('renders context headline', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Unlock unlimited programs'), findsOneWidget);
+    });
+
+    testWidgets('renders optional subtext when provided', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(
+            headline: 'Unlock unlimited programs',
+            subtext: 'You have reached the free plan limit.',
+          ),
+        ),
+      );
+
+      expect(find.text('You have reached the free plan limit.'), findsOneWidget);
+    });
+
+    testWidgets('does not render subtext when not provided', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('You have reached the free plan limit.'), findsNothing);
+    });
+
+    testWidgets('renders Annual and Monthly plan labels', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Annual'), findsOneWidget);
+      expect(find.text('Monthly'), findsOneWidget);
+    });
+
+    testWidgets('renders RECOMMENDED badge on annual plan', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('RECOMMENDED'), findsOneWidget);
+    });
+
+    testWidgets('renders restore purchases button', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Already subscribed? Restore purchases'), findsOneWidget);
+    });
+
+    testWidgets('renders benefits list', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Unlimited programs'), findsOneWidget);
+      expect(find.text('Full analytics history — all time'), findsOneWidget);
+    });
+
+    testWidgets('shows loading indicator when isLoading is true', (tester) async {
+      // isLoading is true after purchaseMonthly/Annual starts but before
+      // the stream responds — simulate via provider state observation
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      // By default isLoading is false — plan cards are shown
+      expect(find.text('Annual'), findsOneWidget);
+    });
+
+    testWidgets('hides plan cards and shows spinner when isLoading', (tester) async {
+      // Wrap sub in a notifier that reports loading
+      final loadingSub = SubscriptionProvider();
+      // Trigger loading state by monitoring the widget directly via a
+      // lightweight approach: verify plan card is visible initially
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: loadingSub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.text('Annual'), findsOneWidget);
+      loadingSub.dispose();
+    });
+
+    testWidgets('show() opens modal bottom sheet', (tester) async {
+      // Provider must wrap MaterialApp so showModalBottomSheet can access it
+      // through the root navigator's overlay (a separate route from home).
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SubscriptionProvider>.value(
+          value: sub,
+          child: MaterialApp(
+            home: Builder(
+              builder: (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () => PaywallScreen.show(
+                    context,
+                    headline: 'Unlock unlimited programs',
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsOneWidget);
+      expect(find.text('Unlock unlimited programs'), findsOneWidget);
+    });
+  });
+
+  group('PaywallScreen - fallback prices', () {
+    testWidgets('shows fallback price when products not loaded', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text(r'$39.99/year'), findsOneWidget);
+      expect(find.text(r'$6.99/month'), findsOneWidget);
+    });
+  });
+
+  group('PaywallScreen - error state', () {
+    testWidgets('shows error message when sub has error', (tester) async {
+      // Error is set internally by the purchase stream — we verify the
+      // widget reads the error field from the provider
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      // No error initially
+      expect(find.textContaining('Purchase failed'), findsNothing);
+    });
+
+    testWidgets('renders legal footnote', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(
+        find.textContaining('Terms of Service'),
+        findsOneWidget,
+      );
+    });
+  });
+
+  group('PaywallScreen - pro subscriber', () {
+    setUp(() {
+      sub.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+    });
+
+    testWidgets('paywall still renders for pro (upgrade context is handled by caller)', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const PaywallScreen(headline: 'Unlock unlimited programs'),
+        ),
+      );
+
+      expect(find.text('Overload Pro'), findsOneWidget);
+    });
+  });
+}

--- a/fittrack/test/services/subscription_service_integration_test.dart
+++ b/fittrack/test/services/subscription_service_integration_test.dart
@@ -1,0 +1,133 @@
+/// Integration tests for SubscriptionService.
+///
+/// SubscriptionService has two concerns:
+///   1. InAppPurchase interactions (platform channel — cannot be tested in CI)
+///   2. Firestore read/write of the subscription map
+///
+/// These tests cover concern (2) using FakeFirebaseFirestore, verifying that
+/// loadFromFirestore correctly deserialises subscription data across all status
+/// values and that a missing/absent subscription field returns null.
+
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/services/subscription_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fakeFirestore;
+  late SubscriptionService service;
+
+  setUp(() {
+    fakeFirestore = FakeFirebaseFirestore();
+    service = SubscriptionService.forTest(fakeFirestore);
+  });
+
+  group('SubscriptionService - Firestore lifecycle', () {
+    test('loadFromFirestore returns null for document with no subscription',
+        () async {
+      await fakeFirestore.collection('users').doc('u1').set({
+        'displayName': 'Joel',
+        'createdAt': Timestamp.now(),
+      });
+
+      expect(await service.loadFromFirestore('u1'), isNull);
+    });
+
+    test('loadFromFirestore returns null for non-existent document', () async {
+      expect(await service.loadFromFirestore('no-such-user'), isNull);
+    });
+
+    test(
+        'loadFromFirestore returns correct SubscriptionInfo for active pro subscription',
+        () async {
+      final expiry = DateTime(2027, 6, 30);
+      await fakeFirestore.collection('users').doc('u2').set({
+        'subscription': {
+          'status': 'active',
+          'productId': 'fittrack_pro_annual',
+          'platform': 'ios',
+          'expiresAt': Timestamp.fromDate(expiry),
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final info = await service.loadFromFirestore('u2');
+
+      expect(info, isNotNull);
+      expect(info!.isPro, isTrue);
+      expect(info.tier, SubscriptionTier.pro);
+      expect(info.status, SubscriptionStatus.active);
+      expect(info.productId, 'fittrack_pro_annual');
+      expect(info.platform, 'ios');
+      expect(info.expiresAt, expiry);
+    });
+
+    test('loadFromFirestore returns free tier for expired subscription',
+        () async {
+      await fakeFirestore.collection('users').doc('u3').set({
+        'subscription': {
+          'status': 'expired',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'android',
+          'expiresAt': Timestamp.fromDate(DateTime(2025, 1, 1)),
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final info = await service.loadFromFirestore('u3');
+
+      expect(info!.isPro, isFalse);
+      expect(info.tier, SubscriptionTier.free);
+      expect(info.status, SubscriptionStatus.expired);
+    });
+
+    test('loadFromFirestore handles trial status as pro', () async {
+      await fakeFirestore.collection('users').doc('u4').set({
+        'subscription': {
+          'status': 'trial',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'android',
+          'expiresAt': null,
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final info = await service.loadFromFirestore('u4');
+
+      expect(info!.isPro, isTrue);
+      expect(info.tier, SubscriptionTier.pro);
+      expect(info.status, SubscriptionStatus.trial);
+    });
+
+    test('multiple users have independent subscription state', () async {
+      await fakeFirestore.collection('users').doc('free-user').set({
+        'subscription': {
+          'status': 'free',
+          'productId': null,
+          'platform': null,
+          'expiresAt': null,
+          'updatedAt': Timestamp.now(),
+        },
+      });
+      await fakeFirestore.collection('users').doc('pro-user').set({
+        'subscription': {
+          'status': 'active',
+          'productId': 'fittrack_pro_annual',
+          'platform': 'ios',
+          'expiresAt': Timestamp.fromDate(DateTime(2027, 1, 1)),
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final freeInfo = await service.loadFromFirestore('free-user');
+      final proInfo = await service.loadFromFirestore('pro-user');
+
+      expect(freeInfo!.isPro, isFalse);
+      expect(proInfo!.isPro, isTrue);
+    });
+  });
+}

--- a/fittrack/test/services/subscription_service_test.dart
+++ b/fittrack/test/services/subscription_service_test.dart
@@ -1,0 +1,130 @@
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/services/subscription_service.dart';
+
+void main() {
+  late FakeFirebaseFirestore fakeFirestore;
+  late SubscriptionService service;
+
+  setUp(() {
+    fakeFirestore = FakeFirebaseFirestore();
+    service = SubscriptionService.forTest(fakeFirestore);
+  });
+
+  group('SubscriptionService - product getters', () {
+    test('monthlyProduct returns null before initialization', () {
+      expect(service.monthlyProduct, isNull);
+    });
+
+    test('annualProduct returns null before initialization', () {
+      expect(service.annualProduct, isNull);
+    });
+
+    test('products is empty before initialization', () {
+      expect(service.products, isEmpty);
+    });
+  });
+
+  group('SubscriptionService - loadFromFirestore', () {
+    test('returns null when user document has no subscription field', () async {
+      await fakeFirestore.collection('users').doc('user-1').set({
+        'displayName': 'Test User',
+        'email': 'test@example.com',
+        'createdAt': Timestamp.now(),
+      });
+
+      final result = await service.loadFromFirestore('user-1');
+      expect(result, isNull);
+    });
+
+    test('returns null when user document does not exist', () async {
+      final result = await service.loadFromFirestore('nonexistent-user');
+      expect(result, isNull);
+    });
+
+    test('returns SubscriptionInfo.free() for free status', () async {
+      await fakeFirestore.collection('users').doc('user-1').set({
+        'subscription': {
+          'status': 'free',
+          'productId': null,
+          'platform': null,
+          'expiresAt': null,
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final result = await service.loadFromFirestore('user-1');
+      expect(result, isNotNull);
+      expect(result!.status, SubscriptionStatus.free);
+      expect(result.isPro, isFalse);
+    });
+
+    test('returns pro SubscriptionInfo for active status', () async {
+      final expiry = DateTime(2027, 1, 1);
+      await fakeFirestore.collection('users').doc('user-1').set({
+        'subscription': {
+          'status': 'active',
+          'productId': 'fittrack_pro_annual',
+          'platform': 'ios',
+          'expiresAt': Timestamp.fromDate(expiry),
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final result = await service.loadFromFirestore('user-1');
+      expect(result, isNotNull);
+      expect(result!.status, SubscriptionStatus.active);
+      expect(result.tier, SubscriptionTier.pro);
+      expect(result.isPro, isTrue);
+      expect(result.productId, 'fittrack_pro_annual');
+      expect(result.platform, 'ios');
+      expect(result.expiresAt, expiry);
+    });
+
+    test('returns pro SubscriptionInfo for trial status', () async {
+      await fakeFirestore.collection('users').doc('user-1').set({
+        'subscription': {
+          'status': 'trial',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'android',
+          'expiresAt': null,
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final result = await service.loadFromFirestore('user-1');
+      expect(result!.tier, SubscriptionTier.pro);
+      expect(result.isPro, isTrue);
+    });
+
+    test('returns free tier for expired status', () async {
+      await fakeFirestore.collection('users').doc('user-1').set({
+        'subscription': {
+          'status': 'expired',
+          'productId': 'fittrack_pro_monthly',
+          'platform': 'ios',
+          'expiresAt': Timestamp.fromDate(DateTime(2025, 1, 1)),
+          'updatedAt': Timestamp.now(),
+        },
+      });
+
+      final result = await service.loadFromFirestore('user-1');
+      expect(result!.tier, SubscriptionTier.free);
+      expect(result.isPro, isFalse);
+    });
+  });
+
+  group('SubscriptionService - product ID constants', () {
+    test('product IDs match expected store identifiers', () {
+      expect(SubscriptionService.monthlyId, 'fittrack_pro_monthly');
+      expect(SubscriptionService.annualId, 'fittrack_pro_annual');
+      expect(SubscriptionService.productIds,
+          containsAll(['fittrack_pro_monthly', 'fittrack_pro_annual']));
+    });
+  });
+}

--- a/fittrack/test/widgets/pro_gate_widget_test.dart
+++ b/fittrack/test/widgets/pro_gate_widget_test.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:fittrack/models/subscription.dart';
+import 'package:fittrack/providers/subscription_provider.dart';
+import 'package:fittrack/widgets/pro_gate_widget.dart';
+
+Widget _buildSubject({
+  required SubscriptionProvider sub,
+  required Widget child,
+}) {
+  // Provider must wrap MaterialApp so modal bottom sheets inherit it through
+  // the root navigator's overlay (showModalBottomSheet creates a new route).
+  return ChangeNotifierProvider<SubscriptionProvider>.value(
+    value: sub,
+    child: MaterialApp(
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  late SubscriptionProvider sub;
+
+  setUp(() {
+    sub = SubscriptionProvider();
+  });
+
+  tearDown(() {
+    sub.dispose();
+  });
+
+  group('ProGateWidget - free tier', () {
+    testWidgets('shows lock icon', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+    });
+
+    testWidgets('shows paywall headline', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text("Track every rep's progress"), findsOneWidget);
+    });
+
+    testWidgets('shows optional subtext when provided', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            paywallSubtext: 'Available on Overload Pro.',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Available on Overload Pro.'), findsOneWidget);
+    });
+
+    testWidgets('does not show subtext when not provided', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Available on Overload Pro.'), findsNothing);
+    });
+
+    testWidgets('shows Upgrade to Pro button', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Upgrade to Pro'), findsOneWidget);
+    });
+
+    testWidgets('child is still in the tree but pointer-ignored (blurred)', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      // Child is present (blurred behind overlay) but wrapped in IgnorePointer.
+      // Filter to ignoring:true because Flutter's framework adds IgnorePointer(ignoring:false)
+      // nodes internally (e.g. Scaffold focus management).
+      expect(find.text('Premium Content'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((w) => w is IgnorePointer && w.ignoring),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping Upgrade to Pro opens PaywallScreen', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Upgrade to Pro'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Overload Pro'), findsOneWidget);
+    });
+
+    testWidgets('paywall opens with correct headline', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Upgrade to Pro'));
+      await tester.pumpAndSettle();
+
+      expect(find.text("Track every rep's progress"), findsWidgets);
+    });
+  });
+
+  group('ProGateWidget - pro tier', () {
+    setUp(() {
+      sub.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+    });
+
+    testWidgets('renders child directly without overlay', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Premium Content'), findsOneWidget);
+      expect(find.byIcon(Icons.lock_outline), findsNothing);
+      expect(find.text('Upgrade to Pro'), findsNothing);
+    });
+
+    testWidgets('no blur or IgnorePointer wrapping child', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      // Only check for IgnorePointer with ignoring:true — framework internal nodes
+      // (ignoring:false) are present in both free and pro trees.
+      expect(
+        find.byWidgetPredicate((w) => w is IgnorePointer && w.ignoring),
+        findsNothing,
+      );
+    });
+  });
+
+  group('ProGateWidget - isProOverride', () {
+    testWidgets('treats override as pro — renders child directly', (tester) async {
+      sub.setProOverrideForTest(value: true);
+
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      expect(find.text('Premium Content'), findsOneWidget);
+      expect(find.byIcon(Icons.lock_outline), findsNothing);
+    });
+  });
+
+  group('ProGateWidget - state transitions', () {
+    testWidgets('switches to pro view when subscription upgrades', (tester) async {
+      await tester.pumpWidget(
+        _buildSubject(
+          sub: sub,
+          child: const ProGateWidget(
+            paywallHeadline: 'Track every rep\'s progress',
+            child: Text('Premium Content'),
+          ),
+        ),
+      );
+
+      // Free state — lock shown
+      expect(find.byIcon(Icons.lock_outline), findsOneWidget);
+
+      sub.setSubscriptionInfoForTest(
+        const SubscriptionInfo(
+          tier: SubscriptionTier.pro,
+          status: SubscriptionStatus.active,
+        ),
+      );
+      await tester.pump();
+
+      // Pro state — no lock
+      expect(find.byIcon(Icons.lock_outline), findsNothing);
+      expect(find.text('Premium Content'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Updates all paywall trigger copy across 7 screens to match brand voice (confident, direct, specific — per Brand_Marketing_Strategy.md §4.3/§9.3)
- Adds "Save 52% vs monthly" savings callout to the annual plan card (§9.5 annual conversion tactic)
- Replaces the static legal footnote with tappable Terms of Service and Privacy Policy links via `url_launcher` (placeholder URLs: overloadapp.com/terms and overloadapp.com/privacy)
- Increases legal text opacity from 0.5 → 0.7 for legibility
- Updates `programs_screen_gating_test` assertions to match new copy

## Copy changes

| Trigger | Old | New |
|---------|-----|-----|
| Program limit | "Unlock unlimited programs" | "You've built 3 programs. Serious lifters run more." |
| Pre-built templates | "Access 6+ expert program templates" | "Start with an expert-built program." |
| Analytics Exercise tab | "Track every rep's progress" | "Every rep tells a story." |
| Analytics Trends tab | "See your full training history" | "Your PR history is in there." |
| Save template | "Save your best workouts as templates" | "That workout's good enough to save." |
| Custom exercises | "Create up to 50 custom exercises" | "Build your full exercise library." |
| Profile upgrade CTA | "Everything you need to train smarter." | "Unlimited programs. Full analytics. $39.99/year." |

## No lifetime option

Per user decision, the lifetime purchase option has been deferred. Not implemented.

Closes #448
Closes #473
Part of #445