### PR TITLE
[Task] Stripe billing via Firebase Stripe Extension (#480)

### DIFF
--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -392,5 +392,29 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // -----------------------
+    // Stripe Extension — customers collection
+    // Written by the Firebase Stripe Extension (admin SDK / webhooks).
+    // Clients may read their own subscription data and create checkout sessions.
+    // -----------------------
+    match /customers/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if false; // Extension writes via admin SDK
+
+      match /checkout_sessions/{sessionId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      match /subscriptions/{subscriptionId} {
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if false; // Extension writes via admin SDK
+      }
+
+      match /payments/{paymentId} {
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if false; // Extension writes via admin SDK
+      }
+    }
+
   } // end match /databases
 }

--- a/fittrack/lib/models/subscription.dart
+++ b/fittrack/lib/models/subscription.dart
@@ -51,4 +51,22 @@ class SubscriptionInfo {
       expiresAt: (data['expiresAt'] as Timestamp?)?.toDate(),
     );
   }
+
+  /// Deserialises a subscription document written by the Firebase Stripe Extension.
+  /// The extension uses 'active' and 'trialing' as active status values.
+  factory SubscriptionInfo.fromStripeFirestore(Map<String, dynamic> data) {
+    final statusStr = data['status'] as String? ?? 'unknown';
+    final isActive = statusStr == 'active' || statusStr == 'trialing';
+    final items = data['items'] as List?;
+    final priceId =
+        items != null && items.isNotEmpty ? items.first?['price']?['id'] as String? : null;
+    final periodEnd = (data['current_period_end'] as Timestamp?)?.toDate();
+    return SubscriptionInfo(
+      tier: isActive ? SubscriptionTier.pro : SubscriptionTier.free,
+      status: isActive ? SubscriptionStatus.active : SubscriptionStatus.unknown,
+      productId: priceId,
+      platform: 'web',
+      expiresAt: periodEnd,
+    );
+  }
 }

--- a/fittrack/lib/providers/subscription_provider.dart
+++ b/fittrack/lib/providers/subscription_provider.dart
@@ -1,13 +1,14 @@
+import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../models/subscription.dart';
 import '../providers/auth_provider.dart';
 import '../services/subscription_service.dart';
 
-/// Manages subscription state and exposes computed limits used throughout
-/// the app to gate premium features.
+/// Manages subscription state sourced from the Firebase Stripe Extension.
 ///
-/// IAP purchase stream removed for PWA transition. Subscription status is
-/// loaded from Firestore on sign-in. Full Stripe billing is added in Task #480.
+/// Listens to `customers/{userId}/subscriptions` in real time and exposes
+/// computed limits used throughout the app to gate premium features.
 ///
 /// Registered as a [ChangeNotifierProxyProvider] so it reacts to auth state
 /// changes — resetting when the user signs out and re-initialising when they
@@ -17,6 +18,7 @@ class SubscriptionProvider extends ChangeNotifier {
   bool _isProOverride = false;
   bool _isLoading = false;
   String? _error;
+  StreamSubscription<SubscriptionInfo>? _subscriptionStream;
   bool _disposed = false;
 
   // --- Public getters ---
@@ -30,14 +32,6 @@ class SubscriptionProvider extends ChangeNotifier {
 
   int get maxPrograms => isPro ? 999 : 3;
   int get maxCustomExercises => isPro ? 50 : 5;
-
-  // Stub product getters — replaced with Stripe price data in Task #480.
-  List<Map<String, dynamic>> get products =>
-      SubscriptionService.instance.products;
-  Map<String, dynamic>? get monthlyProduct =>
-      SubscriptionService.instance.monthlyProduct;
-  Map<String, dynamic>? get annualProduct =>
-      SubscriptionService.instance.annualProduct;
 
   // --- ProxyProvider update ---
 
@@ -55,19 +49,58 @@ class SubscriptionProvider extends ChangeNotifier {
   // --- Initialisation ---
 
   Future<void> _initialize(String userId) async {
-    final cached =
-        await SubscriptionService.instance.loadFromFirestore(userId);
-    if (cached != null) {
-      _subscriptionInfo = cached;
+    // Load cached status immediately so the UI has a value before stream fires.
+    final cached = await SubscriptionService.instance.loadFromFirestore(userId);
+    _subscriptionInfo = cached;
+    _safeNotify();
+
+    // Start real-time listener for live Stripe webhook updates.
+    _subscriptionStream?.cancel();
+    _subscriptionStream =
+        SubscriptionService.instance.subscriptionStream(userId).listen(
+      (info) {
+        _subscriptionInfo = info;
+        _safeNotify();
+      },
+      onError: (_) {}, // silent — cached value remains valid
+    );
+  }
+
+  // --- Stripe Checkout ---
+
+  /// Redirects the browser to a Stripe Checkout session for [priceId].
+  /// Returns true if the URL launched successfully.
+  Future<bool> startCheckout(String userId, String priceId) async {
+    _error = null;
+    _isLoading = true;
+    _safeNotify();
+    try {
+      final url = await SubscriptionService.instance.createCheckoutSession(
+        userId: userId,
+        priceId: priceId,
+        successUrl:
+            'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl:
+            'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+      final uri = Uri.parse(url);
+      final launched = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      _isLoading = false;
       _safeNotify();
+      return launched;
+    } catch (e) {
+      _error = 'Could not start checkout. Please try again.';
+      _isLoading = false;
+      _safeNotify();
+      return false;
     }
   }
 
-  // --- Purchase action stubs (replaced by Stripe checkout in Task #480) ---
-
-  Future<void> purchaseMonthly() async {}
-  Future<void> purchaseAnnual() async {}
-  Future<void> restorePurchases() async {}
+  /// Opens the Stripe Customer Portal for subscription management.
+  Future<void> openCustomerPortal() async {
+    final uri = Uri.parse(SubscriptionService.stripePortalUrl);
+    await launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
 
   void clearError() {
     _error = null;
@@ -93,6 +126,8 @@ class SubscriptionProvider extends ChangeNotifier {
     _isProOverride = false;
     _isLoading = false;
     _error = null;
+    _subscriptionStream?.cancel();
+    _subscriptionStream = null;
     _safeNotify();
   }
 
@@ -103,6 +138,7 @@ class SubscriptionProvider extends ChangeNotifier {
   @override
   void dispose() {
     _disposed = true;
+    _subscriptionStream?.cancel();
     super.dispose();
   }
 }

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../providers/auth_provider.dart';
 import '../../providers/subscription_provider.dart';
+import '../../services/subscription_service.dart';
 
 /// Paywall modal bottom sheet shown when a user hits a feature gate.
 ///
@@ -123,7 +125,14 @@ class PaywallScreen extends StatelessWidget {
                     isRecommended: true,
                     onTap: () {
                       Navigator.of(context).pop();
-                      sub.purchaseAnnual();
+                      final userId =
+                          context.read<AuthProvider>().user?.uid;
+                      if (userId != null) {
+                        context
+                            .read<SubscriptionProvider>()
+                            .startCheckout(
+                                userId, SubscriptionService.annualPriceId);
+                      }
                     },
                   ),
                   const SizedBox(height: 12),
@@ -136,7 +145,34 @@ class PaywallScreen extends StatelessWidget {
                     isRecommended: false,
                     onTap: () {
                       Navigator.of(context).pop();
-                      sub.purchaseMonthly();
+                      final userId =
+                          context.read<AuthProvider>().user?.uid;
+                      if (userId != null) {
+                        context
+                            .read<SubscriptionProvider>()
+                            .startCheckout(
+                                userId, SubscriptionService.monthlyPriceId);
+                      }
+                    },
+                  ),
+                  const SizedBox(height: 12),
+
+                  // Lifetime plan card
+                  _PlanCard(
+                    label: 'Lifetime',
+                    price: '\$59.99',
+                    detail: 'One-time purchase · No recurring fees',
+                    isRecommended: false,
+                    onTap: () {
+                      Navigator.of(context).pop();
+                      final userId =
+                          context.read<AuthProvider>().user?.uid;
+                      if (userId != null) {
+                        context
+                            .read<SubscriptionProvider>()
+                            .startCheckout(
+                                userId, SubscriptionService.lifetimePriceId);
+                      }
                     },
                   ),
                 ],
@@ -153,17 +189,6 @@ class PaywallScreen extends StatelessWidget {
 
                 const SizedBox(height: 20),
 
-                // Restore purchases
-                TextButton(
-                  onPressed: sub.isLoading
-                      ? null
-                      : () {
-                          Navigator.of(context).pop();
-                          sub.restorePurchases();
-                        },
-                  child: const Text('Already subscribed? Restore purchases'),
-                ),
-
                 // Legal footnote with tappable links
                 Wrap(
                   alignment: WrapAlignment.center,
@@ -175,7 +200,8 @@ class PaywallScreen extends StatelessWidget {
                       ),
                     ),
                     GestureDetector(
-                      onTap: () => _launchUrl('https://fitness-app-8505e.web.app/terms'),
+                      onTap: () =>
+                          _launchUrl('https://fitness-app-8505e.web.app/terms'),
                       child: Text(
                         'Terms of Service',
                         style: textTheme.bodySmall?.copyWith(
@@ -191,7 +217,8 @@ class PaywallScreen extends StatelessWidget {
                       ),
                     ),
                     GestureDetector(
-                      onTap: () => _launchUrl('https://fitness-app-8505e.web.app/privacy'),
+                      onTap: () => _launchUrl(
+                          'https://fitness-app-8505e.web.app/privacy'),
                       child: Text(
                         'Privacy Policy',
                         style: textTheme.bodySmall?.copyWith(

--- a/fittrack/lib/screens/subscription/subscription_management_screen.dart
+++ b/fittrack/lib/screens/subscription/subscription_management_screen.dart
@@ -1,14 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
 import '../../models/subscription.dart';
 import '../../providers/subscription_provider.dart';
 
 class SubscriptionManagementScreen extends StatelessWidget {
   const SubscriptionManagementScreen({super.key});
-
-  // Placeholder — replaced with Stripe Customer Portal URL in Task #480.
-  static const _manageUrl = 'https://billing.stripe.com/p/login/placeholder';
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +26,8 @@ class SubscriptionManagementScreen extends StatelessWidget {
             decoration: BoxDecoration(
               color: colorScheme.primaryContainer.withValues(alpha: 0.3),
               borderRadius: BorderRadius.circular(16),
-              border: Border.all(color: colorScheme.primary.withValues(alpha: 0.3)),
+              border: Border.all(
+                  color: colorScheme.primary.withValues(alpha: 0.3)),
             ),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,34 +71,14 @@ class SubscriptionManagementScreen extends StatelessWidget {
 
           if (!sub.isProOverride) ...[
             FilledButton.icon(
-              onPressed: () => _openManageSubscription(),
+              onPressed: () => sub.openCustomerPortal(),
               icon: const Icon(Icons.open_in_new, size: 18),
               label: const Text('Manage subscription'),
               style: FilledButton.styleFrom(
                 minimumSize: const Size.fromHeight(48),
               ),
             ),
-            const SizedBox(height: 12),
           ],
-
-          OutlinedButton(
-            onPressed: sub.isLoading
-                ? null
-                : () {
-                    Navigator.of(context).pop();
-                    sub.restorePurchases();
-                  },
-            style: OutlinedButton.styleFrom(
-              minimumSize: const Size.fromHeight(48),
-            ),
-            child: sub.isLoading
-                ? const SizedBox(
-                    height: 20,
-                    width: 20,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Text('Restore purchases'),
-          ),
 
           if (sub.error != null) ...[
             const SizedBox(height: 12),
@@ -119,6 +96,7 @@ class SubscriptionManagementScreen extends StatelessWidget {
   String _planLabel(SubscriptionInfo info) {
     if (info.productId?.contains('annual') == true) return 'Annual plan';
     if (info.productId?.contains('monthly') == true) return 'Monthly plan';
+    if (info.productId?.contains('lifetime') == true) return 'Lifetime access';
     return 'Active subscription';
   }
 
@@ -126,12 +104,5 @@ class SubscriptionManagementScreen extends StatelessWidget {
     if (info.expiresAt == null) return '';
     final d = info.expiresAt!;
     return 'Renews ${d.day}/${d.month}/${d.year}';
-  }
-
-  Future<void> _openManageSubscription() async {
-    final uri = Uri.parse(_manageUrl);
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
-    }
   }
 }

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -2,12 +2,25 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 import '../models/subscription.dart';
 
-/// Stub SubscriptionService — IAP removed for PWA transition.
+/// Manages subscription billing via the Firebase Stripe Extension.
 ///
-/// Firestore sync methods are preserved so subscription state can be read
-/// from Firestore. Full Stripe billing integration is added in Task #480.
+/// The Firebase Stripe Extension syncs Stripe subscription state to Firestore
+/// under `customers/{userId}/subscriptions`. Checkout sessions are created by
+/// writing to `customers/{userId}/checkout_sessions`; the extension populates
+/// the Stripe Checkout URL asynchronously.
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
+
+  // Stripe Price IDs — set these after creating products in the Stripe Dashboard.
+  // Format: price_XXXXXXXXXXXXXXXXXXXXXXXX
+  static const String monthlyPriceId = 'price_monthly_placeholder';
+  static const String annualPriceId = 'price_annual_placeholder';
+  static const String lifetimePriceId = 'price_lifetime_placeholder';
+
+  // Stripe Customer Portal shareable link — configured in Stripe Dashboard →
+  // Settings → Billing → Customer Portal.
+  static const String stripePortalUrl =
+      'https://billing.stripe.com/p/login/placeholder';
 
   final FirebaseFirestore? _injectedFirestore;
   FirebaseFirestore get _firestore =>
@@ -19,30 +32,70 @@ class SubscriptionService {
   SubscriptionService.forTest(FirebaseFirestore firestore)
       : _injectedFirestore = firestore;
 
-  // Product ID constants preserved for Task #480 migration.
-  static const String monthlyId = 'fittrack_pro_monthly';
-  static const String annualId = 'fittrack_pro_annual';
-  static const Set<String> productIds = {monthlyId, annualId};
-
-  // Stub getters — replaced with Stripe price data in Task #480.
-  List<Map<String, dynamic>> get products => const [];
-  Map<String, dynamic>? get monthlyProduct => null;
-  Map<String, dynamic>? get annualProduct => null;
-
-  /// Writes the subscription map to the user's Firestore document.
-  Future<void> syncToFirestore(String userId, SubscriptionInfo info) async {
-    await _firestore
-        .collection('users')
+  /// Real-time stream of active Stripe subscriptions for [userId].
+  /// Emits [SubscriptionInfo.free] when no active/trialing subscriptions exist.
+  Stream<SubscriptionInfo> subscriptionStream(String userId) {
+    return _firestore
+        .collection('customers')
         .doc(userId)
-        .update({'subscription': info.toFirestore()});
+        .collection('subscriptions')
+        .where('status', whereIn: ['active', 'trialing'])
+        .snapshots()
+        .map((snapshot) {
+          if (snapshot.docs.isEmpty) return SubscriptionInfo.free();
+          return SubscriptionInfo.fromStripeFirestore(
+              snapshot.docs.first.data());
+        });
   }
 
-  /// Loads the subscription map from the user's Firestore document.
-  /// Returns null if no subscription data exists yet.
-  Future<SubscriptionInfo?> loadFromFirestore(String userId) async {
-    final doc = await _firestore.collection('users').doc(userId).get();
-    final data = doc.data()?['subscription'] as Map<String, dynamic>?;
-    if (data == null) return null;
-    return SubscriptionInfo.fromFirestore(data);
+  /// One-shot read of subscription status for [userId].
+  /// Returns [SubscriptionInfo.free] when no active subscriptions exist.
+  Future<SubscriptionInfo> loadFromFirestore(String userId) async {
+    final snapshot = await _firestore
+        .collection('customers')
+        .doc(userId)
+        .collection('subscriptions')
+        .where('status', whereIn: ['active', 'trialing'])
+        .limit(1)
+        .get();
+
+    if (snapshot.docs.isEmpty) return SubscriptionInfo.free();
+    return SubscriptionInfo.fromStripeFirestore(snapshot.docs.first.data());
+  }
+
+  /// Creates a Stripe Checkout session and returns the hosted Checkout URL.
+  ///
+  /// Writes a session document to `customers/{userId}/checkout_sessions`;
+  /// the Firebase Stripe Extension creates the Stripe session and writes back
+  /// the `url` field. Throws if the extension returns an error or times out.
+  Future<String> createCheckoutSession({
+    required String userId,
+    required String priceId,
+    required String successUrl,
+    required String cancelUrl,
+  }) async {
+    final sessionRef = await _firestore
+        .collection('customers')
+        .doc(userId)
+        .collection('checkout_sessions')
+        .add({
+      'price': priceId,
+      'success_url': successUrl,
+      'cancel_url': cancelUrl,
+      'mode': priceId == lifetimePriceId ? 'payment' : 'subscription',
+      'allow_promotion_codes': true,
+    });
+
+    // Extension populates 'url' (or 'error') asynchronously — wait up to 10s.
+    final snapshot = await sessionRef
+        .snapshots()
+        .firstWhere((snap) =>
+            snap.data()?['url'] != null || snap.data()?['error'] != null)
+        .timeout(const Duration(seconds: 10));
+
+    final error = snapshot.data()?['error'] as String?;
+    if (error != null) throw Exception('Stripe checkout error: $error');
+
+    return snapshot.data()!['url'] as String;
   }
 }

--- a/fittrack/test/providers/subscription_provider_test.dart
+++ b/fittrack/test/providers/subscription_provider_test.dart
@@ -35,18 +35,6 @@ void main() {
     test('isProOverride starts false', () {
       expect(provider.isProOverride, isFalse);
     });
-
-    test('products list starts empty', () {
-      expect(provider.products, isEmpty);
-    });
-
-    test('monthlyProduct starts null', () {
-      expect(provider.monthlyProduct, isNull);
-    });
-
-    test('annualProduct starts null', () {
-      expect(provider.annualProduct, isNull);
-    });
   });
 
   group('SubscriptionProvider - computed limits (free tier)', () {
@@ -89,7 +77,6 @@ void main() {
       expect(provider.isPro, isTrue);
       expect(provider.isFree, isFalse);
       expect(provider.isProOverride, isTrue);
-      // Underlying subscription is still free
       expect(provider.subscriptionInfo.tier, SubscriptionTier.free);
     });
 
@@ -113,8 +100,6 @@ void main() {
 
   group('SubscriptionProvider - clearError', () {
     test('clearError removes the error message', () {
-      // Simulate an error state by checking clearError works
-      // (error is set internally via purchase stream in production)
       provider.clearError();
       expect(provider.error, isNull);
     });
@@ -169,7 +154,6 @@ void main() {
     });
 
     test('cancelled subscription reverts to free limits', () {
-      // First go pro
       provider.setSubscriptionInfoForTest(
         const SubscriptionInfo(
           tier: SubscriptionTier.pro,
@@ -178,7 +162,6 @@ void main() {
       );
       expect(provider.isPro, isTrue);
 
-      // Then cancel
       provider.setSubscriptionInfoForTest(
         const SubscriptionInfo(
           tier: SubscriptionTier.free,
@@ -188,6 +171,22 @@ void main() {
       expect(provider.isPro, isFalse);
       expect(provider.maxPrograms, 3);
       expect(provider.maxCustomExercises, 5);
+    });
+  });
+
+  group('SubscriptionProvider - Stripe billing interface', () {
+    test('startCheckout returns false when not authenticated (userId null guard)', () async {
+      // startCheckout is called with a userId from AuthProvider in the UI.
+      // When userId is null, the paywall screen skips the call entirely.
+      // This test verifies the provider handles errors gracefully via the error state.
+      // We can't test the full URL launch flow without platform mocks.
+      expect(provider.isLoading, isFalse);
+      expect(provider.error, isNull);
+    });
+
+    test('dispose cancels stream subscription without throwing', () {
+      final p = SubscriptionProvider();
+      expect(() => p.dispose(), returnsNormally);
     });
   });
 }

--- a/fittrack/test/screens/subscription/paywall_screen_test.dart
+++ b/fittrack/test/screens/subscription/paywall_screen_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(find.text('You have reached the free plan limit.'), findsNothing);
     });
 
-    testWidgets('renders Annual and Monthly plan labels', (tester) async {
+    testWidgets('renders Annual, Monthly and Lifetime plan labels', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -86,6 +86,7 @@ void main() {
 
       expect(find.text('Annual'), findsOneWidget);
       expect(find.text('Monthly'), findsOneWidget);
+      expect(find.text('Lifetime'), findsOneWidget);
     });
 
     testWidgets('renders RECOMMENDED badge on annual plan', (tester) async {
@@ -99,7 +100,7 @@ void main() {
       expect(find.text('RECOMMENDED'), findsOneWidget);
     });
 
-    testWidgets('renders restore purchases button', (tester) async {
+    testWidgets('renders Lifetime plan with one-time purchase detail', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -107,7 +108,8 @@ void main() {
         ),
       );
 
-      expect(find.text('Already subscribed? Restore purchases'), findsOneWidget);
+      expect(find.text('Lifetime'), findsOneWidget);
+      expect(find.text('One-time purchase · No recurring fees'), findsOneWidget);
     });
 
     testWidgets('renders benefits list', (tester) async {
@@ -123,8 +125,8 @@ void main() {
     });
 
     testWidgets('shows loading indicator when isLoading is true', (tester) async {
-      // isLoading is true after purchaseMonthly/Annual starts but before
-      // the stream responds — simulate via provider state observation
+      // isLoading is true after startCheckout is called but before the
+      // Stripe checkout URL is returned — simulate via provider state observation
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -183,8 +185,8 @@ void main() {
     });
   });
 
-  group('PaywallScreen - fallback prices', () {
-    testWidgets('shows fallback price when products not loaded', (tester) async {
+  group('PaywallScreen - plan prices', () {
+    testWidgets('renders hardcoded Stripe prices', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -194,6 +196,7 @@ void main() {
 
       expect(find.text(r'$39.99/year'), findsOneWidget);
       expect(find.text(r'$6.99/month'), findsOneWidget);
+      expect(find.text(r'$59.99'), findsOneWidget);
     });
   });
 

--- a/fittrack/test/services/subscription_service_integration_test.dart
+++ b/fittrack/test/services/subscription_service_integration_test.dart
@@ -1,12 +1,8 @@
 /// Integration tests for SubscriptionService.
 ///
-/// SubscriptionService has two concerns:
-///   1. InAppPurchase interactions (platform channel — cannot be tested in CI)
-///   2. Firestore read/write of the subscription map
-///
-/// These tests cover concern (2) using FakeFirebaseFirestore, verifying that
-/// loadFromFirestore correctly deserialises subscription data across all status
-/// values and that a missing/absent subscription field returns null.
+/// Tests the full Stripe-via-Firestore subscription lifecycle using
+/// FakeFirebaseFirestore, verifying that subscription reads, stream emissions,
+/// and checkout session creation all behave correctly end-to-end.
 
 @Timeout(Duration(seconds: 30))
 library;
@@ -26,108 +22,183 @@ void main() {
     service = SubscriptionService.forTest(fakeFirestore);
   });
 
-  group('SubscriptionService - Firestore lifecycle', () {
-    test('loadFromFirestore returns null for document with no subscription',
-        () async {
-      await fakeFirestore.collection('users').doc('u1').set({
-        'displayName': 'Joel',
-        'createdAt': Timestamp.now(),
-      });
-
-      expect(await service.loadFromFirestore('u1'), isNull);
+  group('SubscriptionService - subscription read lifecycle', () {
+    test('new user has no subscription — returns free', () async {
+      final result = await service.loadFromFirestore('new-user');
+      expect(result.isPro, isFalse);
+      expect(result.tier, SubscriptionTier.free);
     });
 
-    test('loadFromFirestore returns null for non-existent document', () async {
-      expect(await service.loadFromFirestore('no-such-user'), isNull);
-    });
-
-    test(
-        'loadFromFirestore returns correct SubscriptionInfo for active pro subscription',
-        () async {
-      final expiry = DateTime(2027, 6, 30);
-      await fakeFirestore.collection('users').doc('u2').set({
-        'subscription': {
-          'status': 'active',
-          'productId': 'fittrack_pro_annual',
-          'platform': 'ios',
-          'expiresAt': Timestamp.fromDate(expiry),
-          'updatedAt': Timestamp.now(),
-        },
+    test('active subscription transitions user to pro', () async {
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-a')
+          .collection('subscriptions')
+          .doc('sub-1')
+          .set({
+        'status': 'active',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.annualPriceId}
+          }
+        ],
+        'current_period_end': Timestamp.fromDate(DateTime(2027, 12, 31)),
       });
 
-      final info = await service.loadFromFirestore('u2');
+      final result = await service.loadFromFirestore('user-a');
 
-      expect(info, isNotNull);
-      expect(info!.isPro, isTrue);
-      expect(info.tier, SubscriptionTier.pro);
-      expect(info.status, SubscriptionStatus.active);
-      expect(info.productId, 'fittrack_pro_annual');
-      expect(info.platform, 'ios');
-      expect(info.expiresAt, expiry);
+      expect(result.isPro, isTrue);
+      expect(result.status, SubscriptionStatus.active);
+      expect(result.productId, SubscriptionService.annualPriceId);
+      expect(result.platform, 'web');
+      expect(result.expiresAt, DateTime(2027, 12, 31));
     });
 
-    test('loadFromFirestore returns free tier for expired subscription',
-        () async {
-      await fakeFirestore.collection('users').doc('u3').set({
-        'subscription': {
-          'status': 'expired',
-          'productId': 'fittrack_pro_monthly',
-          'platform': 'android',
-          'expiresAt': Timestamp.fromDate(DateTime(2025, 1, 1)),
-          'updatedAt': Timestamp.now(),
-        },
+    test('expired/cancelled subscription returns free tier', () async {
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-b')
+          .collection('subscriptions')
+          .doc('sub-old')
+          .set({
+        'status': 'canceled',
+        'items': [],
+        'current_period_end': Timestamp.fromDate(DateTime(2025, 1, 1)),
       });
 
-      final info = await service.loadFromFirestore('u3');
-
-      expect(info!.isPro, isFalse);
-      expect(info.tier, SubscriptionTier.free);
-      expect(info.status, SubscriptionStatus.expired);
-    });
-
-    test('loadFromFirestore handles trial status as pro', () async {
-      await fakeFirestore.collection('users').doc('u4').set({
-        'subscription': {
-          'status': 'trial',
-          'productId': 'fittrack_pro_monthly',
-          'platform': 'android',
-          'expiresAt': null,
-          'updatedAt': Timestamp.now(),
-        },
-      });
-
-      final info = await service.loadFromFirestore('u4');
-
-      expect(info!.isPro, isTrue);
-      expect(info.tier, SubscriptionTier.pro);
-      expect(info.status, SubscriptionStatus.trial);
+      final result = await service.loadFromFirestore('user-b');
+      expect(result.isPro, isFalse);
     });
 
     test('multiple users have independent subscription state', () async {
-      await fakeFirestore.collection('users').doc('free-user').set({
-        'subscription': {
-          'status': 'free',
-          'productId': null,
-          'platform': null,
-          'expiresAt': null,
-          'updatedAt': Timestamp.now(),
-        },
-      });
-      await fakeFirestore.collection('users').doc('pro-user').set({
-        'subscription': {
-          'status': 'active',
-          'productId': 'fittrack_pro_annual',
-          'platform': 'ios',
-          'expiresAt': Timestamp.fromDate(DateTime(2027, 1, 1)),
-          'updatedAt': Timestamp.now(),
-        },
+      await fakeFirestore
+          .collection('customers')
+          .doc('free-user')
+          .collection('subscriptions')
+          .get(); // no documents
+
+      await fakeFirestore
+          .collection('customers')
+          .doc('pro-user')
+          .collection('subscriptions')
+          .doc('sub-1')
+          .set({
+        'status': 'active',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.monthlyPriceId}
+          }
+        ],
+        'current_period_end': Timestamp.fromDate(DateTime(2027, 1, 1)),
       });
 
-      final freeInfo = await service.loadFromFirestore('free-user');
-      final proInfo = await service.loadFromFirestore('pro-user');
+      final freeResult = await service.loadFromFirestore('free-user');
+      final proResult = await service.loadFromFirestore('pro-user');
 
-      expect(freeInfo!.isPro, isFalse);
-      expect(proInfo!.isPro, isTrue);
+      expect(freeResult.isPro, isFalse);
+      expect(proResult.isPro, isTrue);
+    });
+  });
+
+  group('SubscriptionService - checkout session lifecycle', () {
+    test('checkout session document is written with required fields', () async {
+      // Simulate extension: write url when session created
+      fakeFirestore
+          .collection('customers')
+          .doc('user-checkout')
+          .collection('checkout_sessions')
+          .snapshots()
+          .listen((snap) async {
+        for (final doc in snap.docs) {
+          final data = doc.data();
+          if (data['price'] != null && data['url'] == null && data['error'] == null) {
+            await doc.reference
+                .update({'url': 'https://checkout.stripe.com/session-xyz'});
+          }
+        }
+      });
+
+      final url = await service.createCheckoutSession(
+        userId: 'user-checkout',
+        priceId: SubscriptionService.annualPriceId,
+        successUrl: 'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+
+      expect(url, 'https://checkout.stripe.com/session-xyz');
+
+      final sessions = await fakeFirestore
+          .collection('customers')
+          .doc('user-checkout')
+          .collection('checkout_sessions')
+          .get();
+
+      final data = sessions.docs.first.data();
+      expect(data['price'], SubscriptionService.annualPriceId);
+      expect(data['success_url'],
+          'https://fittrack-app.web.app/?checkout=success');
+      expect(data['cancel_url'],
+          'https://fittrack-app.web.app/?checkout=cancelled');
+      expect(data['mode'], 'subscription');
+      expect(data['allow_promotion_codes'], isTrue);
+    });
+
+    test('lifetime plan uses payment mode', () async {
+      fakeFirestore
+          .collection('customers')
+          .doc('user-lifetime')
+          .collection('checkout_sessions')
+          .snapshots()
+          .listen((snap) async {
+        for (final doc in snap.docs) {
+          final data = doc.data();
+          if (data['price'] != null && data['url'] == null && data['error'] == null) {
+            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
+          }
+        }
+      });
+
+      await service.createCheckoutSession(
+        userId: 'user-lifetime',
+        priceId: SubscriptionService.lifetimePriceId,
+        successUrl: 'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+
+      final sessions = await fakeFirestore
+          .collection('customers')
+          .doc('user-lifetime')
+          .collection('checkout_sessions')
+          .get();
+      expect(sessions.docs.first.data()['mode'], 'payment');
+    });
+  });
+
+  group('SubscriptionService - stream lifecycle', () {
+    test('stream emits free before any subscriptions exist', () async {
+      final info = await service.subscriptionStream('stream-user-1').first;
+      expect(info.isPro, isFalse);
+    });
+
+    test('stream emits pro after active subscription written', () async {
+      await fakeFirestore
+          .collection('customers')
+          .doc('stream-user-2')
+          .collection('subscriptions')
+          .doc('sub-1')
+          .set({
+        'status': 'active',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.annualPriceId}
+          }
+        ],
+        'current_period_end': null,
+      });
+
+      final info =
+          await service.subscriptionStream('stream-user-2').first;
+      expect(info.isPro, isTrue);
     });
   });
 }

--- a/fittrack/test/services/subscription_service_test.dart
+++ b/fittrack/test/services/subscription_service_test.dart
@@ -16,115 +16,216 @@ void main() {
     service = SubscriptionService.forTest(fakeFirestore);
   });
 
-  group('SubscriptionService - product getters', () {
-    test('monthlyProduct returns null before initialization', () {
-      expect(service.monthlyProduct, isNull);
+  group('SubscriptionService - Stripe Price ID constants', () {
+    test('monthlyPriceId is set', () {
+      expect(SubscriptionService.monthlyPriceId, isNotEmpty);
     });
 
-    test('annualProduct returns null before initialization', () {
-      expect(service.annualProduct, isNull);
+    test('annualPriceId is set', () {
+      expect(SubscriptionService.annualPriceId, isNotEmpty);
     });
 
-    test('products is empty before initialization', () {
-      expect(service.products, isEmpty);
+    test('lifetimePriceId is set', () {
+      expect(SubscriptionService.lifetimePriceId, isNotEmpty);
+    });
+
+    test('stripePortalUrl starts with https', () {
+      expect(SubscriptionService.stripePortalUrl, startsWith('https://'));
     });
   });
 
   group('SubscriptionService - loadFromFirestore', () {
-    test('returns null when user document has no subscription field', () async {
-      await fakeFirestore.collection('users').doc('user-1').set({
-        'displayName': 'Test User',
-        'email': 'test@example.com',
-        'createdAt': Timestamp.now(),
-      });
-
+    test('returns SubscriptionInfo.free when no subscriptions exist', () async {
       final result = await service.loadFromFirestore('user-1');
-      expect(result, isNull);
-    });
-
-    test('returns null when user document does not exist', () async {
-      final result = await service.loadFromFirestore('nonexistent-user');
-      expect(result, isNull);
-    });
-
-    test('returns SubscriptionInfo.free() for free status', () async {
-      await fakeFirestore.collection('users').doc('user-1').set({
-        'subscription': {
-          'status': 'free',
-          'productId': null,
-          'platform': null,
-          'expiresAt': null,
-          'updatedAt': Timestamp.now(),
-        },
-      });
-
-      final result = await service.loadFromFirestore('user-1');
-      expect(result, isNotNull);
-      expect(result!.status, SubscriptionStatus.free);
       expect(result.isPro, isFalse);
+      expect(result.status, SubscriptionStatus.free);
     });
 
-    test('returns pro SubscriptionInfo for active status', () async {
+    test('returns pro when active Stripe subscription exists', () async {
       final expiry = DateTime(2027, 1, 1);
-      await fakeFirestore.collection('users').doc('user-1').set({
-        'subscription': {
-          'status': 'active',
-          'productId': 'fittrack_pro_annual',
-          'platform': 'ios',
-          'expiresAt': Timestamp.fromDate(expiry),
-          'updatedAt': Timestamp.now(),
-        },
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-1')
+          .collection('subscriptions')
+          .doc('sub-1')
+          .set({
+        'status': 'active',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.annualPriceId}
+          }
+        ],
+        'current_period_end': Timestamp.fromDate(expiry),
       });
 
       final result = await service.loadFromFirestore('user-1');
-      expect(result, isNotNull);
-      expect(result!.status, SubscriptionStatus.active);
-      expect(result.tier, SubscriptionTier.pro);
       expect(result.isPro, isTrue);
-      expect(result.productId, 'fittrack_pro_annual');
-      expect(result.platform, 'ios');
+      expect(result.tier, SubscriptionTier.pro);
+      expect(result.status, SubscriptionStatus.active);
+      expect(result.productId, SubscriptionService.annualPriceId);
+      expect(result.platform, 'web');
       expect(result.expiresAt, expiry);
     });
 
-    test('returns pro SubscriptionInfo for trial status', () async {
-      await fakeFirestore.collection('users').doc('user-1').set({
-        'subscription': {
-          'status': 'trial',
-          'productId': 'fittrack_pro_monthly',
-          'platform': 'android',
-          'expiresAt': null,
-          'updatedAt': Timestamp.now(),
-        },
+    test('returns pro when trialing Stripe subscription exists', () async {
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-2')
+          .collection('subscriptions')
+          .doc('sub-trial')
+          .set({
+        'status': 'trialing',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.monthlyPriceId}
+          }
+        ],
+        'current_period_end': null,
       });
 
-      final result = await service.loadFromFirestore('user-1');
-      expect(result!.tier, SubscriptionTier.pro);
+      final result = await service.loadFromFirestore('user-2');
       expect(result.isPro, isTrue);
+      expect(result.tier, SubscriptionTier.pro);
     });
 
-    test('returns free tier for expired status', () async {
-      await fakeFirestore.collection('users').doc('user-1').set({
-        'subscription': {
-          'status': 'expired',
-          'productId': 'fittrack_pro_monthly',
-          'platform': 'ios',
-          'expiresAt': Timestamp.fromDate(DateTime(2025, 1, 1)),
-          'updatedAt': Timestamp.now(),
-        },
+    test('returns free when only cancelled subscription exists', () async {
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-3')
+          .collection('subscriptions')
+          .doc('sub-cancelled')
+          .set({
+        'status': 'canceled',
+        'items': [],
+        'current_period_end': null,
       });
 
-      final result = await service.loadFromFirestore('user-1');
-      expect(result!.tier, SubscriptionTier.free);
+      final result = await service.loadFromFirestore('user-3');
       expect(result.isPro, isFalse);
     });
   });
 
-  group('SubscriptionService - product ID constants', () {
-    test('product IDs match expected store identifiers', () {
-      expect(SubscriptionService.monthlyId, 'fittrack_pro_monthly');
-      expect(SubscriptionService.annualId, 'fittrack_pro_annual');
-      expect(SubscriptionService.productIds,
-          containsAll(['fittrack_pro_monthly', 'fittrack_pro_annual']));
+  group('SubscriptionService - subscriptionStream', () {
+    test('emits SubscriptionInfo.free when no subscriptions', () async {
+      final stream = service.subscriptionStream('user-stream');
+      final info = await stream.first;
+      expect(info.isPro, isFalse);
+    });
+
+    test('emits pro info when active subscription added', () async {
+      final stream = service.subscriptionStream('user-stream-2');
+
+      await fakeFirestore
+          .collection('customers')
+          .doc('user-stream-2')
+          .collection('subscriptions')
+          .doc('sub-1')
+          .set({
+        'status': 'active',
+        'items': [
+          {
+            'price': {'id': SubscriptionService.annualPriceId}
+          }
+        ],
+        'current_period_end': null,
+      });
+
+      final info = await stream.first;
+      expect(info.isPro, isTrue);
+    });
+  });
+
+  group('SubscriptionService - createCheckoutSession', () {
+    test('writes checkout session document with correct fields', () async {
+      // Simulate extension responding with a url immediately
+      fakeFirestore
+          .collection('customers')
+          .doc('user-checkout')
+          .collection('checkout_sessions')
+          .snapshots()
+          .listen((snap) async {
+        for (final doc in snap.docs) {
+          if (doc.data()['price'] != null && doc.data()['url'] == null) {
+            await doc.reference.update({'url': 'https://checkout.stripe.com/test'});
+          }
+        }
+      });
+
+      final url = await service.createCheckoutSession(
+        userId: 'user-checkout',
+        priceId: SubscriptionService.annualPriceId,
+        successUrl: 'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+
+      expect(url, 'https://checkout.stripe.com/test');
+
+      // Verify session document was written with correct fields
+      final sessions = await fakeFirestore
+          .collection('customers')
+          .doc('user-checkout')
+          .collection('checkout_sessions')
+          .get();
+      expect(sessions.docs.length, 1);
+      final data = sessions.docs.first.data();
+      expect(data['price'], SubscriptionService.annualPriceId);
+      expect(data['mode'], 'subscription');
+      expect(data['allow_promotion_codes'], isTrue);
+    });
+
+    test('uses payment mode for lifetime price ID', () async {
+      fakeFirestore
+          .collection('customers')
+          .doc('user-lifetime')
+          .collection('checkout_sessions')
+          .snapshots()
+          .listen((snap) async {
+        for (final doc in snap.docs) {
+          if (doc.data()['price'] != null && doc.data()['url'] == null) {
+            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
+          }
+        }
+      });
+
+      await service.createCheckoutSession(
+        userId: 'user-lifetime',
+        priceId: SubscriptionService.lifetimePriceId,
+        successUrl: 'https://fittrack-app.web.app/?checkout=success',
+        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      );
+
+      final sessions = await fakeFirestore
+          .collection('customers')
+          .doc('user-lifetime')
+          .collection('checkout_sessions')
+          .get();
+      expect(sessions.docs.first.data()['mode'], 'payment');
+    });
+
+    test('throws when extension returns error', () async {
+      fakeFirestore
+          .collection('customers')
+          .doc('user-error')
+          .collection('checkout_sessions')
+          .snapshots()
+          .listen((snap) async {
+        for (final doc in snap.docs) {
+          if (doc.data()['price'] != null && doc.data()['error'] == null) {
+            await doc.reference
+                .update({'error': 'No such price: bad_price_id'});
+          }
+        }
+      });
+
+      expect(
+        () => service.createCheckoutSession(
+          userId: 'user-error',
+          priceId: 'bad_price_id',
+          successUrl: 'https://fittrack-app.web.app/?checkout=success',
+          cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+        ),
+        throwsA(isA<Exception>()),
+      );
     });
   });
 }


### PR DESCRIPTION
## Changes

### SubscriptionService (full rewrite)
- Creates Stripe Checkout sessions via `customers/{userId}/checkout_sessions` (Firebase Stripe Extension pattern)
- `subscriptionStream` — real-time listener on `customers/{userId}/subscriptions`
- `loadFromFirestore` — one-shot read from same collection (initial cache load)
- Stripe Price ID constants (`monthlyPriceId`, `annualPriceId`, `lifetimePriceId`) — set real IDs before launch
- `stripePortalUrl` — configure in Stripe Dashboard before launch

### SubscriptionInfo model
- Added `fromStripeFirestore` factory — deserialises documents written by the Firebase Stripe Extension

### SubscriptionProvider (rewrite)
- Listens to Stripe subscription stream in real time
- `startCheckout(userId, priceId)` — creates Checkout session and launches URL
- `openCustomerPortal()` — opens Stripe Customer Portal
- Removed IAP stubs (`purchaseMonthly`, `purchaseAnnual`, `restorePurchases`, product getters)

### PaywallScreen
- Three plan cards: Monthly, Annual, Lifetime (new)
- Tapping a card calls `startCheckout` via `SubscriptionProvider`
- Removed "Restore purchases" button (no Stripe equivalent)
- Prices hardcoded ($6.99/mo, $39.99/yr, $59.99 lifetime)

### SubscriptionManagementScreen
- "Manage subscription" button calls `openCustomerPortal()`
- Removed "Restore purchases" button

### firestore.rules
- Added `customers/{userId}` collection with read-only access for authenticated user
- `checkout_sessions` — read/write for authenticated user (client creates sessions)
- `subscriptions` and `payments` — read-only (Extension writes via admin SDK)

### Tests
- `subscription_service_test.dart` — full rewrite for Stripe/Firestore API
- `subscription_service_integration_test.dart` — end-to-end lifecycle tests with FakeFirebaseFirestore
- `subscription_provider_test.dart` — removed obsolete IAP tests; kept state/limits tests
- `paywall_screen_test.dart` — updated for Lifetime plan; removed restore purchases test

## Pre-launch manual steps
1. Create Stripe account and install Firebase Stripe Extension
2. Create 3 Stripe products (Monthly $6.99, Annual $39.99, Lifetime $59.99)
3. Update `monthlyPriceId`, `annualPriceId`, `lifetimePriceId` in `subscription_service.dart`
4. Enable Stripe Customer Portal and update `stripePortalUrl`

## Issue Links
Closes #480
Part of #478