### PR TITLE
[Task] Firebase Hosting multi-site config for PWA (#479)

### DIFF
--- a/fittrack/.firebaserc
+++ b/fittrack/.firebaserc
@@ -1,5 +1,13 @@
 {
   "projects": {
     "default": "fitness-app-8505e"
+  },
+  "targets": {
+    "fitness-app-8505e": {
+      "hosting": {
+        "marketing": ["fitness-app-8505e"],
+        "app": ["fittrack-app"]
+      }
+    }
   }
 }

--- a/fittrack/firebase.json
+++ b/fittrack/firebase.json
@@ -11,28 +11,58 @@
       ]
     }
   ],
-  "hosting": {
-    "site": "fitness-app-8505e",
-    "public": "public",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "cleanUrls": true,
-    "trailingSlash": false,
-    "404": "404.html",
-    "headers": [
-      {
-        "source": "**",
-        "headers": [
-          { "key": "X-Content-Type-Options", "value": "nosniff" },
-          { "key": "X-Frame-Options", "value": "DENY" },
-          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
-        ]
-      }
-    ]
-  },
+  "hosting": [
+    {
+      "target": "marketing",
+      "public": "public",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "cleanUrls": true,
+      "trailingSlash": false,
+      "404": "404.html",
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "app",
+      "public": "build/web",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        { "source": "**", "destination": "/index.html" }
+      ],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          ]
+        },
+        {
+          "source": "/flutter_service_worker.js",
+          "headers": [
+            { "key": "Cache-Control", "value": "no-cache" }
+          ]
+        }
+      ]
+    }
+  ],
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"


### PR DESCRIPTION
## Changes
- Convert `firebase.json` hosting from single object to array with two named targets
- `marketing` target: existing `fitness-app-8505e` site, `public/` directory, preserves all existing headers and config
- `app` target: new `fittrack-app` site, `build/web` directory, SPA rewrite (`** → /index.html`), `no-cache` header on `flutter_service_worker.js`
- Update `.firebaserc` with hosting target mappings: `marketing → fitness-app-8505e`, `app → fittrack-app`

## Pre-deployment requirement
The `fittrack-app` Firebase Hosting site must be created in the Firebase Console before the `app` target can be deployed. Firebase Console → Hosting → Add another site → Site ID: `fittrack-app`.

## Testing
- No application code changed — config files only
- CI runs on this PR to verify no regressions in the test suite

## Issue Links
Closes #479
Part of #478