### PR TITLE
[Task] PWA manifest and index.html Overload branding (#482)

### DIFF
--- a/fittrack/web/index.html
+++ b/fittrack/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Structured strength tracking. Built for progressive overload.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="fittrack">
+  <meta name="apple-mobile-web-app-title" content="Overload">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>fittrack</title>
+  <title>Overload</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/fittrack/web/manifest.json
+++ b/fittrack/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "fittrack",
-    "short_name": "fittrack",
+    "name": "Overload",
+    "short_name": "Overload",
     "start_url": ".",
     "display": "standalone",
-    "background_color": "#0175C2",
-    "theme_color": "#0175C2",
-    "description": "A new Flutter project.",
+    "background_color": "#000000",
+    "theme_color": "#000000",
+    "description": "Structured strength tracking. Built for progressive overload.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
## Changes
- `web/manifest.json` — name, short_name: `Overload`; description updated; background_color and theme_color set to `#000000` (matches app dark theme)
- `web/index.html` — `<title>`, `apple-mobile-web-app-title`, and description meta tag updated to Overload branding

## Testing
- Config-only changes; no Dart code modified
- CI runs to verify no regressions

## Issue Links
Closes #482
Part of #478