### PR TITLE
[Task #491] Add USE_EMULATOR and SKIP_ONBOARDING dart-define flags

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -26,6 +26,8 @@ import 'services/notification_service.dart';
 import 'services/onboarding_service.dart';
 import 'services/returning_user_service.dart';
 
+const bool _kUseEmulator = bool.fromEnvironment('USE_EMULATOR', defaultValue: false);
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
@@ -61,6 +63,16 @@ void main() async {
     }
   } else {
     debugPrint('Firebase already initialized (likely by integration tests), skipping initialization');
+  }
+
+  if (_kUseEmulator) {
+    try {
+      await FirebaseAuth.instance.useAuthEmulator('localhost', 9099);
+      FirebaseFirestore.instance.useFirestoreEmulator('localhost', 8080);
+      debugPrint('[Emulator] Connected to local Firebase emulators');
+    } catch (e) {
+      debugPrint('[Emulator] Warning: $e');
+    }
   }
 
   // Enable Firestore offline persistence (spec requirement from Section 11)

--- a/fittrack/lib/services/onboarding_service.dart
+++ b/fittrack/lib/services/onboarding_service.dart
@@ -1,5 +1,7 @@
 import 'package:shared_preferences/shared_preferences.dart';
 
+const bool _kSkipOnboarding = bool.fromEnvironment('SKIP_ONBOARDING', defaultValue: false);
+
 /// Manages onboarding completion state via SharedPreferences.
 ///
 /// Singleton initialized once in main.dart after SharedPreferences.getInstance().
@@ -26,7 +28,7 @@ class OnboardingService {
 
   /// Returns true if the user has completed or skipped onboarding.
   bool get hasCompletedOnboarding =>
-      _prefs.getBool(_onboardingKey) ?? false;
+      _kSkipOnboarding || (_prefs.getBool(_onboardingKey) ?? false);
 
   /// Marks onboarding as complete. Persists to SharedPreferences.
   Future<void> markComplete() async {


### PR DESCRIPTION
## Summary
- Adds \`USE_EMULATOR\` dart-define compile-time constant to \`main.dart\`; when \`true\`, connects Firebase Auth (port 9099) and Firestore (port 8080) to local emulators before \`runApp()\`
- Adds \`SKIP_ONBOARDING\` dart-define compile-time constant to \`onboarding_service.dart\`; when \`true\`, \`hasCompletedOnboarding\` always returns \`true\`, bypassing the SharedPreferences check
- Both flags default to \`false\` — production builds are completely unaffected

## Test plan
- [ ] Verify CI unit/widget tests pass
- [ ] Confirm \`flutter build web --release --dart-define=USE_EMULATOR=true --dart-define=SKIP_ONBOARDING=true\` compiles without errors (validated in Task #497 CI job)
- [ ] Confirm production build (\`flutter build web --release\`) does NOT connect to emulators (flags absent = false)

Part of #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)