### PR TITLE
[Task] Add Android E2E path filter and workflow_dispatch input (#499)

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -14,7 +14,12 @@ on:
     paths:
       - 'fittrack/**'
       - '.github/workflows/fittrack_test_suite.yml'
-  workflow_dispatch:  # Allow manual triggering from Actions tab
+  workflow_dispatch:
+    inputs:
+      run_android_e2e:
+        description: 'Force-run Android E2E tests (ignores path filter)'
+        type: boolean
+        default: false
 
 # Required permissions for PR comments and test reports
 permissions:
@@ -26,14 +31,36 @@ jobs:
   # Parallel test execution for faster feedback
   #
   # Test Job Descriptions:
+  # - check-changes: Detects whether Android-relevant files changed (gates integration-tests)
   # - unit-tests: Fast validation of business logic (models, services, providers) using mocks
   # - widget-tests: UI component testing with mocked dependencies
   # - integration-tests: End-to-end tests on Android emulator (SLOW, known flaky - see #29)
+  #     Skipped automatically on PWA-only PRs (no android/** or integration_test/** changes).
+  #     Override with workflow_dispatch input run_android_e2e=true. See #490.
   # - enhanced-tests: REAL Firebase integration tests connecting to emulators (validates actual Firebase operations)
   # - performance-tests: Edge case and performance validation
   # - security-checks: Dependency audits and security scanning
+  # - playwright-e2e: Playwright browser tests against compiled Flutter web output (non-blocking)
   #
   # See Docs/Testing/TestClassification.md for complete test type definitions
+
+  check-changes:
+    name: Detect Changed File Paths
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    outputs:
+      android_changed: ${{ steps.filter.outputs.android }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Check for Android/integration_test file changes
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          android:
+            - 'fittrack/android/**'
+            - 'fittrack/integration_test/**'
 
   unit-tests:
     name: Unit Tests (Business Logic)
@@ -139,7 +166,13 @@ jobs:
     name: E2E Tests (Android Emulator)
     runs-on: ubuntu-latest
     timeout-minutes: 80
-    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+    # Skipped on PRs with no android/** or integration_test/** changes to save ~80 min CI time.
+    # Force-run via workflow_dispatch with run_android_e2e=true. See issue #490.
+    needs: [check-changes]
+    if: |
+      (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') &&
+      (needs.check-changes.outputs.android_changed == 'true' ||
+       github.event.inputs.run_android_e2e == 'true')
 
     steps:
     - name: Checkout code
@@ -734,7 +767,7 @@ jobs:
   all-tests-passed:
     name: All Tests Status
     runs-on: ubuntu-latest
-    needs: [unit-tests, widget-tests, integration-tests, performance-tests, enhanced-tests, security-checks, integration-coverage-check]
+    needs: [check-changes, unit-tests, widget-tests, integration-tests, performance-tests, enhanced-tests, security-checks, integration-coverage-check]
     if: (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && always()
 
     steps:
@@ -782,8 +815,10 @@ jobs:
           echo "⚠️  Widget Tests failed (non-blocking)"
         fi
 
-        # Check integration tests - known to be flaky
-        if [[ "${{ needs.integration-tests.result }}" != "success" ]]; then
+        # Check integration tests - known flaky, skipped on PWA-only PRs (see #490)
+        if [[ "${{ needs.integration-tests.result }}" == "skipped" ]]; then
+          echo "⏭️  Integration Tests skipped (no android/ or integration_test/ changes)"
+        elif [[ "${{ needs.integration-tests.result }}" != "success" ]]; then
           echo "⚠️  Integration Tests failed/cancelled (known flaky - see #29)"
         fi
 


### PR DESCRIPTION
## Changes
- Added `workflow_dispatch` input `run_android_e2e` (boolean, default false) to manually force Android E2E
- Added `check-changes` job using `dorny/paths-filter@v3` to detect `fittrack/android/**` and `fittrack/integration_test/**` changes
- `integration-tests` now only runs when Android files changed OR `run_android_e2e=true`
- `all-tests-passed` updated to include `check-changes` in needs; skipped integration-tests now logged as ⏭️ not ⚠️
- Added comments explaining the skip logic with issue link

## Testing
- [ ] On a PR touching only `fittrack/lib/**`: `integration-tests` job is skipped, `all-tests-passed` still passes
- [ ] On a PR touching `fittrack/android/**`: `integration-tests` job runs as before
- [ ] `workflow_dispatch` with `run_android_e2e=true`: Android E2E is forced on

## Design Reference
Technical Design: [Docs/Technical_Designs/PWA_E2E_Browser_Testing_Technical_Design.md](Docs/Technical_Designs/PWA_E2E_Browser_Testing_Technical_Design.md) § 4.8

Closes #499
Part of #490