### PR TITLE
[Task #493] Program/week/workout creation E2E test

### DIFF
--- a/fittrack/playwright/helpers/sign-in.ts
+++ b/fittrack/playwright/helpers/sign-in.ts
@@ -1,0 +1,31 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Signs in via the app's sign-in screen using Firebase Auth emulator credentials.
+ * Waits for the "My Programs" screen to confirm successful sign-in.
+ *
+ * Flutter web HTML renderer renders TextFormField as real <input> elements once
+ * the field is focused. The email field is the first input; password uses type="password".
+ */
+export async function signIn(page: Page, email: string, password: string): Promise<void> {
+  await page.goto('/');
+
+  // Wait for sign-in form to render
+  await page.waitForSelector('text=Sign In', { timeout: 20_000 });
+
+  // Fill email — first text input on the sign-in screen
+  const emailInput = page.locator('input').first();
+  await emailInput.waitFor({ timeout: 10_000 });
+  await emailInput.fill(email);
+
+  // Fill password — obscureText:true renders as type="password"
+  const passwordInput = page.locator('input[type="password"]');
+  await passwordInput.waitFor({ timeout: 10_000 });
+  await passwordInput.fill(password);
+
+  // Click the Sign In button
+  await page.getByText('Sign In', { exact: true }).click();
+
+  // Wait for the home screen to confirm sign-in succeeded
+  await page.waitForSelector('text=My Programs', { timeout: 20_000 });
+}

--- a/fittrack/playwright/tests/program-creation.spec.ts
+++ b/fittrack/playwright/tests/program-creation.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+import { signIn } from '../helpers/sign-in';
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? 'playwright-e2e@test.com';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'playwright-test-123';
+
+const PROGRAM_NAME = 'E2E Created Program';
+const WEEK_NAME = 'E2E Week 1';
+const WORKOUT_NAME = 'E2E Push Day';
+
+test.describe('Program / Week / Workout Creation', () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, EMAIL, PASSWORD);
+  });
+
+  test('creates a program, week, and workout end-to-end', async ({ page }, testInfo) => {
+    // --- SIGN-IN COMPLETE ---
+    await page.screenshot({ path: `test-results/${testInfo.title}/01-signed-in.png` });
+
+    // --- CREATE PROGRAM ---
+    // Click the FAB (+) to open the create options bottom sheet.
+    // Flutter FABs with Icons.add expose aria-label="Add" via the icon's semantic label.
+    await page.getByRole('button', { name: /add/i }).last().click();
+
+    // Bottom sheet: choose "Start Fresh"
+    await expect(page.getByText('Start Fresh')).toBeVisible({ timeout: 10_000 });
+    await page.getByText('Start Fresh').click();
+
+    // CreateProgramScreen: fill program name and submit
+    await expect(page.getByText('Create New Program')).toBeVisible({ timeout: 10_000 });
+    await page.getByPlaceholder('e.g., Full Body Strength').fill(PROGRAM_NAME);
+    await page.screenshot({ path: `test-results/${testInfo.title}/02-program-name-filled.png` });
+    await page.getByText('CREATE', { exact: true }).click();
+
+    // Verify program appears in the list
+    await expect(page.getByText(PROGRAM_NAME)).toBeVisible({ timeout: 15_000 });
+    await page.screenshot({ path: `test-results/${testInfo.title}/03-program-created.png` });
+
+    // --- NAVIGATE INTO PROGRAM ---
+    await page.getByText(PROGRAM_NAME).click();
+    // Wait for program detail screen
+    await expect(page.getByText(PROGRAM_NAME)).toBeVisible({ timeout: 10_000 });
+
+    // --- CREATE WEEK ---
+    // Empty state shows "Create Week" button; if FAB is shown instead, fall back to FAB.
+    const createWeekButton = page.getByText('Create Week', { exact: true });
+    const hasEmptyState = await createWeekButton.isVisible().catch(() => false);
+    if (hasEmptyState) {
+      await createWeekButton.click();
+    } else {
+      await page.getByRole('button', { name: /add/i }).last().click();
+    }
+
+    // CreateWeekScreen: fill week name and submit
+    await expect(page.getByText('Create New Week')).toBeVisible({ timeout: 10_000 });
+    await page.getByPlaceholder('e.g., Week 1, Foundation Week').fill(WEEK_NAME);
+    await page.screenshot({ path: `test-results/${testInfo.title}/04-week-name-filled.png` });
+    await page.getByText('CREATE', { exact: true }).click();
+
+    // Verify week appears
+    await expect(page.getByText(WEEK_NAME)).toBeVisible({ timeout: 15_000 });
+    await page.screenshot({ path: `test-results/${testInfo.title}/05-week-created.png` });
+
+    // --- NAVIGATE INTO WEEK ---
+    await page.getByText(WEEK_NAME).click();
+    await expect(page.getByText(WEEK_NAME)).toBeVisible({ timeout: 10_000 });
+
+    // --- CREATE WORKOUT ---
+    const createWorkoutButton = page.getByText('Create Workout', { exact: true });
+    const hasWorkoutEmptyState = await createWorkoutButton.isVisible().catch(() => false);
+    if (hasWorkoutEmptyState) {
+      await createWorkoutButton.click();
+    } else {
+      await page.getByRole('button', { name: /add/i }).last().click();
+    }
+
+    // CreateWorkoutScreen: fill workout name and submit
+    await expect(page.getByText('Create Workout').first()).toBeVisible({ timeout: 10_000 });
+    await page.getByPlaceholder('e.g., Push Day, Upper Body, Cardio').fill(WORKOUT_NAME);
+    await page.screenshot({ path: `test-results/${testInfo.title}/06-workout-name-filled.png` });
+    await page.getByText('CREATE', { exact: true }).click();
+
+    // Verify workout appears
+    await expect(page.getByText(WORKOUT_NAME)).toBeVisible({ timeout: 15_000 });
+    await page.screenshot({ path: `test-results/${testInfo.title}/07-workout-created.png` });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds shared `helpers/sign-in.ts` helper used by all E2E tests
- Adds `tests/program-creation.spec.ts` covering Story 1: sign in → create program via Start Fresh → add week → add a workout, with 7 screenshots captured at key steps

## Test flow
1. Sign in with emulator test user
2. Click FAB → bottom sheet → Start Fresh → fill program name → CREATE
3. Verify program appears in list
4. Navigate into program → create week → CREATE
5. Verify week appears
6. Navigate into week → create workout → CREATE
7. Verify workout appears

Part of #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)