### PR TITLE
feat(#454): add acid green colour scheme

### DIFF
--- a/fittrack/lib/providers/theme_provider.dart
+++ b/fittrack/lib/providers/theme_provider.dart
@@ -7,6 +7,7 @@ enum ColorSchemeType {
   energeticOrange,
   electricPurple,
   crimsonPower,
+  acidGreen,
 }
 
 class ThemeProvider extends ChangeNotifier {
@@ -95,6 +96,8 @@ class ThemeProvider extends ChangeNotifier {
         return const Color(0xFF7C3AED);
       case ColorSchemeType.crimsonPower:
         return const Color(0xFFDC143C);
+      case ColorSchemeType.acidGreen:
+        return const Color(0xFF39FF14);
     }
   }
 }

--- a/fittrack/lib/screens/profile/settings_screen.dart
+++ b/fittrack/lib/screens/profile/settings_screen.dart
@@ -373,6 +373,8 @@ class SettingsScreen extends StatelessWidget {
         return const Color(0xFF7C3AED);
       case ColorSchemeType.crimsonPower:
         return const Color(0xFFDC143C);
+      case ColorSchemeType.acidGreen:
+        return const Color(0xFF39FF14);
     }
   }
 
@@ -386,6 +388,8 @@ class SettingsScreen extends StatelessWidget {
         return 'Electric Purple';
       case ColorSchemeType.crimsonPower:
         return 'Crimson Power';
+      case ColorSchemeType.acidGreen:
+        return 'Acid Green';
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `acidGreen` to `ColorSchemeType` enum
- Seed colour `#39FF14` wired into `ThemeProvider.seedColor`
- `_getColorForScheme` and `_getDisplayNameForScheme` in `settings_screen.dart` updated to include "Acid Green"
- Persists via existing SharedPreferences mechanism — no new keys needed

## Related
Closes #454
Parent: #445

🤖 Generated with [Claude Code](https://claude.com/claude-code)