### PR TITLE
[Task #492] Set up Playwright infrastructure

### DIFF
--- a/fittrack/playwright/global-setup.ts
+++ b/fittrack/playwright/global-setup.ts
@@ -1,0 +1,99 @@
+import { createTestUser, seedFirestoreDoc, clearEmulatorData } from './helpers/firebase-emulator';
+
+const TEST_EMAIL = 'playwright-e2e@test.com';
+const TEST_PASSWORD = 'playwright-test-123';
+
+export default async function globalSetup(): Promise<void> {
+  // Start with a clean slate
+  await clearEmulatorData();
+
+  // Create test user and verify email
+  const uid = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+
+  // Expose credentials to tests via env vars
+  process.env.E2E_TEST_EMAIL = TEST_EMAIL;
+  process.env.E2E_TEST_PASSWORD = TEST_PASSWORD;
+  process.env.E2E_TEST_UID = uid;
+
+  // Seed user profile with isProOverride to unlock Analytics Pro gate
+  await seedFirestoreDoc(`users/${uid}`, {
+    userId: uid,
+    email: TEST_EMAIL,
+    displayName: 'Playwright Test User',
+    isProOverride: true,
+    createdAt: new Date().toISOString(),
+  });
+
+  // Seed a full workout hierarchy for logging and analytics tests
+  const programId = 'e2e-program-001';
+  const weekId = 'e2e-week-001';
+  const workoutId = 'e2e-workout-001';
+  const exerciseId = 'e2e-exercise-001';
+  const setId = 'e2e-set-001';
+
+  await seedFirestoreDoc(`users/${uid}/programs/${programId}`, {
+    userId: uid,
+    id: programId,
+    name: 'E2E Test Program',
+    createdAt: new Date().toISOString(),
+    weekCount: 1,
+  });
+
+  await seedFirestoreDoc(`users/${uid}/programs/${programId}/weeks/${weekId}`, {
+    userId: uid,
+    id: weekId,
+    programId,
+    name: 'Week 1',
+    weekNumber: 1,
+    createdAt: new Date().toISOString(),
+    workoutCount: 1,
+  });
+
+  await seedFirestoreDoc(
+    `users/${uid}/programs/${programId}/weeks/${weekId}/workouts/${workoutId}`,
+    {
+      userId: uid,
+      id: workoutId,
+      weekId,
+      programId,
+      name: 'E2E Workout',
+      createdAt: new Date().toISOString(),
+      exerciseCount: 1,
+    }
+  );
+
+  await seedFirestoreDoc(
+    `users/${uid}/programs/${programId}/weeks/${weekId}/workouts/${workoutId}/exercises/${exerciseId}`,
+    {
+      userId: uid,
+      id: exerciseId,
+      workoutId,
+      weekId,
+      programId,
+      name: 'Bench Press',
+      exerciseType: 'strength',
+      order: 0,
+      createdAt: new Date().toISOString(),
+    }
+  );
+
+  await seedFirestoreDoc(
+    `users/${uid}/programs/${programId}/weeks/${weekId}/workouts/${workoutId}/exercises/${exerciseId}/sets/${setId}`,
+    {
+      userId: uid,
+      id: setId,
+      exerciseId,
+      workoutId,
+      weekId,
+      programId,
+      setNumber: 1,
+      reps: 5,
+      weight: 60,
+      checked: false,
+      createdAt: new Date().toISOString(),
+    }
+  );
+
+  console.log(`[global-setup] Test user created: ${TEST_EMAIL} (uid: ${uid})`);
+  console.log('[global-setup] Seeded workout hierarchy for E2E tests');
+}

--- a/fittrack/playwright/global-teardown.ts
+++ b/fittrack/playwright/global-teardown.ts
@@ -1,0 +1,6 @@
+import { clearEmulatorData } from './helpers/firebase-emulator';
+
+export default async function globalTeardown(): Promise<void> {
+  await clearEmulatorData();
+  console.log('[global-teardown] Emulator data cleared');
+}

--- a/fittrack/playwright/helpers/firebase-emulator.ts
+++ b/fittrack/playwright/helpers/firebase-emulator.ts
@@ -1,0 +1,94 @@
+const AUTH_URL = 'http://localhost:9099';
+const FIRESTORE_URL = 'http://localhost:8080';
+const PROJECT_ID = 'fitness-app-8505e';
+
+export async function createTestUser(email: string, password: string): Promise<string> {
+  // Create user via Auth emulator REST API
+  const res = await fetch(
+    `${AUTH_URL}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=fake-api-key`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, returnSecureToken: true }),
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`createTestUser failed: ${await res.text()}`);
+  }
+  const data = await res.json() as { localId: string };
+
+  // Mark email as verified via OOB endpoint
+  const oobRes = await fetch(
+    `${AUTH_URL}/emulator/v1/projects/${PROJECT_ID}/accounts`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ localId: data.localId, emailVerified: true }),
+    }
+  );
+  if (!oobRes.ok) {
+    throw new Error(`setEmailVerified failed: ${await oobRes.text()}`);
+  }
+
+  return data.localId;
+}
+
+export async function seedFirestoreDoc(
+  path: string,
+  fields: Record<string, unknown>
+): Promise<void> {
+  // Convert plain JS values to Firestore REST value format
+  const firestoreFields = toFirestoreFields(fields);
+  const segments = path.split('/');
+  const docId = segments[segments.length - 1];
+  const collectionPath = segments.slice(0, -1).join('/');
+
+  const url = `${FIRESTORE_URL}/v1/projects/${PROJECT_ID}/databases/(default)/documents/${collectionPath}/${docId}`;
+  const res = await fetch(url, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ fields: firestoreFields }),
+  });
+  if (!res.ok) {
+    throw new Error(`seedFirestoreDoc(${path}) failed: ${await res.text()}`);
+  }
+}
+
+export async function clearEmulatorData(): Promise<void> {
+  const url = `${FIRESTORE_URL}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`;
+  await fetch(url, { method: 'DELETE' });
+  // Auth emulator clear
+  const authClearUrl = `${AUTH_URL}/emulator/v1/projects/${PROJECT_ID}/accounts`;
+  await fetch(authClearUrl, { method: 'DELETE' });
+}
+
+// Converts a plain JS object to Firestore REST API field format
+function toFirestoreFields(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[key] = toFirestoreValue(value);
+  }
+  return result;
+}
+
+function toFirestoreValue(value: unknown): unknown {
+  if (value === null) return { nullValue: null };
+  if (typeof value === 'boolean') return { booleanValue: value };
+  if (typeof value === 'number') {
+    return Number.isInteger(value)
+      ? { integerValue: String(value) }
+      : { doubleValue: value };
+  }
+  if (typeof value === 'string') return { stringValue: value };
+  if (Array.isArray(value)) {
+    return { arrayValue: { values: value.map(toFirestoreValue) } };
+  }
+  if (typeof value === 'object' && value !== null) {
+    return {
+      mapValue: {
+        fields: toFirestoreFields(value as Record<string, unknown>),
+      },
+    };
+  }
+  return { stringValue: String(value) };
+}

--- a/fittrack/playwright/package.json
+++ b/fittrack/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "fittrack-playwright",
+  "private": true,
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.47.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/fittrack/playwright/playwright.config.ts
+++ b/fittrack/playwright/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  retries: 1,
+  workers: 1,
+  reporter: [
+    ['list'],
+    ['json', { outputFile: 'playwright-report/results.json' }],
+    ['github'],
+    ['html', { outputFolder: 'playwright-report/html', open: 'never' }],
+  ],
+  use: {
+    baseURL: 'http://localhost:3000',
+    screenshot: 'on',
+    trace: 'on-first-retry',
+    video: 'on-first-retry',
+  },
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
+  projects: [
+    {
+      name: 'mobile-375px',
+      use: {
+        ...devices['Pixel 5'],
+        viewport: { width: 375, height: 812 },
+      },
+    },
+    {
+      name: 'desktop-1280px',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+  ],
+});

--- a/fittrack/playwright/tsconfig.json
+++ b/fittrack/playwright/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Adds \`fittrack/playwright/\` Node.js project with Playwright test runner configured for Flutter web PWA testing
- Two viewport projects: mobile-375px and desktop-1280px, both using headless Chromium
- Firebase emulator helpers use REST APIs (no Firebase SDK dependency in test runner)
- Global setup seeds a complete workout hierarchy and sets \`isProOverride: true\` so Analytics Pro gate is open for test user
- Global teardown clears all emulator data for a clean next run

## Files added
- \`playwright/package.json\` — Node project config with \`@playwright/test ^1.47.0\`
- \`playwright/tsconfig.json\` — TypeScript config
- \`playwright/playwright.config.ts\` — Playwright config (projects, reporters, global setup/teardown)
- \`playwright/helpers/firebase-emulator.ts\` — \`createTestUser()\`, \`seedFirestoreDoc()\`, \`clearEmulatorData()\`
- \`playwright/global-setup.ts\` — creates test user, seeds Firestore hierarchy
- \`playwright/global-teardown.ts\` — clears emulator state

Part of #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)