### PR TITLE
[Task] CI pipeline: Flutter web build and dual-target deploy (#483)

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -6,12 +6,15 @@ on:
       - main
     paths:
       - 'fittrack/public/**'
+      - 'fittrack/lib/**'
+      - 'fittrack/web/**'
+      - 'fittrack/pubspec.yaml'
       - 'fittrack/firebase.json'
   workflow_dispatch:
 
 jobs:
-  deploy:
-    name: Deploy to Firebase Hosting
+  deploy-marketing:
+    name: Deploy Marketing Site
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -19,11 +22,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Deploy to Firebase Hosting
+      - name: Deploy marketing site to Firebase Hosting
         uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
           projectId: fitness-app-8505e
+          target: marketing
+          channelId: live
+          entryPoint: ./fittrack
+
+  deploy-pwa:
+    name: Build and Deploy PWA
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.35.1
+          cache: true
+
+      - name: Install dependencies
+        run: |
+          cd fittrack
+          flutter pub get
+
+      - name: Build Flutter web
+        run: |
+          cd fittrack
+          flutter build web --release
+
+      - name: Deploy PWA to Firebase Hosting
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          projectId: fitness-app-8505e
+          target: app
           channelId: live
           entryPoint: ./fittrack


### PR DESCRIPTION
## Changes
- Split single `deploy` job into `deploy-marketing` and `deploy-pwa` (two independent jobs — marketing deploys even if Flutter build fails)
- `deploy-marketing`: same as before but now uses `target: marketing` to match the multi-site config from #479
- `deploy-pwa`: Flutter 3.35.1 setup → `flutter pub get` → `flutter build web --release` → deploy with `target: app`
- Paths trigger expanded to include `fittrack/lib/**`, `fittrack/web/**`, `fittrack/pubspec.yaml` so app code changes trigger a redeploy

## Dependencies
- Requires #479 (multi-site firebase.json) to be merged before this pipeline deploys successfully
- Requires #481 (mobile packages removed) for `flutter build web` to compile

## Testing
- CI runs on this PR (test suite only — deploy job only fires on main push)

## Issue Links
Closes #483
Part of #478