### PR TITLE
fix: rename prebuilt template ID stronglifts-5x5 → strength-5x5

### DIFF
--- a/fittrack/assets/data/prebuilt_programs.json
+++ b/fittrack/assets/data/prebuilt_programs.json
@@ -928,7 +928,7 @@
       ]
     },
     {
-      "id": "stronglifts-5x5",
+      "id": "strength-5x5",
       "name": "5x5 Strength",
       "description": "Classic linear progression strength program focused on compound lifts. Add weight every session for consistent strength gains.",
       "category": "strength",


### PR DESCRIPTION
## Summary

Removes third-party brand name from the 5x5 Strength prebuilt template Firestore document ID.

- `stronglifts-5x5` → `strength-5x5` in `assets/data/prebuilt_programs.json`
- Display name "5x5 Strength" unchanged
- No Dart code or tests reference the template ID directly

## Notes
The Firestore `prebuiltPrograms` collection will need to be re-seeded after this merges to remove the old document and create the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)