### PR TITLE
[Task] Remove mobile-only packages, stub notification/review services (#481)

### DIFF
--- a/Docs/PRDs/PWA_Transition_PRD.md
+++ b/Docs/PRDs/PWA_Transition_PRD.md
@@ -1,0 +1,203 @@
+# PRD: Transition to Progressive Web Application
+
+**Status:** Ready for Design
+**Priority:** High
+**Platform:** Both (web — Android Chrome + iOS Safari + desktop)
+**Feature Type:** New Feature
+**GitHub Issue:** #478
+**Created:** 2026-06-14
+
+---
+
+## 1. Problem Statement
+
+Google Play requires a developer account physical address that is publicly visible on the store listing. For a solo founder without a registered business address this is a dealbreaker — the address cannot be hidden and is permanently attached to every published app.
+
+The app (Overload, package `com.fittrack.app`) is ~6–8 weeks from Play Store submission. Rather than register a business address to satisfy Google's requirement, we pivot the distribution channel: instead of a native Android app, we publish as a Progressive Web Application hosted on Firebase Hosting.
+
+This pivot also:
+- **Eliminates the 30% Google Play billing cut** — replaced by Stripe at ~3% per transaction
+- **Enables instant deployments** — no store review cycle; push code and users get it immediately
+- **Broadens reach** — works on Android Chrome, iOS Safari (16.4+), and desktop browsers without separate builds
+
+The Android codebase and packaging are preserved in case the distribution decision changes later (e.g., after registering a business, or switching to iOS App Store which handles address differently).
+
+---
+
+## 2. Users
+
+**Primary:** New users arriving via direct link, Reddit/social sharing, or the marketing site (`overload.fitness`) who install the PWA to their home screen on Android or iOS.
+
+**Existing:** Current beta testers who currently access via Firebase App Distribution APK — they will migrate to the PWA URL.
+
+---
+
+## 3. Existing Implementation Notes
+
+Relevant to the SA when designing:
+
+- **Flutter web already configured:** `fittrack/web/` exists with PWA manifest, icons, and Flutter bootstrap template. `flutter build web` is expected to work without major code changes — the framework, Firestore, Auth, Analytics, and Storage all have first-class web support.
+- **Mobile-only packages in `pubspec.yaml`** that will break a web build: `in_app_purchase`, `flutter_local_notifications`, `in_app_review`, `path_provider`. These must be removed or conditionally excluded before the web build works.
+- **`SubscriptionService`** (`lib/services/subscription_service.dart`) currently wraps `in_app_purchase`. It will be fully rewritten to use the Firebase Stripe Extension.
+- **`PaywallScreen`** (`lib/screens/subscription/paywall_screen.dart`) will be updated to trigger a Stripe Checkout redirect rather than opening a native IAP sheet.
+- **Firebase Hosting currently serves one site:** `fitness-app-8505e.web.app` → marketing site at `fittrack/public/`. The PWA needs a second Firebase Hosting site.
+- **PWA URL (confirmed):** `app.fitness-app-8505e.web.app` — no custom domain configuration required for launch.
+- **Subscription pricing (unchanged):** $6.99/month, $39.99/year, $59.99 lifetime. These become Stripe Price IDs instead of App Store product IDs.
+- **Notifications deferred:** `flutter_local_notifications` and FCM web push are OUT OF SCOPE for this launch. Notification service calls will be stubbed/removed so the web build compiles. A follow-up PRD will cover web push notifications.
+- **Android packaging preserved:** `fittrack/android/` and `beta_build.yml` are NOT touched by this feature.
+
+---
+
+## 4. User Stories
+
+### Story 1: Access the App via Browser
+
+**As a** new user who clicked a link to Overload,
+**I want to** open the app in my mobile browser and be prompted to install it to my home screen,
+**so that** I can use it like a native app without going through an app store.
+
+**Acceptance Criteria:**
+1. Navigating to `https://app.fitness-app-8505e.web.app` loads the Overload Flutter app in a browser.
+2. On Android Chrome, the browser displays an "Add to Home Screen" / "Install App" prompt after a brief interaction.
+3. On iOS Safari 16.4+, the user can manually add to home screen via the share sheet.
+4. After installation, the app launches in standalone mode (no browser chrome, full screen).
+5. The app icon and name ("Overload") display correctly on the home screen.
+
+---
+
+### Story 2: Subscribe via Stripe Checkout
+
+**As a** free-tier user who has hit a feature gate (e.g. attempting to create a 4th program),
+**I want to** subscribe to Overload Pro by completing a payment flow,
+**so that** I can unlock unlimited programs and advanced analytics.
+
+**Acceptance Criteria:**
+1. Tapping a Pro gate trigger (paywall screen) presents the existing plan options: Monthly ($6.99), Annual ($39.99), Lifetime ($59.99).
+2. Tapping a plan opens Stripe Checkout in the browser (redirect, not an in-app sheet).
+3. After successful payment, Stripe returns the user to the app with their subscription active.
+4. The user's subscription status updates in the app without requiring a manual refresh (Firestore listener picks up the change written by the Firebase Stripe Extension webhook).
+5. If the user closes Stripe Checkout without completing payment, they return to the paywall screen and their status remains unchanged.
+6. Subscription cancellation is handled via the Stripe Customer Portal (linked from Settings → Subscription Management screen).
+
+---
+
+### Story 3: Use the App Offline
+
+**As a** user in the gym with poor mobile signal,
+**I want to** view and log my workouts even without an internet connection,
+**so that** I don't lose a session due to connectivity issues.
+
+**Acceptance Criteria:**
+1. Programs, weeks, workouts, exercises, and sets that were previously loaded are accessible when offline.
+2. Set logging (check/uncheck, create set) works offline and syncs to Firestore when connectivity is restored.
+3. A visible indicator informs the user they are in offline mode (consistent with current offline behavior).
+4. No crash or error dialog appears when opening the app without network access.
+
+---
+
+### Story 4: App Compiles and Runs Without Mobile-Only Packages
+
+**As a** developer deploying the Flutter web build,
+**I want** the codebase to compile without errors when targeting the web platform,
+**so that** CI can build and deploy the PWA automatically.
+
+**Acceptance Criteria:**
+1. `flutter build web` completes without errors.
+2. `in_app_purchase`, `flutter_local_notifications`, `in_app_review`, and `path_provider` are removed from `pubspec.yaml`.
+3. All call sites that referenced notification APIs are removed or stubbed so the code compiles (no functionality replaced — notifications are out of scope).
+4. CSV export uses `dart:html` to trigger a browser file download instead of `path_provider`.
+5. Share functionality falls back to copy-to-clipboard with a "Copied!" confirmation.
+6. `in_app_review` prompts are removed entirely (no replacement for web).
+
+---
+
+### Story 5: CI Automatically Deploys the PWA on Push to Main
+
+**As a** developer,
+**I want** the CI pipeline to build and deploy the Flutter web app to Firebase Hosting automatically when changes merge to `main`,
+**so that** PWA deployments are hands-free and consistent.
+
+**Acceptance Criteria:**
+1. Pushing to `main` triggers `deploy_website.yml`, which builds the Flutter web app (`flutter build web --release`) and deploys it to the `app.fitness-app-8505e.web.app` Firebase Hosting site.
+2. The existing marketing site (`fitness-app-8505e.web.app`) deploys to its existing target without changes.
+3. `beta_build.yml` (Android APK build) is untouched and continues to function.
+4. Build failures surface as a failed GitHub Actions check.
+
+---
+
+## 5. Functional Requirements
+
+- FR-1: Firebase Hosting second site configured at `app.fitness-app-8505e.web.app`
+- FR-2: Flutter web build deploys to second site via CI
+- FR-3: `in_app_purchase` replaced with Firebase Stripe Extension + Stripe Checkout redirect
+- FR-4: Subscription status written to Firestore by Stripe webhook; `SubscriptionProvider` reads it unchanged
+- FR-5: Stripe Customer Portal linked from Settings → Subscription Management for cancellation/management
+- FR-6: Mobile-only packages removed from `pubspec.yaml`; all call sites compile cleanly
+- FR-7: CSV export functional via `dart:html` browser download
+- FR-8: PWA manifest and service worker validated; app installable on Android Chrome and iOS Safari
+- FR-9: Firestore offline persistence confirmed functional in PWA context
+
+---
+
+## 6. Non-Functional Requirements
+
+- NFR-1: **Performance** — Flutter web initial load under 5 seconds on 4G mobile connection
+- NFR-2: **Offline** — Core workout logging functions without network access (Firestore offline persistence)
+- NFR-3: **Security** — Stripe keys never committed to the repository; loaded via Firebase environment config
+- NFR-4: **Compatibility** — Tested on Android Chrome 120+, iOS Safari 16.4+, Chrome desktop
+- NFR-5: **Payments PCI compliance** — Stripe Checkout (hosted) handles all card data; app never handles raw card numbers
+
+---
+
+## 7. Out of Scope (Deferred)
+
+- **FCM web push notifications** — `NotificationService` and `LifecycleNotificationService` for web are a separate post-launch PRD. For this launch, notification calls are stubbed/removed.
+- **Custom domain** (`app.overload.fitness`) — deferred; launch uses `app.fitness-app-8505e.web.app`
+- **iOS App Store submission** — separate decision; Apple handles developer address differently
+- **Android Play Store submission** — the original dealbreaker; kept deferred
+
+---
+
+## 8. User Flow
+
+**New user — first open:**
+1. User opens `https://app.fitness-app-8505e.web.app` (from link or marketing site CTA)
+2. Flutter app loads; onboarding flow runs
+3. Android: browser shows install prompt → user adds to home screen
+4. iOS: user manually adds via share sheet
+
+**Subscription:**
+1. User hits Pro gate (e.g. 4th program)
+2. Paywall screen shows plan options
+3. User taps "Start Pro Monthly" → redirected to Stripe Checkout
+4. Completes payment → returned to app URL with success param
+5. Stripe webhook fires → Firebase Stripe Extension writes `status: active` to Firestore
+6. Firestore listener in `SubscriptionProvider` updates → Pro features unlock
+
+**Offline workout logging:**
+1. User opens app without internet
+2. Firestore offline cache serves data
+3. User logs sets normally
+4. On reconnection, Firestore syncs pending writes
+
+---
+
+## 9. Success Metrics
+
+- Flutter web build compiles with zero errors
+- PWA installable on Android Chrome and iOS Safari (passes Lighthouse PWA audit)
+- Stripe test subscription round-trip works end-to-end (checkout → webhook → Firestore → app unlock)
+- Offline mode: can log a set while airplane mode active; set visible in Firestore after reconnect
+- CI deploys PWA to Firebase Hosting on push to `main` without manual intervention
+
+---
+
+## 10. Overall Acceptance Criteria
+
+- [ ] `https://app.fitness-app-8505e.web.app` loads the Overload app
+- [ ] All 38 screens render without runtime errors on web
+- [ ] Stripe Checkout completes a test subscription and unlocks Pro features
+- [ ] App is installable to home screen (Android + iOS)
+- [ ] CI pipeline deploys automatically on push to `main`
+- [ ] Marketing site deployment is unaffected
+- [ ] Android build pipeline (`beta_build.yml`) is unaffected

--- a/Docs/Technical_Designs/PWA_Transition_Technical_Design.md
+++ b/Docs/Technical_Designs/PWA_Transition_Technical_Design.md
@@ -1,0 +1,814 @@
+# PWA Transition — Technical Design
+
+**Status:** Approved
+**GitHub Issue:** #478
+**PRD:** [Docs/PRDs/PWA_Transition_PRD.md](../PRDs/PWA_Transition_PRD.md)
+**Created:** 2026-06-14
+
+---
+
+## 1. Current Architecture Analysis
+
+### State Management
+Provider pattern throughout (`provider ^6.1.1`). All providers are `ChangeNotifier` subclasses registered in `main.dart` via `MultiProvider`. Auth-dependent providers use `ChangeNotifierProxyProvider`. This pattern is unchanged by the PWA pivot.
+
+### File Structure
+```
+fittrack/lib/
+  main.dart                    — Firebase init, service init, runApp
+  providers/                   — ChangeNotifier state
+  services/                    — Singletons with .instance getter + forTest constructors
+  screens/                     — Screen widgets, grouped by feature
+  models/                      — Data models + Firestore serialisation
+  widgets/                     — Shared UI components
+  converters/                  — Firestore ↔ model converters
+```
+
+### Services Pattern
+All services use a `static final instance` singleton. Test constructors (`forTest()`) accept injected dependencies (Firestore, SharedPreferences, etc.). This pattern is maintained in rewrites.
+
+### Existing Web Readiness
+`fittrack/web/` exists with PWA manifest, icons, and Flutter bootstrap. The manifest currently has stale values (`name: "fittrack"`, `description: "A new Flutter project."`) that need updating. `FirestoreService.enableOfflinePersistence()` is already called in `main.dart` — offline persistence works for web without changes.
+
+### Packages That Break the Web Build
+| Package | Used In | Reason Breaks Web |
+|---------|---------|-------------------|
+| `in_app_purchase ^3.2.0` | `SubscriptionService`, `SubscriptionProvider` | No web implementation |
+| `flutter_local_notifications ^19.4.1` | `NotificationService`, `LifecycleNotificationService` | No web implementation |
+| `timezone ^0.10.0` | `LifecycleNotificationService` | Used for `tz.TZDateTime` scheduling |
+| `in_app_review ^2.0.9` | `AppReviewService` | No web implementation |
+| `path_provider ^2.1.2` | pubspec only — not imported anywhere in lib/ | Unused; safe to drop |
+| `share_plus ^11.1.0` | pubspec only — not imported anywhere in lib/ | Unused; safe to drop |
+| `csv ^6.0.0` | pubspec only — not imported anywhere in lib/ | Unused; safe to drop |
+
+**Key finding:** `path_provider`, `share_plus`, and `csv` are declared in `pubspec.yaml` but have zero import sites in `lib/`. They can be removed with no code changes.
+
+### `dart:io` Usage in Subscription Files
+- `subscription_provider.dart:2` — `import 'dart:io'` for `Platform.isIOS` (in `_handlePurchaseUpdates`, which is being removed)
+- `subscription_management_screen.dart:1` — `import 'dart:io'` for `Platform.isIOS ? _iosManageUrl : _androidManageUrl` (replaced with a single Stripe Portal URL)
+
+Both `dart:io` imports are removed as part of the Stripe rewrite.
+
+---
+
+## 2. Architecture Overview
+
+The pivot strategy is **targeted removal + minimal replacement**: remove mobile-only package dependencies, stub notification services, rewrite subscription billing to Stripe, update infra config. The core app architecture (Provider, Firestore, Auth, all 38 screens) is untouched.
+
+### What Changes
+1. **Packages** — 7 packages removed from `pubspec.yaml` (4 have code, 3 are unused)
+2. **Notification services** — stubbed to no-ops; analytics tracking inside `LifecycleNotificationService` preserved
+3. **Subscription service + provider** — rewritten to use Firebase Stripe Extension via Firestore
+4. **Paywall and management screens** — updated for Stripe Checkout redirect and Customer Portal
+5. **Firebase Hosting config** — second site added for PWA
+6. **CI pipeline** — Flutter web build + deploy step added
+7. **PWA manifest + index.html** — branding updated to "Overload"
+
+### What Stays Identical
+- All 38 screens (rendering, navigation, business logic)
+- All providers except `SubscriptionProvider`
+- `FirestoreService` (offline persistence already enabled)
+- `AuthProvider`, `ProgramProvider`, all other providers
+- Firebase Auth, Analytics, Crashlytics (all web-compatible)
+- `SubscriptionInfo` model and `SubscriptionProvider` gating logic (`isPro`, `maxPrograms`, `maxCustomExercises`)
+- `fittrack/android/` and `beta_build.yml` — preserved entirely
+
+---
+
+## 3. Detailed Design
+
+### Task #481 — Remove Mobile-Only Package Dependencies
+
+**Foundation task — must be completed first as it unblocks the web build.**
+
+#### pubspec.yaml changes
+Remove from `dependencies`:
+```yaml
+# Remove these 4:
+flutter_local_notifications: ^19.4.1
+timezone: ^0.10.0
+in_app_purchase: ^3.2.0
+in_app_review: ^2.0.9
+
+# Remove these 3 (unused in code):
+path_provider: ^2.1.2
+share_plus: ^11.1.0
+csv: ^6.0.0
+```
+
+Keep all others unchanged. `firebase_messaging ^16.0.1` stays — it is web-compatible and still used for FCM token storage in `LifecycleNotificationService`.
+
+#### lib/services/notification_service.dart — Stub
+Replace entire file with a no-op stub. The public API (`initialize`, `scheduleWorkoutReminder`, `scheduleRecurringWorkoutReminder`, `showNotification`, `cancelNotification`, `cancelAllNotifications`, `getPendingNotifications`) is preserved so call sites continue to compile, but all methods are no-ops.
+
+Remove the `Day` and `Time` classes (they were internal to the scheduling API). If any call site references them, remove those call sites.
+
+```dart
+// Stub: local notification scheduling deferred to FCM web push PRD
+class NotificationService {
+  static final NotificationService instance = NotificationService._();
+  NotificationService._();
+
+  Future<void> initialize() async {}
+  Future<void> scheduleWorkoutReminder({...}) async {}
+  Future<void> scheduleRecurringWorkoutReminder({...}) async {}
+  Future<void> showNotification({...}) async {}
+  Future<void> cancelNotification(int id) async {}
+  Future<void> cancelAllNotifications() async {}
+  Future<List<Never>> getPendingNotifications() async => [];
+}
+```
+
+#### lib/services/lifecycle_notification_service.dart — Partial stub
+This service has two roles: notification scheduling (remove) and retention analytics tracking (keep). Analytics tracking uses only `SharedPreferences` and `AppAnalyticsService` — both web-compatible.
+
+Remove:
+- `flutter_local_notifications` import
+- `timezone` import
+- `FlutterLocalNotificationsPlugin _localNotifications` field
+- `_initLocalNotifications()`, `_scheduleLocalNotification()`, `_scheduleActivationNotifications()`, `_scheduleRetentionNotifications()`, `_showPRNotification()` methods
+- `_day1NotifId`, `_day3NotifId`, `_day10NotifId`, `_day30NotifId`, `_prNotifBaseId` constants
+- Notification channel ID constants
+
+Keep:
+- `FirebaseMessaging` import and `_messaging` field (FCM token storage, web-compatible)
+- SharedPreferences tracking keys and state
+- `_initFCM()`, `_onFCMTokenRefresh()`, `_onFCMMessageReceived()`
+- Analytics logging: `_logRetentionSessions()`, `AppAnalyticsService` calls
+- `recordWorkoutLogged()` analytics logic (milestone events)
+- `requestPermissionIfEligible()` — keep but just requests FCM permission, no local notifications
+
+Update `recordWorkoutLogged()` to remove the `_localNotifications.cancel(...)` calls (since local notifications are gone). Keep the analytics milestone logic.
+
+Update `onAppLaunch()` to only call `_scheduleRetentionNotifications()` as a no-op stub (or remove it entirely and just call `_logRetentionSessions()`).
+
+#### lib/services/app_review_service.dart — Stub review call
+Remove `in_app_review` import and `InAppReview _inAppReview` field.
+
+In `maybeRequestReview()`: keep eligibility check and analytics logging, but replace the actual `_inAppReview.requestReview()` call with a no-op. The service remains structurally intact for future use.
+
+```dart
+// In maybeRequestReview():
+try {
+  await AppAnalyticsService.instance.logReviewPromptTriggered();
+  // in_app_review has no web equivalent — review prompt deferred
+  await _prefs.setBool(_reviewRequestedKey, true);
+} catch (e) {
+  _requestedThisSession = false;
+}
+```
+
+Update `AppReviewService.forTest` constructor to remove the `InAppReview` parameter (breaking change in test constructor — update test files accordingly).
+
+#### lib/main.dart — Remove notification init
+The `NotificationService.instance.initialize()` call can stay (it's now a no-op). No changes needed — the stub handles it silently.
+
+---
+
+### Task #479 — Firebase Hosting Multi-Site Configuration
+
+#### Step 1: Create second Firebase Hosting site
+Developer action in Firebase Console:
+1. Go to Firebase Console → Hosting → Add another site
+2. Site ID: `fittrack-app` (produces URL `fittrack-app.web.app`)
+3. Note: Firebase Hosting site IDs are globally unique. `app.fitness-app-8505e.web.app` is not a valid Firebase Hosting URL — the actual URL will be `fittrack-app.web.app` (or the chosen site ID). This is the correct PWA launch URL.
+
+#### fittrack/.firebaserc — Add hosting targets
+```json
+{
+  "projects": {
+    "default": "fitness-app-8505e"
+  },
+  "targets": {
+    "fitness-app-8505e": {
+      "hosting": {
+        "marketing": ["fitness-app-8505e"],
+        "app": ["fittrack-app"]
+      }
+    }
+  }
+}
+```
+
+#### fittrack/firebase.json — Convert to array format
+Convert `"hosting"` from a single object to an array with two targets:
+
+```json
+{
+  "functions": [...],
+  "hosting": [
+    {
+      "target": "marketing",
+      "public": "public",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "cleanUrls": true,
+      "trailingSlash": false,
+      "404": "404.html",
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "app",
+      "public": "build/web",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          ]
+        },
+        {
+          "source": "/flutter_service_worker.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache" }
+          ]
+        }
+      ]
+    }
+  ],
+  "firestore": {...},
+  "emulators": {...}
+}
+```
+
+**Note on PWA routing:** Flutter web apps are single-page apps. The `"rewrites": [{"source": "**", "destination": "/index.html"}]` rule ensures deep links and page refreshes serve `index.html` rather than 404. The service worker header prevents the service worker from being cached, ensuring PWA updates deploy immediately.
+
+---
+
+### Task #480 — Replace in_app_purchase with Stripe Subscription Billing
+
+**This is the most complex task (~2 weeks). Depends on #481.**
+
+#### Prerequisites (developer actions before coding)
+1. Create Stripe account and activate it
+2. Install Firebase Stripe Extension in Firebase Console (Extensions → stripe-firestore-stripe-payments)
+3. Configure extension:
+   - Stripe API key (secret key from Stripe dashboard)
+   - Products collection: `customers`
+   - Sync new users: Yes
+4. Create three Stripe Products in Stripe Dashboard:
+   - Monthly: $6.99/month recurring → note Price ID (`price_monthly_xxx`)
+   - Annual: $39.99/year recurring → note Price ID (`price_annual_xxx`)
+   - Lifetime: $59.99 one-time → note Price ID (`price_lifetime_xxx`)
+5. Enable Stripe Customer Portal in Stripe Dashboard (Settings → Billing → Customer Portal)
+6. Store Price IDs in Firebase Remote Config (or as constants, updated before launch)
+7. Configure Stripe Checkout success/cancel URLs:
+   - Success: `https://fittrack-app.web.app/?checkout=success`
+   - Cancel: `https://fittrack-app.web.app/?checkout=cancelled`
+
+#### How Firebase Stripe Extension Works
+The extension creates a Firestore-based integration:
+- Creates `customers/{userId}` document when a user signs up (synced from Firebase Auth)
+- To start a checkout session: write to `customers/{userId}/checkout_sessions`
+- Extension creates Stripe Checkout session and writes back the `url`
+- App reads the `url` and redirects the browser to it via `url_launcher`
+- Stripe handles payment, then redirects back to the app's success URL
+- Stripe webhook fires → extension writes subscription status to `customers/{userId}/subscriptions`
+- `SubscriptionProvider` listens to this collection and updates app state
+
+#### lib/services/subscription_service.dart — Full rewrite
+
+Remove all `in_app_purchase` code. New implementation:
+
+```dart
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+import '../models/subscription.dart';
+
+class SubscriptionService {
+  static final SubscriptionService instance = SubscriptionService._();
+
+  static const String monthlyPriceId = 'price_monthly_xxx';   // set from config
+  static const String annualPriceId = 'price_annual_xxx';     // set from config
+  static const String lifetimePriceId = 'price_lifetime_xxx'; // set from config
+
+  final FirebaseFirestore? _injectedFirestore;
+  FirebaseFirestore get _firestore =>
+      _injectedFirestore ?? FirebaseFirestore.instance;
+
+  SubscriptionService._() : _injectedFirestore = null;
+
+  @visibleForTesting
+  SubscriptionService.forTest(FirebaseFirestore firestore)
+      : _injectedFirestore = firestore;
+
+  /// Stream of active Stripe subscriptions for [userId].
+  /// Written by the Firebase Stripe Extension webhook.
+  Stream<SubscriptionInfo> subscriptionStream(String userId) {
+    return _firestore
+        .collection('customers')
+        .doc(userId)
+        .collection('subscriptions')
+        .where('status', whereIn: ['active', 'trialing'])
+        .snapshots()
+        .map((snapshot) {
+          if (snapshot.docs.isEmpty) return SubscriptionInfo.free();
+          final data = snapshot.docs.first.data();
+          return SubscriptionInfo.fromStripeFirestore(data);
+        });
+  }
+
+  /// Writes a checkout session document and returns the Stripe Checkout URL.
+  /// The Firebase Stripe Extension populates the `url` field asynchronously.
+  Future<String> createCheckoutSession({
+    required String userId,
+    required String priceId,
+    required String successUrl,
+    required String cancelUrl,
+  }) async {
+    final sessionRef = await _firestore
+        .collection('customers')
+        .doc(userId)
+        .collection('checkout_sessions')
+        .add({
+      'price': priceId,
+      'success_url': successUrl,
+      'cancel_url': cancelUrl,
+      'mode': priceId == lifetimePriceId ? 'payment' : 'subscription',
+      'allow_promotion_codes': true,
+    });
+
+    // Wait for extension to populate url (timeout after 10s)
+    final snapshot = await sessionRef.snapshots().firstWhere(
+      (snap) => snap.data()?['url'] != null || snap.data()?['error'] != null,
+    ).timeout(const Duration(seconds: 10));
+
+    final error = snapshot.data()?['error'] as String?;
+    if (error != null) throw Exception('Stripe checkout error: $error');
+
+    return snapshot.data()!['url'] as String;
+  }
+
+  /// Loads the Stripe Customer Portal URL for subscription management.
+  /// The Customer Portal shareable link is configured in the Stripe Dashboard.
+  static const String stripePortalUrl =
+      'https://billing.stripe.com/p/login/xxx'; // configured post-launch
+
+  /// Fallback: reads subscription status directly from Firestore.
+  Future<SubscriptionInfo> loadFromFirestore(String userId) async {
+    final snapshot = await _firestore
+        .collection('customers')
+        .doc(userId)
+        .collection('subscriptions')
+        .where('status', whereIn: ['active', 'trialing'])
+        .limit(1)
+        .get();
+
+    if (snapshot.docs.isEmpty) return SubscriptionInfo.free();
+    return SubscriptionInfo.fromStripeFirestore(snapshot.docs.first.data());
+  }
+}
+```
+
+#### lib/models/subscription.dart — Add Stripe factory
+Add `SubscriptionInfo.fromStripeFirestore`:
+
+```dart
+factory SubscriptionInfo.fromStripeFirestore(Map<String, dynamic> data) {
+  final statusStr = data['status'] as String? ?? 'unknown';
+  final isActive = statusStr == 'active' || statusStr == 'trialing';
+  final priceId = (data['items'] as List?)?.firstOrNull?['price']?['id'] as String?;
+  final periodEnd = (data['current_period_end'] as Timestamp?)?.toDate();
+  return SubscriptionInfo(
+    tier: isActive ? SubscriptionTier.pro : SubscriptionTier.free,
+    status: isActive ? SubscriptionStatus.active : SubscriptionStatus.unknown,
+    productId: priceId,
+    platform: 'web',
+    expiresAt: periodEnd,
+  );
+}
+```
+
+Keep `SubscriptionInfo.fromFirestore` for backwards compatibility with any existing Firestore data written by the old IAP integration.
+
+#### lib/providers/subscription_provider.dart — Rewrite
+
+Remove all `in_app_purchase` imports and `PurchaseDetails` handling. Replace with a Firestore stream listener:
+
+```dart
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import '../models/subscription.dart';
+import '../providers/auth_provider.dart';
+import '../services/subscription_service.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class SubscriptionProvider extends ChangeNotifier {
+  SubscriptionInfo _subscriptionInfo = SubscriptionInfo.free();
+  bool _isProOverride = false;
+  bool _isLoading = false;
+  String? _error;
+  StreamSubscription<SubscriptionInfo>? _subscriptionStream;
+  bool _disposed = false;
+
+  // Public getters — unchanged interface used throughout the app
+  bool get isPro => _isProOverride || _subscriptionInfo.isPro;
+  bool get isFree => !isPro;
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+  SubscriptionInfo get subscriptionInfo => _subscriptionInfo;
+  bool get isProOverride => _isProOverride;
+  int get maxPrograms => isPro ? 999 : 3;
+  int get maxCustomExercises => isPro ? 50 : 5;
+
+  void update(AuthProvider auth) {
+    final userId = auth.user?.uid;
+    final profile = auth.userProfile;
+    if (userId == null) { _reset(); return; }
+    _isProOverride = profile?.isProOverride ?? false;
+    _initialize(userId);
+  }
+
+  Future<void> _initialize(String userId) async {
+    // Load cached status immediately
+    final cached = await SubscriptionService.instance.loadFromFirestore(userId);
+    _subscriptionInfo = cached;
+    _safeNotify();
+
+    // Start real-time listener
+    _subscriptionStream?.cancel();
+    _subscriptionStream = SubscriptionService.instance
+        .subscriptionStream(userId)
+        .listen((info) {
+          _subscriptionInfo = info;
+          _safeNotify();
+        });
+  }
+
+  /// Opens Stripe Checkout for the given price ID.
+  /// Returns true if the URL launched successfully.
+  Future<bool> startCheckout(String userId, String priceId) async {
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    try {
+      final url = await SubscriptionService.instance.createCheckoutSession(
+        userId: userId,
+        priceId: priceId,
+        successUrl: 'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+      final uri = Uri.parse(url);
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      _isLoading = false;
+      _safeNotify();
+      return launched;
+    } catch (e) {
+      _error = 'Could not start checkout. Please try again.';
+      _isLoading = false;
+      _safeNotify();
+      return false;
+    }
+  }
+
+  Future<void> openCustomerPortal() async {
+    final uri = Uri.parse(SubscriptionService.stripePortalUrl);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  void clearError() { _error = null; _safeNotify(); }
+
+  @visibleForTesting
+  void setSubscriptionInfoForTest(SubscriptionInfo info) {
+    _subscriptionInfo = info; _safeNotify();
+  }
+
+  @visibleForTesting
+  void setProOverrideForTest({required bool value}) {
+    _isProOverride = value; _safeNotify();
+  }
+
+  void _reset() {
+    _subscriptionInfo = SubscriptionInfo.free();
+    _isProOverride = false;
+    _isLoading = false;
+    _error = null;
+    _subscriptionStream?.cancel();
+    _subscriptionStream = null;
+    _safeNotify();
+  }
+
+  void _safeNotify() { if (!_disposed) notifyListeners(); }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _subscriptionStream?.cancel();
+    super.dispose();
+  }
+}
+```
+
+**Important:** `startCheckout` requires the userId. The PaywallScreen gets this from `AuthProvider` via Provider. The `SubscriptionProvider.update()` receives `AuthProvider` but doesn't store the userId — the paywall screen must read userId from the auth provider directly when calling `startCheckout`.
+
+#### lib/screens/subscription/paywall_screen.dart — Update for Stripe redirect
+
+Remove `sub.purchaseAnnual()` / `sub.purchaseMonthly()` calls. Replace with `sub.startCheckout(userId, priceId)`.
+
+Changes:
+- Add `context.read<AuthProvider>().user?.uid` to get userId
+- Remove "Restore purchases" button (no web equivalent for Stripe)
+- Update plan cards to show all three plans (Monthly, Annual, Lifetime)
+- Use hardcoded prices in the display (Stripe price IDs don't carry display prices)
+- Update `sub.annualProduct?.price` and `sub.monthlyProduct?.price` to hardcoded strings
+
+The `_PlanCard` widget stays identical. The `onTap` callbacks change:
+```dart
+onTap: () {
+  Navigator.of(context).pop();
+  final userId = context.read<AuthProvider>().user?.uid;
+  if (userId != null) {
+    context.read<SubscriptionProvider>()
+        .startCheckout(userId, SubscriptionService.annualPriceId);
+  }
+}
+```
+
+#### lib/screens/subscription/subscription_management_screen.dart — Stripe Portal
+
+Remove `dart:io` import and `Platform.isIOS` check. Replace `_openManageSubscription()` to use Stripe Customer Portal:
+
+```dart
+Future<void> _openManageSubscription(BuildContext context) async {
+  await context.read<SubscriptionProvider>().openCustomerPortal();
+}
+```
+
+Remove the iOS/Android URL constants. The "Restore purchases" button is removed (no Stripe equivalent).
+
+#### Firestore Security Rules Update
+The Firebase Stripe Extension requires read access to `customers/{uid}/subscriptions` for the authenticated user. Add to `firestore.rules`:
+
+```
+match /customers/{userId} {
+  allow read: if request.auth != null && request.auth.uid == userId;
+  allow write: if false; // Extension writes via admin SDK
+
+  match /checkout_sessions/{sessionId} {
+    allow read, write: if request.auth != null && request.auth.uid == userId;
+  }
+
+  match /subscriptions/{subscriptionId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false; // Extension writes via admin SDK
+  }
+}
+```
+
+---
+
+### Task #483 — Update CI Pipeline for Flutter Web Builds
+
+**Depends on #479 (needs the app hosting site to exist) and #481 (needs web build to compile).**
+
+#### .github/workflows/deploy_website.yml — Full rewrite
+
+Add Flutter setup and web build. Deploy both targets:
+
+```yaml
+name: Deploy Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'fittrack/public/**'
+      - 'fittrack/lib/**'
+      - 'fittrack/web/**'
+      - 'fittrack/pubspec.yaml'
+      - 'fittrack/firebase.json'
+  workflow_dispatch:
+
+jobs:
+  deploy-marketing:
+    name: Deploy Marketing Site
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy marketing site to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: fitness-app-8505e
+          target: marketing
+          channelId: live
+          entryPoint: ./fittrack
+
+  deploy-pwa:
+    name: Build and Deploy PWA
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.35.1
+          cache: true
+
+      - name: Install dependencies
+        run: |
+          cd fittrack
+          flutter pub get
+
+      - name: Build Flutter web
+        run: |
+          cd fittrack
+          flutter build web --release
+
+      - name: Deploy PWA to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: fitness-app-8505e
+          target: app
+          channelId: live
+          entryPoint: ./fittrack
+```
+
+**Note:** Splitting into two jobs allows the marketing site to deploy even if the Flutter build fails, and vice versa.
+
+The `paths` trigger now includes `fittrack/lib/**`, `fittrack/web/**`, and `fittrack/pubspec.yaml` so code changes trigger a redeploy.
+
+---
+
+### Task #482 — PWA Install Prompt and Offline Service Worker Validation
+
+**Final task — run after all others are complete.**
+
+#### fittrack/web/manifest.json — Update branding
+
+```json
+{
+  "name": "Overload",
+  "short_name": "Overload",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "description": "Structured strength tracking. Built for progressive overload.",
+  "orientation": "portrait-primary",
+  "prefer_related_applications": false,
+  "icons": [
+    { "src": "icons/Icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icons/Icon-512.png", "sizes": "512x512", "type": "image/png" },
+    {
+      "src": "icons/Icon-maskable-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "icons/Icon-maskable-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}
+```
+
+#### fittrack/web/index.html — Update branding
+
+Update:
+- `<meta name="apple-mobile-web-app-title" content="Overload">`
+- `<meta name="description" content="Structured strength tracking. Built for progressive overload.">`
+- `<title>Overload</title>`
+
+#### Firestore offline persistence
+Already configured in `main.dart` via `FirestoreService.enableOfflinePersistence()`. No changes needed. Verify it works in web by testing offline scenario in Chrome DevTools.
+
+#### Validation checklist for developer
+- [ ] Run `flutter build web` locally — zero errors
+- [ ] Deploy to `fittrack-app.web.app` via CI
+- [ ] Open URL in Android Chrome → install prompt appears after interaction
+- [ ] Open URL in iOS Safari 16.4+ → add to home screen via share sheet works
+- [ ] App icon shows "Overload" on home screen
+- [ ] Standalone mode (no browser chrome) confirmed
+- [ ] Enable airplane mode → previously loaded programs visible and editable
+- [ ] Log a set offline → set visible in Firestore after re-enabling network
+- [ ] Run Lighthouse PWA audit → passes installability checks
+
+---
+
+## 4. Task Sequencing and Dependencies
+
+```
+#481 (Remove mobile-only packages)    ──┬──► #480 (Stripe billing)
+                                        │
+#479 (Firebase Hosting multi-site)  ────┤
+                                        │
+                                        ├──► #483 (CI pipeline)
+                                        │
+                                        └──► #482 (PWA validation) ← all others
+```
+
+**Recommended order:**
+1. **#481** — Foundation. Enables `flutter build web`. ~2 days.
+2. **#479** — Infra. Can be done in parallel with #481 (touches different files). ~0.5 days.
+3. **#480** — Stripe billing. Depends on #481 (IAP must be gone). ~2 weeks.
+4. **#483** — CI. Depends on #479 + #481. ~0.5 days.
+5. **#482** — Validation. Depends on all others. ~1–2 days.
+
+---
+
+## 5. Testing Strategy
+
+Following the existing testing patterns (mockito, `fake_cloud_firestore`, integration test helpers).
+
+### Task #481 Tests
+- Unit tests for stubbed `NotificationService` — all methods return without error
+- Unit tests for `LifecycleNotificationService` analytics tracking still fires (mock SharedPreferences, mock AppAnalyticsService)
+- Unit tests for `AppReviewService.maybeRequestReview()` no-op path
+- No web build test here — verified in #483 CI step
+
+### Task #480 Tests
+- Unit tests for `SubscriptionService` (`forTest` constructor with `fake_cloud_firestore`):
+  - `subscriptionStream` returns `SubscriptionInfo.free()` when no subscriptions
+  - `subscriptionStream` returns `SubscriptionInfo` with `isPro: true` when active subscription exists
+  - `createCheckoutSession` writes correct document to Firestore
+  - `loadFromFirestore` returns correct status
+- Unit tests for `SubscriptionProvider`:
+  - `isPro` gate works correctly for all status values
+  - `startCheckout` sets `isLoading` then clears it
+  - `openCustomerPortal` calls `url_launcher` with the portal URL
+- Widget tests for `PaywallScreen`:
+  - Renders three plan cards (Monthly, Annual, Lifetime)
+  - Tapping a plan calls `startCheckout`
+  - Loading state shows `CircularProgressIndicator`
+- **Integration test** (`test/services/subscription_service_integration_test.dart`) — required per `CLAUDE.md`
+
+### Task #482 Tests
+- Manual validation only (no automated tests for Lighthouse or manual install flow)
+- Offline test: use Chrome DevTools to verify Firestore cache serves data
+
+---
+
+## 6. Security Considerations
+
+- **Stripe secret key** — stored in Firebase Extension config (environment variable in Google Cloud), never in the Flutter app or repository
+- **Stripe publishable key** — not needed; using Stripe Checkout redirect, not embedded SDK
+- **Firestore rules** — `customers/{uid}/subscriptions` readable only by the authenticated user; writable only by the Extension (admin SDK)
+- **Checkout session** — written by the Flutter client but the Extension validates it server-side before creating the Stripe session; no price manipulation possible
+- **dart:io removal** — eliminates `Platform.isIOS` checks that could behave unexpectedly on web
+
+---
+
+## 7. Files Summary
+
+### New files
+None — all changes are modifications to existing files.
+
+### Modified files (by task)
+
+**#481:**
+- `fittrack/pubspec.yaml` — remove 7 packages
+- `fittrack/lib/services/notification_service.dart` — stub rewrite
+- `fittrack/lib/services/lifecycle_notification_service.dart` — partial stub (keep analytics)
+- `fittrack/lib/services/app_review_service.dart` — remove InAppReview, no-op review call
+
+**#479:**
+- `fittrack/firebase.json` — convert hosting to array, add app target
+- `fittrack/.firebaserc` — add hosting targets
+
+**#480:**
+- `fittrack/lib/services/subscription_service.dart` — full rewrite (Stripe)
+- `fittrack/lib/providers/subscription_provider.dart` — rewrite (Firestore stream)
+- `fittrack/lib/models/subscription.dart` — add `fromStripeFirestore` factory
+- `fittrack/lib/screens/subscription/paywall_screen.dart` — Stripe Checkout redirect
+- `fittrack/lib/screens/subscription/subscription_management_screen.dart` — Stripe Portal
+- `fittrack/firestore.rules` — add `customers` collection rules
+
+**#483:**
+- `.github/workflows/deploy_website.yml` — add Flutter build + multi-target deploy
+
+**#482:**
+- `fittrack/web/manifest.json` — update to "Overload" branding
+- `fittrack/web/index.html` — update title and meta tags
+
+---
+
+## 8. Implementation Notes
+
+*(To be updated by Developer Agent as implementation progresses)*

--- a/fittrack/lib/providers/subscription_provider.dart
+++ b/fittrack/lib/providers/subscription_provider.dart
@@ -1,13 +1,13 @@
-import 'dart:async';
-import 'dart:io';
 import 'package:flutter/foundation.dart';
-import 'package:in_app_purchase/in_app_purchase.dart';
 import '../models/subscription.dart';
 import '../providers/auth_provider.dart';
 import '../services/subscription_service.dart';
 
 /// Manages subscription state and exposes computed limits used throughout
 /// the app to gate premium features.
+///
+/// IAP purchase stream removed for PWA transition. Subscription status is
+/// loaded from Firestore on sign-in. Full Stripe billing is added in Task #480.
 ///
 /// Registered as a [ChangeNotifierProxyProvider] so it reacts to auth state
 /// changes — resetting when the user signs out and re-initialising when they
@@ -17,12 +17,10 @@ class SubscriptionProvider extends ChangeNotifier {
   bool _isProOverride = false;
   bool _isLoading = false;
   String? _error;
-  StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
   bool _disposed = false;
 
   // --- Public getters ---
 
-  /// True when the user has an active Pro subscription or the developer bypass.
   bool get isPro => _isProOverride || _subscriptionInfo.isPro;
   bool get isFree => !isPro;
   bool get isLoading => _isLoading;
@@ -30,14 +28,15 @@ class SubscriptionProvider extends ChangeNotifier {
   SubscriptionInfo get subscriptionInfo => _subscriptionInfo;
   bool get isProOverride => _isProOverride;
 
-  // Computed limits used by gating logic throughout the app.
   int get maxPrograms => isPro ? 999 : 3;
   int get maxCustomExercises => isPro ? 50 : 5;
 
-  List<ProductDetails> get products => SubscriptionService.instance.products;
-  ProductDetails? get monthlyProduct =>
+  // Stub product getters — replaced with Stripe price data in Task #480.
+  List<Map<String, dynamic>> get products =>
+      SubscriptionService.instance.products;
+  Map<String, dynamic>? get monthlyProduct =>
       SubscriptionService.instance.monthlyProduct;
-  ProductDetails? get annualProduct =>
+  Map<String, dynamic>? get annualProduct =>
       SubscriptionService.instance.annualProduct;
 
   // --- ProxyProvider update ---
@@ -56,101 +55,31 @@ class SubscriptionProvider extends ChangeNotifier {
   // --- Initialisation ---
 
   Future<void> _initialize(String userId) async {
-    // Fast path: load cached Firestore status before IAP initialises.
     final cached =
         await SubscriptionService.instance.loadFromFirestore(userId);
     if (cached != null) {
       _subscriptionInfo = cached;
       _safeNotify();
     }
-
-    // Initialise IAP plugin and load store products.
-    await SubscriptionService.instance.initialize();
-
-    // Start listening to purchase stream.
-    _purchaseSubscription?.cancel();
-    _purchaseSubscription = SubscriptionService.instance.purchaseStream
-        .listen((purchases) => _handlePurchaseUpdates(purchases, userId));
-
-    // Silent restore to pick up any active subscriptions on sign-in / re-launch.
-    await SubscriptionService.instance.restorePurchases();
   }
 
-  // --- Purchase stream handler ---
+  // --- Purchase action stubs (replaced by Stripe checkout in Task #480) ---
 
-  Future<void> _handlePurchaseUpdates(
-      List<PurchaseDetails> purchases, String userId) async {
-    for (final purchase in purchases) {
-      switch (purchase.status) {
-        case PurchaseStatus.purchased:
-        case PurchaseStatus.restored:
-          final info = SubscriptionInfo(
-            tier: SubscriptionTier.pro,
-            status: SubscriptionStatus.active,
-            productId: purchase.productID,
-            platform: Platform.isIOS ? 'ios' : 'android',
-          );
-          _subscriptionInfo = info;
-          await SubscriptionService.instance.syncToFirestore(userId, info);
-          await SubscriptionService.instance.completePurchase(purchase);
-          _isLoading = false;
-          _safeNotify();
-
-        case PurchaseStatus.error:
-          _error = purchase.error?.message ?? 'Purchase failed';
-          _isLoading = false;
-          _safeNotify();
-
-        case PurchaseStatus.pending:
-          _isLoading = true;
-          _safeNotify();
-
-        case PurchaseStatus.canceled:
-          _isLoading = false;
-          _safeNotify();
-      }
-    }
-  }
-
-  // --- Purchase actions ---
-
-  Future<void> purchaseMonthly() async {
-    final product = monthlyProduct;
-    if (product == null) return;
-    _error = null;
-    _isLoading = true;
-    _safeNotify();
-    await SubscriptionService.instance.buySubscription(product);
-  }
-
-  Future<void> purchaseAnnual() async {
-    final product = annualProduct;
-    if (product == null) return;
-    _error = null;
-    _isLoading = true;
-    _safeNotify();
-    await SubscriptionService.instance.buySubscription(product);
-  }
-
-  Future<void> restorePurchases() async {
-    _isLoading = true;
-    _safeNotify();
-    await SubscriptionService.instance.restorePurchases();
-  }
+  Future<void> purchaseMonthly() async {}
+  Future<void> purchaseAnnual() async {}
+  Future<void> restorePurchases() async {}
 
   void clearError() {
     _error = null;
     _safeNotify();
   }
 
-  /// Sets subscription state directly without triggering IAP — for tests only.
   @visibleForTesting
   void setSubscriptionInfoForTest(SubscriptionInfo info) {
     _subscriptionInfo = info;
     _safeNotify();
   }
 
-  /// Sets the pro override flag directly — for tests only.
   @visibleForTesting
   void setProOverrideForTest({required bool value}) {
     _isProOverride = value;
@@ -164,8 +93,6 @@ class SubscriptionProvider extends ChangeNotifier {
     _isProOverride = false;
     _isLoading = false;
     _error = null;
-    _purchaseSubscription?.cancel();
-    _purchaseSubscription = null;
     _safeNotify();
   }
 
@@ -176,7 +103,6 @@ class SubscriptionProvider extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
-    _purchaseSubscription?.cancel();
     super.dispose();
   }
 }

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -118,7 +118,7 @@ class PaywallScreen extends StatelessWidget {
                     label: 'Annual',
                     badge: 'RECOMMENDED',
                     savings: 'Save 52% vs monthly',
-                    price: sub.annualProduct?.price ?? '\$39.99/year',
+                    price: '\$39.99/year',
                     detail: 'Billed annually · 14-day free trial',
                     isRecommended: true,
                     onTap: () {
@@ -131,7 +131,7 @@ class PaywallScreen extends StatelessWidget {
                   // Monthly plan card
                   _PlanCard(
                     label: 'Monthly',
-                    price: sub.monthlyProduct?.price ?? '\$6.99/month',
+                    price: '\$6.99/month',
                     detail: '14-day free trial',
                     isRecommended: false,
                     onTap: () {

--- a/fittrack/lib/screens/subscription/subscription_management_screen.dart
+++ b/fittrack/lib/screens/subscription/subscription_management_screen.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -8,9 +7,8 @@ import '../../providers/subscription_provider.dart';
 class SubscriptionManagementScreen extends StatelessWidget {
   const SubscriptionManagementScreen({super.key});
 
-  static const _iosManageUrl = 'https://apps.apple.com/account/subscriptions';
-  static const _androidManageUrl =
-      'https://play.google.com/store/account/subscriptions';
+  // Placeholder — replaced with Stripe Customer Portal URL in Task #480.
+  static const _manageUrl = 'https://billing.stripe.com/p/login/placeholder';
 
   @override
   Widget build(BuildContext context) {
@@ -131,8 +129,7 @@ class SubscriptionManagementScreen extends StatelessWidget {
   }
 
   Future<void> _openManageSubscription() async {
-    final url = Platform.isIOS ? _iosManageUrl : _androidManageUrl;
-    final uri = Uri.parse(url);
+    final uri = Uri.parse(_manageUrl);
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri, mode: LaunchMode.externalApplication);
     }

--- a/fittrack/lib/services/app_review_service.dart
+++ b/fittrack/lib/services/app_review_service.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/foundation.dart';
-import 'package:in_app_review/in_app_review.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'app_analytics_service.dart';
 
-/// Manages the in-app review prompt lifecycle.
+/// Manages the app review prompt lifecycle.
+///
+/// On web, native review dialogs are not available. The eligibility check and
+/// analytics event are preserved so the data pipeline is intact. The actual
+/// review call is a no-op until a platform-appropriate replacement is added.
 ///
 /// Eligible if: workouts started ≥ 5 AND days since first launch ≥ 7
 /// AND review has not already been requested on this install.
-///
-/// The platform (iOS/Android) applies its own rate limiting on top —
-/// calling [requestReview] does not guarantee the dialog appears.
 class AppReviewService {
   static const String _firstLaunchKey = 'overload_first_launch_date';
   static const String _workoutCountKey = 'overload_workout_count';
@@ -22,35 +22,24 @@ class AppReviewService {
   static AppReviewService get instance => _instance!;
 
   final SharedPreferences _prefs;
-  final InAppReview _inAppReview;
 
-  // Guards against firing twice in one app session (e.g. navigating back from
-  // multiple workouts in the same session).
   bool _requestedThisSession = false;
 
-  AppReviewService._internal(this._prefs, this._inAppReview) {
+  AppReviewService._internal(this._prefs) {
     _recordFirstLaunchIfNeeded();
   }
 
   @visibleForTesting
-  AppReviewService.forTest(SharedPreferences prefs, InAppReview inAppReview)
-      : _prefs = prefs,
-        _inAppReview = inAppReview {
+  AppReviewService.forTest(SharedPreferences prefs) : _prefs = prefs {
     _recordFirstLaunchIfNeeded();
   }
 
   static void initialize(SharedPreferences prefs) {
-    _instance = AppReviewService._internal(prefs, InAppReview.instance);
+    _instance = AppReviewService._internal(prefs);
   }
 
-  /// Null-safe wrapper for use in widget code.
-  ///
-  /// Widget tests that don't go through [main] or [OverloadApp] never call
-  /// [initialize], so [_instance] is null. These static helpers no-op
-  /// in that case instead of throwing.
   static void tryRecordWorkoutStarted() => _instance?.recordWorkoutStarted();
 
-  /// Null-safe wrapper for use in widget code. See [tryRecordWorkoutStarted].
   static void tryMaybeRequestReview() {
     _instance?.maybeRequestReview();
   }
@@ -61,8 +50,6 @@ class AppReviewService {
     }
   }
 
-  /// Called each time the user opens a workout. Increments the counter used
-  /// for review eligibility.
   void recordWorkoutStarted() {
     final count = _prefs.getInt(_workoutCountKey) ?? 0;
     _prefs.setInt(_workoutCountKey, count + 1);
@@ -83,29 +70,23 @@ class AppReviewService {
       daysSinceFirstLaunch >= _minDaysSinceLaunch &&
       !hasBeenRequested;
 
-  /// Checks eligibility and requests a review if conditions are met.
+  /// Checks eligibility and logs the review prompt analytics event.
   ///
-  /// Safe to call speculatively — returns immediately if ineligible.
-  /// Must NOT be called from within an active workout screen.
+  /// The actual review dialog is omitted on web — this preserves the
+  /// eligibility gate and analytics so the data pipeline remains intact.
   Future<void> maybeRequestReview() async {
     if (!isEligible || _requestedThisSession) return;
     _requestedThisSession = true;
 
     try {
       await AppAnalyticsService.instance.logReviewPromptTriggered();
-
-      final available = await _inAppReview.isAvailable();
-      if (available) {
-        await _prefs.setBool(_reviewRequestedKey, true);
-        await _inAppReview.requestReview();
-      }
+      await _prefs.setBool(_reviewRequestedKey, true);
     } catch (e) {
       _requestedThisSession = false;
-      debugPrint('[AppReview] Failed to request review: $e');
+      debugPrint('[AppReview] Failed to log review prompt: $e');
     }
   }
 
-  /// Resets persisted review state. For testing and debug use only.
   @visibleForTesting
   Future<void> resetForTesting() async {
     await _prefs.remove(_reviewRequestedKey);

--- a/fittrack/lib/services/lifecycle_notification_service.dart
+++ b/fittrack/lib/services/lifecycle_notification_service.dart
@@ -1,25 +1,18 @@
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:timezone/timezone.dart' as tz;
 import 'app_analytics_service.dart';
 
-/// Lifecycle-triggered push notifications for activation and retention.
+/// Lifecycle event tracking for activation and retention analytics.
 ///
-/// Triggers (Brand_Marketing_Strategy.md §9.2):
-///   Day 1 after install, no workout → activation nudge
-///   Day 3, 0 workouts logged        → reactivation nudge
-///   Personal record achieved        → delight notification (immediate)
-///   10-day inactivity               → retention nudge
-///   30-day inactivity               → churn-reactivation nudge
+/// Local notification scheduling is deferred to a post-launch PWA web-push
+/// PRD. FCM token storage and all analytics events are preserved so the
+/// analytics pipeline remains intact.
 ///
-/// Trial triggers (Trial Day 10, Trial expiry) are NOT implemented here —
-/// they depend on the subscription feature (issue #448).
-///
-/// All on-device triggers use [FlutterLocalNotificationsPlugin] scheduled
-/// notifications, which fire even when the app is closed. FCM is initialised
-/// for permission handling and future server-side delivery.
+/// Triggers tracked (analytics only — no notifications fired):
+///   Day 1, Day 7, Day 30 session retention flags
+///   First workout, workout milestone (5), reactivation (10-day inactivity)
+///   PR achieved (analytics log only)
 class LifecycleNotificationService {
   static const String _installDateKey = 'overload_lifecycle_install_date';
   static const String _lastWorkoutDateKey = 'overload_lifecycle_last_workout_date';
@@ -32,33 +25,14 @@ class LifecycleNotificationService {
   static const String _d7FiredKey = 'overload_analytics_d7_session_fired';
   static const String _d30FiredKey = 'overload_analytics_d30_session_fired';
 
-  // Stable IDs — scheduling with the same ID replaces any existing notification
-  // of that type so only one of each trigger is ever queued.
-  static const int _day1NotifId = 1001;
-  static const int _day3NotifId = 1002;
-  static const int _day10NotifId = 1003;
-  static const int _day30NotifId = 1004;
-  static const int _prNotifBaseId = 2000;
-
-  // Notification channel IDs / names
-  static const String _activationChannelId = 'lifecycle_activation';
-  static const String _retentionChannelId = 'lifecycle_retention';
-  static const String _prChannelId = 'pr_achievement';
-
-  // Deep-link payload values — read by the navigation layer on tap.
-  static const String payloadWorkouts = 'route:workouts';
-  static const String payloadHome = 'route:home';
-
   static LifecycleNotificationService? _instance;
   static bool get isInitialized => _instance != null;
 
   final SharedPreferences _prefs;
-  final FlutterLocalNotificationsPlugin _localNotifications;
   final FirebaseMessaging _messaging;
 
   LifecycleNotificationService._internal(
     this._prefs,
-    this._localNotifications,
     this._messaging,
   ) {
     _recordInstallDateIfNeeded();
@@ -67,25 +41,20 @@ class LifecycleNotificationService {
   @visibleForTesting
   LifecycleNotificationService.forTest(
     SharedPreferences prefs,
-    FlutterLocalNotificationsPlugin localNotifications,
     FirebaseMessaging messaging,
   )   : _prefs = prefs,
-        _localNotifications = localNotifications,
         _messaging = messaging {
     _recordInstallDateIfNeeded();
   }
 
-  /// Initialises the service and sets up local notification + FCM handlers.
+  /// Initialises the service and FCM token refresh listener.
   ///
   /// Call once from [main] after Firebase and SharedPreferences are ready.
-  /// Non-blocking failures are logged but do not throw.
   static Future<void> initialize(SharedPreferences prefs) async {
     _instance = LifecycleNotificationService._internal(
       prefs,
-      FlutterLocalNotificationsPlugin(),
       FirebaseMessaging.instance,
     );
-    await _instance!._initLocalNotifications();
     await _instance!._initFCM();
   }
 
@@ -112,28 +81,9 @@ class LifecycleNotificationService {
     }
   }
 
-  Future<void> _initLocalNotifications() async {
-    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const iosSettings = DarwinInitializationSettings(
-      requestAlertPermission: false,
-      requestBadgePermission: false,
-      requestSoundPermission: false,
-    );
-    await _localNotifications.initialize(
-      const InitializationSettings(android: androidSettings, iOS: iosSettings),
-      onDidReceiveNotificationResponse: _onNotificationTapped,
-    );
-  }
-
   Future<void> _initFCM() async {
     FirebaseMessaging.onMessage.listen(_onFCMMessageReceived);
     _messaging.onTokenRefresh.listen(_onFCMTokenRefresh);
-  }
-
-  void _onNotificationTapped(NotificationResponse response) {
-    final payload = response.payload ?? '';
-    AppAnalyticsService.instance.logLifecycleNotificationOpened(payload);
-    debugPrint('[LifecycleNotif] Tapped: $payload');
   }
 
   void _onFCMMessageReceived(RemoteMessage message) {
@@ -148,18 +98,14 @@ class LifecycleNotificationService {
 
   // ─── Public API ─────────────────────────────────────────────────────────────
 
-  /// Call on every app launch. Schedules or cancels lifecycle notifications
-  /// based on the user's current install age and workout history.
+  /// Call on every app launch. Fires retention session analytics.
   Future<void> onAppLaunch() async {
-    await _scheduleActivationNotifications();
-    await _scheduleRetentionNotifications();
     _logRetentionSessions();
   }
 
   /// Call when the user completes a workout session.
   ///
-  /// Increments the workout count, cancels activation nudges, and resets the
-  /// inactivity window to today.
+  /// Increments the workout count and resets the inactivity window to today.
   void recordWorkoutLogged() {
     // Capture inactivity window BEFORE updating last workout date.
     final inactivityDays = daysSinceLastWorkout;
@@ -178,29 +124,19 @@ class LifecycleNotificationService {
     if (count > 1 && inactivityDays >= 10) {
       AppAnalyticsService.instance.logUserReactivated(inactivityDays);
     }
-
-    // User has engaged — cancel first-workout activation nudges.
-    _localNotifications.cancel(_day1NotifId);
-    _localNotifications.cancel(_day3NotifId);
-
-    // Reset the inactivity window from today.
-    _scheduleRetentionNotifications();
   }
 
-  /// Call when a personal record is detected. Fires an immediate notification.
+  /// Call when a personal record is detected. Logs analytics only.
   Future<void> recordPRAchieved(
     String exerciseName,
     String valueDisplay,
   ) async {
-    await _showPRNotification(exerciseName, valueDisplay);
     AppAnalyticsService.instance.logLifecycleNotificationScheduled('pr_achieved');
   }
 
-  /// Requests notification permission after the user's first workout.
+  /// Requests FCM permission after the user's first workout.
   ///
   /// No-op if permission was already requested or no workout has been logged.
-  /// On iOS this shows the native permission dialog. On Android 13+ this
-  /// shows the runtime permission prompt. On older Android it's a no-op.
   Future<void> requestPermissionIfEligible() async {
     if (permissionRequested) return;
     if (workoutCount < 1) return;
@@ -264,145 +200,5 @@ class LifecycleNotificationService {
       _prefs.setBool(_d30FiredKey, true);
       AppAnalyticsService.instance.logDayThirtySession();
     }
-  }
-
-  // ─── Scheduling ─────────────────────────────────────────────────────────────
-
-  Future<void> _scheduleActivationNotifications() async {
-    if (workoutCount > 0) {
-      await _localNotifications.cancel(_day1NotifId);
-      await _localNotifications.cancel(_day3NotifId);
-      return;
-    }
-
-    final install = installDate;
-    if (install == null) return;
-
-    final now = DateTime.now();
-    final day1Fire = install.add(const Duration(days: 1));
-    final day3Fire = install.add(const Duration(days: 3));
-
-    if (day1Fire.isAfter(now)) {
-      await _scheduleLocalNotification(
-        id: _day1NotifId,
-        channelId: _activationChannelId,
-        channelName: 'Activation',
-        title: 'Your program is ready',
-        body: 'Log your first workout and start tracking your progress.',
-        scheduledAt: day1Fire,
-        payload: payloadWorkouts,
-      );
-    }
-
-    if (day3Fire.isAfter(now)) {
-      await _scheduleLocalNotification(
-        id: _day3NotifId,
-        channelId: _activationChannelId,
-        channelName: 'Activation',
-        title: "Let's go — day 3 already",
-        body: "Most users who don't log in 3 days churn. We'd rather you didn't.",
-        scheduledAt: day3Fire,
-        payload: payloadWorkouts,
-      );
-    }
-  }
-
-  Future<void> _scheduleRetentionNotifications() async {
-    final reference = lastWorkoutDate ?? installDate;
-    if (reference == null) return;
-
-    final now = DateTime.now();
-    final day10Fire = reference.add(const Duration(days: 10));
-    final day30Fire = reference.add(const Duration(days: 30));
-
-    if (day10Fire.isAfter(now)) {
-      await _scheduleLocalNotification(
-        id: _day10NotifId,
-        channelId: _retentionChannelId,
-        channelName: 'Retention',
-        title: 'Still training?',
-        body: "It's been a while. Your program is still here.",
-        scheduledAt: day10Fire,
-        payload: payloadWorkouts,
-      );
-    }
-
-    if (day30Fire.isAfter(now)) {
-      await _scheduleLocalNotification(
-        id: _day30NotifId,
-        channelId: _retentionChannelId,
-        channelName: 'Retention',
-        title: "Your data's still here. So are your PRs.",
-        body: 'Pick up where you left off.',
-        scheduledAt: day30Fire,
-        payload: payloadWorkouts,
-      );
-    }
-  }
-
-  Future<void> _showPRNotification(
-    String exerciseName,
-    String valueDisplay,
-  ) async {
-    // Use a varying ID so multiple PR notifications can coexist.
-    final id = _prNotifBaseId + (DateTime.now().millisecondsSinceEpoch % 1000);
-
-    await _localNotifications.show(
-      id,
-      'New PR: $exerciseName',
-      'You hit $valueDisplay — a new personal best.',
-      NotificationDetails(
-        android: AndroidNotificationDetails(
-          _prChannelId,
-          'Personal Records',
-          channelDescription:
-              'Notifications when you achieve a new personal record',
-          importance: Importance.defaultImportance,
-          priority: Priority.defaultPriority,
-          icon: '@mipmap/ic_launcher',
-        ),
-        iOS: const DarwinNotificationDetails(
-          presentAlert: true,
-          presentSound: true,
-        ),
-      ),
-      payload: payloadHome,
-    );
-  }
-
-  Future<void> _scheduleLocalNotification({
-    required int id,
-    required String channelId,
-    required String channelName,
-    required String title,
-    required String body,
-    required DateTime scheduledAt,
-    String? payload,
-  }) async {
-    final tzScheduled = tz.TZDateTime.from(scheduledAt, tz.local);
-
-    await _localNotifications.zonedSchedule(
-      id,
-      title,
-      body,
-      tzScheduled,
-      NotificationDetails(
-        android: AndroidNotificationDetails(
-          channelId,
-          channelName,
-          importance: Importance.defaultImportance,
-          priority: Priority.defaultPriority,
-          icon: '@mipmap/ic_launcher',
-        ),
-        iOS: const DarwinNotificationDetails(
-          presentAlert: true,
-          presentSound: true,
-        ),
-      ),
-      payload: payload,
-      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
-    );
-
-    AppAnalyticsService.instance.logLifecycleNotificationScheduled(channelId);
   }
 }

--- a/fittrack/lib/services/notification_service.dart
+++ b/fittrack/lib/services/notification_service.dart
@@ -1,104 +1,21 @@
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:flutter/foundation.dart';
-
+/// No-op stub for notification_service — local notifications deferred to
+/// a post-launch PWA web-push PRD. All methods return immediately without
+/// scheduling or displaying any notifications.
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();
   static NotificationService get instance => _instance;
   NotificationService._internal();
 
-  final FlutterLocalNotificationsPlugin _notifications = 
-      FlutterLocalNotificationsPlugin();
+  Future<void> initialize() async {}
 
-  bool _initialized = false;
-
-  /// Initialize the notification service
-  Future<void> initialize() async {
-    if (_initialized) return;
-
-    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const iosSettings = DarwinInitializationSettings(
-      requestSoundPermission: true,
-      requestBadgePermission: true,
-      requestAlertPermission: true,
-    );
-
-    const initSettings = InitializationSettings(
-      android: androidSettings,
-      iOS: iosSettings,
-    );
-
-    await _notifications.initialize(
-      initSettings,
-      onDidReceiveNotificationResponse: _onNotificationTapped,
-    );
-
-    _initialized = true;
-
-    // Request permissions for iOS
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      await _requestIOSPermissions();
-    }
-  }
-
-  /// Request iOS notification permissions
-  Future<void> _requestIOSPermissions() async {
-    await _notifications
-        .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>()
-        ?.requestPermissions(
-          alert: true,
-          badge: true,
-          sound: true,
-        );
-  }
-
-  /// Handle notification taps
-  void _onNotificationTapped(NotificationResponse response) {
-    // Handle notification navigation here
-    debugPrint('Notification tapped: ${response.payload}');
-  }
-
-  /// Schedule a workout reminder
   Future<void> scheduleWorkoutReminder({
     required int id,
     required String title,
     required String body,
     required DateTime scheduledDate,
     String? payload,
-  }) async {
-    if (!_initialized) await initialize();
+  }) async {}
 
-    const androidDetails = AndroidNotificationDetails(
-      'workout_reminders',
-      'Workout Reminders',
-      channelDescription: 'Notifications for scheduled workouts',
-      importance: Importance.high,
-      priority: Priority.high,
-      icon: '@mipmap/ic_launcher',
-    );
-
-    const iosDetails = DarwinNotificationDetails(
-      presentAlert: true,
-      presentBadge: true,
-      presentSound: true,
-    );
-
-    const notificationDetails = NotificationDetails(
-      android: androidDetails,
-      iOS: iosDetails,
-    );
-
-    await _notifications.zonedSchedule(
-      id,
-      title,
-      body,
-      _convertToTZDateTime(scheduledDate),
-      notificationDetails,
-      payload: payload,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-    );
-  }
-
-  /// Schedule recurring workout reminders
   Future<void> scheduleRecurringWorkoutReminder({
     required int id,
     required String title,
@@ -106,124 +23,23 @@ class NotificationService {
     required Time scheduledTime,
     required List<Day> days,
     String? payload,
-  }) async {
-    if (!_initialized) await initialize();
+  }) async {}
 
-    const androidDetails = AndroidNotificationDetails(
-      'workout_reminders',
-      'Workout Reminders',
-      channelDescription: 'Notifications for scheduled workouts',
-      importance: Importance.high,
-      priority: Priority.high,
-      icon: '@mipmap/ic_launcher',
-    );
-
-    const iosDetails = DarwinNotificationDetails(
-      presentAlert: true,
-      presentBadge: true,
-      presentSound: true,
-    );
-
-    const notificationDetails = NotificationDetails(
-      android: androidDetails,
-      iOS: iosDetails,
-    );
-
-    for (final day in days) {
-      await _notifications.zonedSchedule(
-        id + day.value, // Unique ID for each day
-        title,
-        body,
-        _nextInstanceOfTime(scheduledTime, day),
-        notificationDetails,
-        payload: payload,
-        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-        matchDateTimeComponents: DateTimeComponents.dayOfWeekAndTime,
-      );
-    }
-  }
-
-  /// Show an immediate notification
   Future<void> showNotification({
     required int id,
     required String title,
     required String body,
     String? payload,
-  }) async {
-    if (!_initialized) await initialize();
+  }) async {}
 
-    const androidDetails = AndroidNotificationDetails(
-      'general',
-      'General Notifications',
-      channelDescription: 'General app notifications',
-      importance: Importance.defaultImportance,
-      priority: Priority.defaultPriority,
-      icon: '@mipmap/ic_launcher',
-    );
+  Future<void> cancelNotification(int id) async {}
 
-    const iosDetails = DarwinNotificationDetails(
-      presentAlert: true,
-      presentBadge: true,
-      presentSound: true,
-    );
+  Future<void> cancelAllNotifications() async {}
 
-    const notificationDetails = NotificationDetails(
-      android: androidDetails,
-      iOS: iosDetails,
-    );
-
-    await _notifications.show(
-      id,
-      title,
-      body,
-      notificationDetails,
-      payload: payload,
-    );
-  }
-
-  /// Cancel a specific notification
-  Future<void> cancelNotification(int id) async {
-    await _notifications.cancel(id);
-  }
-
-  /// Cancel all notifications
-  Future<void> cancelAllNotifications() async {
-    await _notifications.cancelAll();
-  }
-
-  /// Get all scheduled notifications
-  Future<List<PendingNotificationRequest>> getPendingNotifications() async {
-    return await _notifications.pendingNotificationRequests();
-  }
-
-  /// Helper to convert DateTime to TZDateTime
-  /// Note: This is a simplified implementation. In production, use the timezone package
-  dynamic _convertToTZDateTime(DateTime dateTime) {
-    // For now, just return the DateTime
-    // In production, you would use: tz.TZDateTime.from(dateTime, tz.local)
-    return dateTime;
-  }
-
-  /// Helper to get next instance of a specific time on a specific day
-  dynamic _nextInstanceOfTime(Time time, Day day) {
-    final now = DateTime.now();
-    var scheduledDate = DateTime(now.year, now.month, now.day, time.hour, time.minute);
-    
-    // Adjust for the correct day of the week
-    while (scheduledDate.weekday != day.value) {
-      scheduledDate = scheduledDate.add(const Duration(days: 1));
-    }
-    
-    // If the time has already passed today, schedule for next week
-    if (scheduledDate.isBefore(now)) {
-      scheduledDate = scheduledDate.add(const Duration(days: 7));
-    }
-    
-    return _convertToTZDateTime(scheduledDate);
-  }
+  Future<List<Map<String, dynamic>>> getPendingNotifications() async => const [];
 }
 
-/// Days of the week for recurring notifications
+/// Days of the week for recurring notifications.
 enum Day {
   monday(1),
   tuesday(2),
@@ -237,7 +53,7 @@ enum Day {
   final int value;
 }
 
-/// Time class for scheduling notifications
+/// Time of day for scheduling recurring notifications.
 class Time {
   final int hour;
   final int minute;
@@ -245,5 +61,6 @@ class Time {
   const Time(this.hour, this.minute);
 
   @override
-  String toString() => '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
+  String toString() =>
+      '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
 }

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -1,17 +1,14 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
-import 'package:in_app_purchase/in_app_purchase.dart';
 import '../models/subscription.dart';
 
-/// Singleton that wraps InAppPurchase for product queries, purchase flow,
-/// and syncing subscription status to/from Firestore.
+/// Stub SubscriptionService — IAP removed for PWA transition.
 ///
-/// Purchase stream handling and state management live in [SubscriptionProvider].
+/// Firestore sync methods are preserved so subscription state can be read
+/// from Firestore. Full Stripe billing integration is added in Task #480.
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
 
-  // Null means "use FirebaseFirestore.instance" — resolved lazily so the
-  // static singleton can be constructed in tests without Firebase initialised.
   final FirebaseFirestore? _injectedFirestore;
   FirebaseFirestore get _firestore =>
       _injectedFirestore ?? FirebaseFirestore.instance;
@@ -22,54 +19,15 @@ class SubscriptionService {
   SubscriptionService.forTest(FirebaseFirestore firestore)
       : _injectedFirestore = firestore;
 
+  // Product ID constants preserved for Task #480 migration.
   static const String monthlyId = 'fittrack_pro_monthly';
   static const String annualId = 'fittrack_pro_annual';
   static const Set<String> productIds = {monthlyId, annualId};
 
-  List<ProductDetails> _products = [];
-
-  List<ProductDetails> get products => List.unmodifiable(_products);
-
-  ProductDetails? get monthlyProduct =>
-      _products.cast<ProductDetails?>().firstWhere(
-            (p) => p?.id == monthlyId,
-            orElse: () => null,
-          );
-
-  ProductDetails? get annualProduct =>
-      _products.cast<ProductDetails?>().firstWhere(
-            (p) => p?.id == annualId,
-            orElse: () => null,
-          );
-
-  Stream<List<PurchaseDetails>> get purchaseStream =>
-      InAppPurchase.instance.purchaseStream;
-
-  /// Initialises the IAP plugin and loads product details from the store.
-  /// Returns false if the store is unavailable (e.g. no network, simulator).
-  Future<bool> initialize() async {
-    final available = await InAppPurchase.instance.isAvailable();
-    if (!available) return false;
-    final response =
-        await InAppPurchase.instance.queryProductDetails(productIds);
-    _products = response.productDetails;
-    return true;
-  }
-
-  Future<void> buySubscription(ProductDetails product) async {
-    final param = PurchaseParam(productDetails: product);
-    await InAppPurchase.instance.buyNonConsumable(purchaseParam: param);
-  }
-
-  Future<void> restorePurchases() async {
-    await InAppPurchase.instance.restorePurchases();
-  }
-
-  Future<void> completePurchase(PurchaseDetails purchase) async {
-    if (purchase.pendingCompletePurchase) {
-      await InAppPurchase.instance.completePurchase(purchase);
-    }
-  }
+  // Stub getters — replaced with Stripe price data in Task #480.
+  List<Map<String, dynamic>> get products => const [];
+  Map<String, dynamic>? get monthlyProduct => null;
+  Map<String, dynamic>? get annualProduct => null;
 
   /// Writes the subscription map to the user's Firestore document.
   Future<void> syncToFirestore(String userId, SubscriptionInfo info) async {

--- a/fittrack/pubspec.lock
+++ b/fittrack/pubspec.lock
@@ -217,14 +217,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.15.0"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -233,14 +225,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  csv:
-    dependency: "direct main"
-    description:
-      name: csv
-      sha256: c6aa2679b2a18cb57652920f674488d89712efaf4d3fdf2e537215b35fc19d6c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -257,14 +241,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
-  dbus:
-    dependency: transitive
-    description:
-      name: dbus
-      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.11"
   equatable:
     dependency: transitive
     description:
@@ -475,38 +451,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
-  flutter_local_notifications:
-    dependency: "direct main"
-    description:
-      name: flutter_local_notifications
-      sha256: a9966c850de5e445331b854fa42df96a8020066d67f125a5964cbc6556643f68
-      url: "https://pub.dev"
-    source: hosted
-    version: "19.4.1"
-  flutter_local_notifications_linux:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.0.0"
-  flutter_local_notifications_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.0"
-  flutter_local_notifications_windows:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications_windows
-      sha256: ed46d7ae4ec9d19e4c8fa2badac5fe27ba87a3fe387343ce726f927af074ec98
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -570,22 +514,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
-  in_app_review:
-    dependency: "direct main"
-    description:
-      name: in_app_review
-      sha256: ab26ac54dbd802896af78c670b265eaeab7ecddd6af4d0751e9604b60574817f
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.11"
-  in_app_review_platform_interface:
-    dependency: transitive
-    description:
-      name: in_app_review_platform_interface
-      sha256: fed2c755f2125caa9ae10495a3c163aa7fab5af3585a9c62ef4a6920c5b45f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.5"
   integration_test:
     dependency: "direct dev"
     description: flutter
@@ -759,30 +687,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  path_provider:
-    dependency: "direct main"
-    description:
-      name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.17"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -807,14 +711,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -895,22 +791,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.28.0"
-  share_plus:
-    dependency: "direct main"
-    description:
-      name: share_plus
-      sha256: d7dc0630a923883c6328ca31b89aa682bacbf2f8304162d29f7c6aaff03a27a1
-      url: "https://pub.dev"
-    source: hosted
-    version: "11.1.0"
-  share_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: share_plus_platform_interface
-      sha256: "88023e53a13429bd65d8e85e11a9b484f49d4c190abbd96c7932b74d6927cc9a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.0"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1116,14 +996,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.11"
-  timezone:
-    dependency: "direct main"
-    description:
-      name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.10.1"
   timing:
     dependency: transitive
     description:
@@ -1149,7 +1021,7 @@ packages:
     source: hosted
     version: "1.4.0"
   url_launcher:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
@@ -1284,14 +1156,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-  win32:
-    dependency: transitive
-    description:
-      name: win32
-      sha256: "66814138c3562338d05613a6e368ed8cfb237ad6d64a9e9334be3f309acfca03"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.14.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -1300,14 +1164,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -26,28 +26,13 @@ dependencies:
   # UI Components
   cupertino_icons: ^1.0.2
   
-  # Local Notifications
-  flutter_local_notifications: ^19.4.1
-  timezone: ^0.10.0
-
   # Utilities
   intl: ^0.20.2
   uuid: ^4.2.1
   shared_preferences: ^2.2.2
-  
-  # In-app review
-  in_app_review: ^2.0.9
 
-  # In-app purchases
-  in_app_purchase: ^3.2.0
-
-  # URL launcher (subscription management deep links)
+  # URL launcher
   url_launcher: ^6.2.0
-
-  # Export functionality
-  csv: ^6.0.0
-  path_provider: ^2.1.2
-  share_plus: ^11.1.0
 
 dev_dependencies:
   flutter_test:

--- a/fittrack/test/services/app_review_service_integration_test.dart
+++ b/fittrack/test/services/app_review_service_integration_test.dart
@@ -5,41 +5,26 @@
 /// persistence across re-initialisation, workout count accumulation, and
 /// eligibility gate logic. Firebase emulators are not required.
 ///
-/// InAppReview (platform channel) is mocked so tests run in CI without a
-/// device. The "integration" value is the SharedPreferences persistence
-/// lifecycle, not the platform review API.
+/// InAppReview has been removed (web platform). The eligibility gate and
+/// analytics event persist; the actual review dialog is a no-op.
 
 @Timeout(Duration(seconds: 30))
 library;
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:in_app_review/in_app_review.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fittrack/services/app_review_service.dart';
 
-import 'app_review_service_integration_test.mocks.dart';
-
-@GenerateMocks([InAppReview])
 void main() {
-  late MockInAppReview mockReview;
-
   const firstLaunchKey = 'overload_first_launch_date';
   const workoutCountKey = 'overload_workout_count';
-
-  setUp(() {
-    mockReview = MockInAppReview();
-    when(mockReview.isAvailable()).thenAnswer((_) async => true);
-    when(mockReview.requestReview()).thenAnswer((_) async {});
-  });
 
   Future<AppReviewService> makeService({
     Map<String, Object> prefsValues = const {},
   }) async {
     SharedPreferences.setMockInitialValues(prefsValues);
     final prefs = await SharedPreferences.getInstance();
-    return AppReviewService.forTest(prefs, mockReview);
+    return AppReviewService.forTest(prefs);
   }
 
   group('AppReviewService - Integration (SharedPreferences lifecycle)', () {
@@ -47,11 +32,11 @@ void main() {
         () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      AppReviewService.forTest(prefs, mockReview);
+      AppReviewService.forTest(prefs);
 
       // Re-initialise from same prefs (simulates app restart)
       final prefs2 = await SharedPreferences.getInstance();
-      final s2 = AppReviewService.forTest(prefs2, mockReview);
+      final s2 = AppReviewService.forTest(prefs2);
 
       expect(s2.daysSinceFirstLaunch, greaterThanOrEqualTo(0),
           reason: 'Launch date should survive re-initialisation');
@@ -62,21 +47,21 @@ void main() {
         () async {
       SharedPreferences.setMockInitialValues({});
       var prefs = await SharedPreferences.getInstance();
-      final s1 = AppReviewService.forTest(prefs, mockReview);
+      final s1 = AppReviewService.forTest(prefs);
       s1.recordWorkoutStarted();
       s1.recordWorkoutStarted();
       s1.recordWorkoutStarted();
 
       // Re-initialise — simulates app restart
       prefs = await SharedPreferences.getInstance();
-      final s2 = AppReviewService.forTest(prefs, mockReview);
+      final s2 = AppReviewService.forTest(prefs);
 
       expect(s2.workoutCount, 3,
           reason: 'Workout count must survive app restart');
       expect(prefs.getInt(workoutCountKey), 3);
     });
 
-    test('review is not requested when below workout count threshold', () async {
+    test('review is not triggered when below workout count threshold', () async {
       final tenDaysAgo =
           DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
       final s = await makeService(prefsValues: {
@@ -86,10 +71,11 @@ void main() {
 
       await s.maybeRequestReview();
 
-      verifyNever(mockReview.requestReview());
+      expect(s.hasBeenRequested, isFalse,
+          reason: 'Should not set flag when below workout threshold');
     });
 
-    test('review is not requested when below days-since-launch threshold',
+    test('review is not triggered when below days-since-launch threshold',
         () async {
       final threeDaysAgo =
           DateTime.now().subtract(const Duration(days: 3)).toIso8601String();
@@ -100,7 +86,8 @@ void main() {
 
       await s.maybeRequestReview();
 
-      verifyNever(mockReview.requestReview());
+      expect(s.hasBeenRequested, isFalse,
+          reason: 'Should not set flag when below days threshold');
     });
 
     test('hasBeenRequested flag persists after review is triggered', () async {
@@ -111,13 +98,13 @@ void main() {
         workoutCountKey: 5,
       });
       var prefs = await SharedPreferences.getInstance();
-      final s1 = AppReviewService.forTest(prefs, mockReview);
+      final s1 = AppReviewService.forTest(prefs);
       await s1.maybeRequestReview();
       expect(s1.hasBeenRequested, isTrue);
 
       // Re-initialise — review should not fire again
       prefs = await SharedPreferences.getInstance();
-      final s2 = AppReviewService.forTest(prefs, mockReview);
+      final s2 = AppReviewService.forTest(prefs);
       expect(s2.hasBeenRequested, isTrue,
           reason: 'Requested flag must persist across app restarts');
       expect(s2.isEligible, isFalse,
@@ -131,7 +118,7 @@ void main() {
           DateTime.now().subtract(const Duration(days: 10)).toIso8601String();
       SharedPreferences.setMockInitialValues({firstLaunchKey: tenDaysAgo});
       var prefs = await SharedPreferences.getInstance();
-      var s = AppReviewService.forTest(prefs, mockReview);
+      var s = AppReviewService.forTest(prefs);
 
       // Log 5 workouts
       for (int i = 0; i < 5; i++) {
@@ -139,20 +126,21 @@ void main() {
       }
       expect(s.isEligible, isTrue);
 
-      // Review fires on first eligible call
+      // Review flag is set on first eligible call
       await s.maybeRequestReview();
-      verify(mockReview.requestReview()).called(1);
+      expect(s.hasBeenRequested, isTrue);
 
       // Re-initialise (next app session) — no longer eligible
       prefs = await SharedPreferences.getInstance();
-      s = AppReviewService.forTest(prefs, mockReview);
+      s = AppReviewService.forTest(prefs);
       expect(s.isEligible, isFalse,
           reason: 'hasBeenRequested flag persists — should not be eligible again');
 
-      // Reset mock interactions, then confirm no second request
-      clearInteractions(mockReview);
+      // Confirm no second trigger
+      final wasRequested = s.hasBeenRequested;
       await s.maybeRequestReview();
-      verifyNever(mockReview.requestReview());
+      expect(s.hasBeenRequested, wasRequested,
+          reason: 'Flag must not change when ineligible');
     });
   });
 }

--- a/fittrack/test/services/app_review_service_test.dart
+++ b/fittrack/test/services/app_review_service_test.dart
@@ -1,39 +1,25 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:in_app_review/in_app_review.dart';
-import 'package:mockito/annotations.dart';
-import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fittrack/services/app_review_service.dart';
-
-import 'app_review_service_test.mocks.dart';
 
 /// Unit tests for AppReviewService.
 ///
 /// Verifies eligibility logic, workout count persistence, first-launch tracking,
-/// and that the native review API is only called when all conditions are met.
+/// and that the hasBeenRequested flag is set when conditions are met.
 ///
-/// AppAnalyticsService.instance is called inside maybeRequestReview() but its
-/// failures are silently swallowed — no Firebase setup required here.
-@GenerateMocks([InAppReview])
+/// InAppReview has been removed (web platform). The eligibility gate and
+/// analytics event persist; the actual review dialog is a no-op.
 void main() {
-  late MockInAppReview mockReview;
-
   const firstLaunchKey = 'overload_first_launch_date';
   const workoutCountKey = 'overload_workout_count';
   const reviewRequestedKey = 'overload_review_requested';
-
-  setUp(() {
-    mockReview = MockInAppReview();
-    when(mockReview.isAvailable()).thenAnswer((_) async => true);
-    when(mockReview.requestReview()).thenAnswer((_) async {});
-  });
 
   Future<AppReviewService> makeService({
     Map<String, Object> prefsValues = const {},
   }) async {
     SharedPreferences.setMockInitialValues(prefsValues);
     final prefs = await SharedPreferences.getInstance();
-    return AppReviewService.forTest(prefs, mockReview);
+    return AppReviewService.forTest(prefs);
   }
 
   Future<AppReviewService> eligibleService() => makeService(prefsValues: {
@@ -138,24 +124,25 @@ void main() {
   });
 
   group('maybeRequestReview', () {
-    test('calls isAvailable and requestReview when eligible', () async {
+    test('sets hasBeenRequested when eligible', () async {
       final s = await eligibleService();
       await s.maybeRequestReview();
-      verify(mockReview.isAvailable()).called(1);
-      verify(mockReview.requestReview()).called(1);
+      expect(s.hasBeenRequested, isTrue);
     });
 
-    test('does not call requestReview when ineligible', () async {
+    test('does not set hasBeenRequested when ineligible', () async {
       final s = await makeService(); // 0 workouts, 0 days
       await s.maybeRequestReview();
-      verifyNever(mockReview.requestReview());
+      expect(s.hasBeenRequested, isFalse);
     });
 
-    test('does not call requestReview a second time in the same session', () async {
+    test('does not set flag twice in the same session', () async {
       final s = await eligibleService();
       await s.maybeRequestReview();
+      // After first call, isEligible is false (hasBeenRequested=true);
+      // calling again must not throw and flag stays true
       await s.maybeRequestReview();
-      verify(mockReview.requestReview()).called(1);
+      expect(s.hasBeenRequested, isTrue);
     });
 
     test('marks hasBeenRequested true and persists to SharedPreferences', () async {
@@ -166,21 +153,12 @@ void main() {
       expect(prefs.getBool(reviewRequestedKey), isTrue);
     });
 
-    test('does not call requestReview when platform is unavailable', () async {
-      when(mockReview.isAvailable()).thenAnswer((_) async => false);
+    test('isEligible becomes false after first call', () async {
       final s = await eligibleService();
+      expect(s.isEligible, isTrue);
       await s.maybeRequestReview();
-      verify(mockReview.isAvailable()).called(1);
-      verifyNever(mockReview.requestReview());
-    });
-
-    test('does not set hasBeenRequested flag when platform is unavailable',
-        () async {
-      when(mockReview.isAvailable()).thenAnswer((_) async => false);
-      final s = await eligibleService();
-      await s.maybeRequestReview();
-      expect(s.hasBeenRequested, isFalse,
-          reason: 'Flag should only be set after a successful request call');
+      expect(s.isEligible, isFalse,
+          reason: 'Once requested, should not be eligible again');
     });
   });
 }

--- a/fittrack/test/services/lifecycle_notification_service_integration_test.dart
+++ b/fittrack/test/services/lifecycle_notification_service_integration_test.dart
@@ -6,51 +6,28 @@
 /// workout count accumulation, last-workout tracking, and the
 /// permission-requested flag — across simulated app restarts.
 ///
-/// FlutterLocalNotificationsPlugin and FirebaseMessaging (platform channels)
-/// are mocked so tests run in CI without a device. The "integration" value
-/// is the SharedPreferences persistence lifecycle.
+/// FirebaseMessaging (platform channel) is mocked so tests run in CI without
+/// a device. The "integration" value is the SharedPreferences persistence
+/// lifecycle.
 
 @Timeout(Duration(seconds: 30))
 library;
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:fittrack/services/lifecycle_notification_service.dart';
 
 import 'lifecycle_notification_service_integration_test.mocks.dart';
 
-@GenerateMocks([FlutterLocalNotificationsPlugin, FirebaseMessaging])
+@GenerateMocks([FirebaseMessaging])
 void main() {
-  late MockFlutterLocalNotificationsPlugin mockNotifications;
   late MockFirebaseMessaging mockMessaging;
 
-  setUpAll(() {
-    tz_data.initializeTimeZones();
-  });
-
   setUp(() {
-    mockNotifications = MockFlutterLocalNotificationsPlugin();
     mockMessaging = MockFirebaseMessaging();
-
-    when(mockNotifications.initialize(
-      any,
-      onDidReceiveNotificationResponse:
-          anyNamed('onDidReceiveNotificationResponse'),
-    )).thenAnswer((_) async => true);
-    when(mockNotifications.cancel(any)).thenAnswer((_) async {});
-    when(mockNotifications.show(any, any, any, any,
-            payload: anyNamed('payload')))
-        .thenAnswer((_) async {});
-    when(mockNotifications.zonedSchedule(
-      any, any, any, any, any,
-      androidScheduleMode: anyNamed('androidScheduleMode'),
-      payload: anyNamed('payload'),
-    )).thenAnswer((_) async {});
 
     when(mockMessaging.requestPermission(
       alert: anyNamed('alert'),
@@ -82,12 +59,11 @@ void main() {
     test('install date is written on first construction and persists', () async {
       SharedPreferences.setMockInitialValues({});
       final prefs = await SharedPreferences.getInstance();
-      LifecycleNotificationService.forTest(prefs, mockNotifications, mockMessaging);
+      LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       // Re-initialise from same prefs instance (simulates app restart)
       final prefs2 = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs2, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs2, mockMessaging);
 
       expect(s2.installDate, isNotNull,
           reason: 'Install date must survive re-initialisation');
@@ -99,14 +75,12 @@ void main() {
           DateTime.now().subtract(const Duration(days: 1)).toIso8601String();
       SharedPreferences.setMockInitialValues({installDateKey: yesterday});
       var prefs = await SharedPreferences.getInstance();
-      final s1 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s1 = LifecycleNotificationService.forTest(prefs, mockMessaging);
       final originalDate = s1.installDate;
 
       // Re-initialise
       prefs = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       expect(s2.installDate!.day, originalDate!.day,
           reason: 'Install date must not be overwritten');
@@ -116,16 +90,14 @@ void main() {
         () async {
       SharedPreferences.setMockInitialValues({});
       var prefs = await SharedPreferences.getInstance();
-      final s1 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s1 = LifecycleNotificationService.forTest(prefs, mockMessaging);
       s1.recordWorkoutLogged();
       s1.recordWorkoutLogged();
       s1.recordWorkoutLogged();
 
       // Re-initialise
       prefs = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       expect(s2.workoutCount, 3,
           reason: 'Workout count must survive app restart');
@@ -135,15 +107,13 @@ void main() {
     test('last workout date persists across re-initialisation', () async {
       SharedPreferences.setMockInitialValues({});
       var prefs = await SharedPreferences.getInstance();
-      final s1 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s1 = LifecycleNotificationService.forTest(prefs, mockMessaging);
       s1.recordWorkoutLogged();
       expect(s1.lastWorkoutDate, isNotNull);
 
       // Re-initialise
       prefs = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       expect(s2.lastWorkoutDate, isNotNull,
           reason: 'Last workout date must survive app restart');
@@ -152,18 +122,15 @@ void main() {
 
     test('permission-requested flag persists across re-initialisation',
         () async {
-      SharedPreferences.setMockInitialValues(
-          {workoutCountKey: 1});
+      SharedPreferences.setMockInitialValues({workoutCountKey: 1});
       var prefs = await SharedPreferences.getInstance();
-      final s1 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s1 = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s1.requestPermissionIfEligible();
       expect(s1.permissionRequested, isTrue);
 
       // Re-initialise
       prefs = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       expect(s2.permissionRequested, isTrue,
           reason: 'Permission flag must survive re-initialisation');
@@ -176,8 +143,7 @@ void main() {
         permissionRequestedKey: true,
       });
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
 
       await s.requestPermissionIfEligible();
 

--- a/fittrack/test/services/lifecycle_notification_service_test.dart
+++ b/fittrack/test/services/lifecycle_notification_service_test.dart
@@ -2,43 +2,20 @@
 library;
 
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:timezone/data/latest.dart' as tz_data;
 import 'package:fittrack/services/lifecycle_notification_service.dart';
 
 import 'lifecycle_notification_service_test.mocks.dart';
 
-@GenerateMocks([FlutterLocalNotificationsPlugin, FirebaseMessaging])
+@GenerateMocks([FirebaseMessaging])
 void main() {
-  late MockFlutterLocalNotificationsPlugin mockNotifications;
   late MockFirebaseMessaging mockMessaging;
 
-  setUpAll(() {
-    tz_data.initializeTimeZones();
-  });
-
   setUp(() async {
-    mockNotifications = MockFlutterLocalNotificationsPlugin();
     mockMessaging = MockFirebaseMessaging();
-
-    when(mockNotifications.initialize(
-      any,
-      onDidReceiveNotificationResponse:
-          anyNamed('onDidReceiveNotificationResponse'),
-    )).thenAnswer((_) async => true);
-    when(mockNotifications.cancel(any)).thenAnswer((_) async {});
-    when(mockNotifications.show(any, any, any, any,
-            payload: anyNamed('payload')))
-        .thenAnswer((_) async {});
-    when(mockNotifications.zonedSchedule(
-      any, any, any, any, any,
-      androidScheduleMode: anyNamed('androidScheduleMode'),
-      payload: anyNamed('payload'),
-    )).thenAnswer((_) async {});
 
     when(mockMessaging.requestPermission(
       alert: anyNamed('alert'),
@@ -66,8 +43,7 @@ void main() {
   }) async {
     SharedPreferences.setMockInitialValues(prefsValues);
     final prefs = await SharedPreferences.getInstance();
-    return LifecycleNotificationService.forTest(
-        prefs, mockNotifications, mockMessaging);
+    return LifecycleNotificationService.forTest(prefs, mockMessaging);
   }
 
   group('LifecycleNotificationService - install date', () {
@@ -125,13 +101,6 @@ void main() {
       s.recordWorkoutLogged();
       expect(s.lastWorkoutDate, isNotNull);
     });
-
-    test('recordWorkoutLogged cancels day-1 and day-3 notifications', () async {
-      final s = await makeService();
-      s.recordWorkoutLogged();
-      verify(mockNotifications.cancel(1001)).called(1);
-      verify(mockNotifications.cancel(1002)).called(1);
-    });
   });
 
   group('LifecycleNotificationService - daysSinceLastWorkout', () {
@@ -156,80 +125,18 @@ void main() {
     });
   });
 
-  group('LifecycleNotificationService - onAppLaunch scheduling', () {
-    test('schedules day-1 notification when install is today and no workouts',
-        () async {
+  group('LifecycleNotificationService - onAppLaunch analytics', () {
+    test('does not throw on fresh install', () async {
       final s = await makeService();
-      await s.onAppLaunch();
-      verify(mockNotifications.zonedSchedule(
-        1001, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      )).called(1);
+      await expectLater(s.onAppLaunch(), completes);
     });
 
-    test('schedules day-3 notification when install is today and no workouts',
-        () async {
-      final s = await makeService();
-      await s.onAppLaunch();
-      verify(mockNotifications.zonedSchedule(
-        1002, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      )).called(1);
-    });
-
-    test('cancels activation notifications when workouts > 0', () async {
+    test('does not throw with existing workout history', () async {
       final s = await makeService(prefsValues: {
         'overload_lifecycle_workout_count': 2,
-        'overload_lifecycle_install_date':
-            DateTime.now().toIso8601String(),
+        'overload_lifecycle_install_date': DateTime.now().toIso8601String(),
       });
-      await s.onAppLaunch();
-      verify(mockNotifications.cancel(1001)).called(1);
-      verify(mockNotifications.cancel(1002)).called(1);
-      verifyNever(mockNotifications.zonedSchedule(
-        1001, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      ));
-    });
-
-    test('schedules day-10 retention notification from install date', () async {
-      final s = await makeService();
-      await s.onAppLaunch();
-      verify(mockNotifications.zonedSchedule(
-        1003, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      )).called(1);
-    });
-
-    test('schedules day-30 retention notification from install date', () async {
-      final s = await makeService();
-      await s.onAppLaunch();
-      verify(mockNotifications.zonedSchedule(
-        1004, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      )).called(1);
-    });
-
-    test('does not schedule day-10 when already past 10 days since last workout',
-        () async {
-      final elevenDaysAgo =
-          DateTime.now().subtract(const Duration(days: 11)).toIso8601String();
-      final s = await makeService(prefsValues: {
-        'overload_lifecycle_install_date': elevenDaysAgo,
-        'overload_lifecycle_last_workout_date': elevenDaysAgo,
-        'overload_lifecycle_workout_count': 3,
-      });
-      await s.onAppLaunch();
-      verifyNever(mockNotifications.zonedSchedule(
-        1003, any, any, any, any,
-        androidScheduleMode: anyNamed('androidScheduleMode'),
-        payload: anyNamed('payload'),
-      ));
+      await expectLater(s.onAppLaunch(), completes);
     });
   });
 
@@ -244,8 +151,7 @@ void main() {
       SharedPreferences.setMockInitialValues(
           {'overload_lifecycle_install_date': oneDayAgo});
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s.onAppLaunch();
       expect(prefs.getBool(d1Key), isTrue);
     });
@@ -266,10 +172,8 @@ void main() {
         d1Key: true,
       });
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s.onAppLaunch();
-      // Flag was already true — value unchanged
       expect(prefs.getBool(d1Key), isTrue);
     });
 
@@ -279,11 +183,9 @@ void main() {
       SharedPreferences.setMockInitialValues(
           {'overload_lifecycle_install_date': sevenDaysAgo});
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s.onAppLaunch();
       expect(prefs.getBool(d7Key), isTrue);
-      s.toString();
     });
 
     test('sets d30 flag on launch at day >= 30', () async {
@@ -292,11 +194,9 @@ void main() {
       SharedPreferences.setMockInitialValues(
           {'overload_lifecycle_install_date': thirtyDaysAgo});
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s.onAppLaunch();
       expect(prefs.getBool(d30Key), isTrue);
-      s.toString();
     });
 
     test('does not set d7 or d30 flags on day 1', () async {
@@ -305,18 +205,15 @@ void main() {
       SharedPreferences.setMockInitialValues(
           {'overload_lifecycle_install_date': oneDayAgo});
       final prefs = await SharedPreferences.getInstance();
-      final s = LifecycleNotificationService.forTest(
-          prefs, mockNotifications, mockMessaging);
+      final s = LifecycleNotificationService.forTest(prefs, mockMessaging);
       await s.onAppLaunch();
       expect(prefs.getBool(d7Key), isNull);
       expect(prefs.getBool(d30Key), isNull);
-      s.toString();
     });
   });
 
   group('LifecycleNotificationService - activation analytics', () {
-    test('recordWorkoutLogged sets first_workout prefs indirectly via count=1',
-        () async {
+    test('recordWorkoutLogged increments count from 0 to 1', () async {
       final s = await makeService();
       expect(s.workoutCount, 0);
       s.recordWorkoutLogged();
@@ -331,8 +228,7 @@ void main() {
       expect(s.workoutCount, 5);
     });
 
-    test('daysSinceLastWorkout is captured before update in recordWorkoutLogged',
-        () async {
+    test('daysSinceLastWorkout resets to 0 after recordWorkoutLogged', () async {
       final twoDaysAgo =
           DateTime.now().subtract(const Duration(days: 2)).toIso8601String();
       final s = await makeService(prefsValues: {
@@ -343,22 +239,7 @@ void main() {
       });
       expect(s.daysSinceLastWorkout, 2);
       s.recordWorkoutLogged();
-      // After logging, last workout date is today so daysSinceLastWorkout = 0
       expect(s.daysSinceLastWorkout, 0);
-    });
-  });
-
-  group('LifecycleNotificationService - PR notification', () {
-    test('recordPRAchieved calls show with exercise name and value', () async {
-      final s = await makeService();
-      await s.recordPRAchieved('Bench Press', '100kg');
-      verify(mockNotifications.show(
-        argThat(greaterThanOrEqualTo(2000)),
-        'New PR: Bench Press',
-        argThat(contains('100kg')),
-        any,
-        payload: anyNamed('payload'),
-      )).called(1);
     });
   });
 
@@ -405,13 +286,12 @@ void main() {
       await s.requestPermissionIfEligible();
       expect(s.permissionRequested, isTrue);
 
-      // Re-initialise from same prefs
-      SharedPreferences.setMockInitialValues(
-          {'overload_lifecycle_workout_count': 1,
-           'overload_notif_permission_requested': true});
+      SharedPreferences.setMockInitialValues({
+        'overload_lifecycle_workout_count': 1,
+        'overload_notif_permission_requested': true,
+      });
       final prefs2 = await SharedPreferences.getInstance();
-      final s2 = LifecycleNotificationService.forTest(
-          prefs2, mockNotifications, mockMessaging);
+      final s2 = LifecycleNotificationService.forTest(prefs2, mockMessaging);
       expect(s2.permissionRequested, isTrue,
           reason: 'Permission flag must survive re-initialisation');
     });

--- a/fittrack/test/services/notification_service_integration_test.dart
+++ b/fittrack/test/services/notification_service_integration_test.dart
@@ -1,0 +1,80 @@
+/// Integration tests for NotificationService.
+///
+/// NotificationService is a no-op stub for the PWA — local notifications are
+/// deferred to a post-launch web-push PRD. These integration tests verify
+/// that the stub API is safe to call in sequence (simulating realistic
+/// app flow), and that no state leaks between calls.
+///
+/// No Firebase emulators required — no platform channels or external
+/// dependencies are exercised.
+
+@Timeout(Duration(seconds: 30))
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/services/notification_service.dart';
+
+void main() {
+  group('NotificationService - Integration (stub API lifecycle)', () {
+    test('initialize followed by scheduleWorkoutReminder completes cleanly',
+        () async {
+      final service = NotificationService.instance;
+      await service.initialize();
+      await service.scheduleWorkoutReminder(
+        id: 100,
+        title: 'Reminder',
+        body: 'Time to train',
+        scheduledDate: DateTime.now().add(const Duration(days: 1)),
+      );
+      // No error — stub is safe to call in sequence
+    });
+
+    test('multiple initialize calls are idempotent', () async {
+      final service = NotificationService.instance;
+      await service.initialize();
+      await service.initialize();
+      await service.initialize();
+      // Should complete without error
+    });
+
+    test('cancel after schedule completes without error', () async {
+      final service = NotificationService.instance;
+      await service.initialize();
+      await service.scheduleWorkoutReminder(
+        id: 200,
+        title: 'Cancellable',
+        body: 'Will be cancelled',
+        scheduledDate: DateTime.now().add(const Duration(days: 7)),
+      );
+      await service.cancelNotification(200);
+    });
+
+    test('cancelAllNotifications after multiple schedules completes without error',
+        () async {
+      final service = NotificationService.instance;
+      await service.initialize();
+      for (int i = 0; i < 5; i++) {
+        await service.showNotification(
+          id: 300 + i,
+          title: 'Notification $i',
+          body: 'Body $i',
+        );
+      }
+      await service.cancelAllNotifications();
+    });
+
+    test('getPendingNotifications always returns empty list', () async {
+      final service = NotificationService.instance;
+      await service.initialize();
+      await service.scheduleWorkoutReminder(
+        id: 400,
+        title: 'Pending check',
+        body: 'body',
+        scheduledDate: DateTime.now().add(const Duration(hours: 2)),
+      );
+      final pending = await service.getPendingNotifications();
+      expect(pending, isEmpty,
+          reason: 'Stub always returns empty — no real scheduling occurs');
+    });
+  });
+}

--- a/fittrack/test/services/notification_service_test.dart
+++ b/fittrack/test/services/notification_service_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/services/notification_service.dart';
+
+/// Unit tests for NotificationService.
+///
+/// NotificationService is a no-op stub for the PWA — local notifications are
+/// deferred to a post-launch web-push PRD. These tests verify that all public
+/// API methods complete without errors and return the correct stub values.
+void main() {
+  late NotificationService service;
+
+  setUp(() {
+    service = NotificationService.instance;
+  });
+
+  group('NotificationService (no-op stub)', () {
+    test('initialize completes without error', () async {
+      await expectLater(service.initialize(), completes);
+    });
+
+    test('scheduleWorkoutReminder completes without error', () async {
+      await expectLater(
+        service.scheduleWorkoutReminder(
+          id: 1,
+          title: 'Test',
+          body: 'Test body',
+          scheduledDate: DateTime.now().add(const Duration(hours: 1)),
+        ),
+        completes,
+      );
+    });
+
+    test('scheduleRecurringWorkoutReminder completes without error', () async {
+      await expectLater(
+        service.scheduleRecurringWorkoutReminder(
+          id: 2,
+          title: 'Recurring',
+          body: 'Recurring body',
+          scheduledTime: const Time(9, 0),
+          days: [Day.monday, Day.wednesday],
+        ),
+        completes,
+      );
+    });
+
+    test('showNotification completes without error', () async {
+      await expectLater(
+        service.showNotification(
+          id: 3,
+          title: 'Immediate',
+          body: 'Immediate body',
+        ),
+        completes,
+      );
+    });
+
+    test('cancelNotification completes without error', () async {
+      await expectLater(service.cancelNotification(1), completes);
+    });
+
+    test('cancelAllNotifications completes without error', () async {
+      await expectLater(service.cancelAllNotifications(), completes);
+    });
+
+    test('getPendingNotifications returns empty list', () async {
+      final result = await service.getPendingNotifications();
+      expect(result, isEmpty);
+    });
+  });
+
+  group('Day enum', () {
+    test('has correct values for all days', () {
+      expect(Day.monday.value, 1);
+      expect(Day.tuesday.value, 2);
+      expect(Day.wednesday.value, 3);
+      expect(Day.thursday.value, 4);
+      expect(Day.friday.value, 5);
+      expect(Day.saturday.value, 6);
+      expect(Day.sunday.value, 7);
+    });
+  });
+
+  group('Time class', () {
+    test('formats correctly with padding', () {
+      expect(const Time(9, 5).toString(), '09:05');
+      expect(const Time(14, 30).toString(), '14:30');
+      expect(const Time(0, 0).toString(), '00:00');
+    });
+  });
+}


### PR DESCRIPTION
## Changes

- Removes 7 packages incompatible with Flutter web: `flutter_local_notifications`, `timezone`, `in_app_review`, `in_app_purchase`, `csv`, `path_provider`, `share_plus`
- `notification_service.dart` → full no-op stub, public API preserved
- `lifecycle_notification_service.dart` → partial stub: local notification scheduling removed, FCM token storage and all analytics events (D1/D7/D30, milestones, reactivation) preserved
- `app_review_service.dart` → `InAppReview` removed, eligibility tracking and analytics event preserved, review call is a no-op
- `subscription_service.dart` → `in_app_purchase` removed, Firestore sync methods preserved for Task #480
- `subscription_provider.dart` → `dart:io` and purchase stream removed, public interface unchanged, purchase actions are no-op stubs for Task #480
- `paywall_screen.dart` → hardcoded plan prices (no longer sourced from IAP store)
- `subscription_management_screen.dart` → `dart:io` removed, Stripe portal URL placeholder

## Testing

- All existing unit/integration tests updated for new service signatures
- New `notification_service_test.dart` and `notification_service_integration_test.dart` added for the stub API

See: Docs/Technical_Designs/PWA_Transition_Technical_Design.md

Closes #481
Part of #478