### PR TITLE
[Task #494-496] Workout logging, analytics, and offline E2E tests

### DIFF
--- a/fittrack/playwright/tests/analytics.spec.ts
+++ b/fittrack/playwright/tests/analytics.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import { signIn } from '../helpers/sign-in';
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? 'playwright-e2e@test.com';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'playwright-test-123';
+
+test.describe('Analytics Screen', () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, EMAIL, PASSWORD);
+  });
+
+  test('analytics screen renders without error', async ({ page }, testInfo) => {
+    // The test user has isProOverride:true seeded in global-setup,
+    // so the Analytics Pro gate is open.
+
+    // Navigate to Analytics via bottom navigation tab
+    await page.getByText('Analytics', { exact: true }).click();
+
+    // The Analytics screen should load without crash or blank screen
+    await expect(page.getByText('Analytics').first()).toBeVisible({ timeout: 15_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/01-analytics-loaded.png` });
+
+    // Verify at least one tab is visible (Overview, Exercise, or Trends)
+    const hasOverviewTab = await page.getByText('Overview').isVisible().catch(() => false);
+    const hasExerciseTab = await page.getByText('Exercise').isVisible().catch(() => false);
+    const hasTrendsTab = await page.getByText('Trends').isVisible().catch(() => false);
+
+    expect(hasOverviewTab || hasExerciseTab || hasTrendsTab).toBeTruthy();
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/02-analytics-tabs-visible.png` });
+
+    // Verify no error dialog is shown (error dialogs typically contain "Error" or "Something went wrong")
+    const errorDialog = page.getByText(/something went wrong/i);
+    await expect(errorDialog).not.toBeVisible();
+
+    // Verify screen is not blank: some content should be present beyond just the nav
+    // The page should have rendered more than just the navigation bar
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.length).toBeGreaterThan(20);
+  });
+});

--- a/fittrack/playwright/tests/offline-smoke.spec.ts
+++ b/fittrack/playwright/tests/offline-smoke.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { signIn } from '../helpers/sign-in';
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? 'playwright-e2e@test.com';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'playwright-test-123';
+
+// Offline smoke test runs only at desktop viewport to reduce complexity.
+// Service worker caching is viewport-independent, so a single project is sufficient.
+test.describe('PWA Offline Smoke', () => {
+  test.skip(({ browserName }) => browserName !== 'chromium', 'PWA service worker only in Chromium');
+
+  test('app shell loads from cache when network is offline', async ({ page, context }, testInfo) => {
+    // --- WARM THE SERVICE WORKER CACHE ---
+    // Sign in first to ensure the service worker has cached the app shell.
+    await signIn(page, EMAIL, PASSWORD);
+    await expect(page.getByText('My Programs')).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the service worker to activate and cache the app shell.
+    // Flutter web registers a service worker on first load; wait for it to be active.
+    await page.waitForFunction(() => {
+      return navigator.serviceWorker?.controller !== null;
+    }, { timeout: 15_000 }).catch(() => {
+      // Service worker may not be active in test environment; continue anyway
+    });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/01-online-loaded.png` });
+
+    // --- GO OFFLINE ---
+    await context.setOffline(true);
+
+    // Reload the page while offline
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => {
+      // Page may take longer to load from cache; catch timeout and continue
+    });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/02-after-offline-reload.png` });
+
+    // --- VERIFY APP SHELL IS VISIBLE OFFLINE ---
+    // The browser should NOT show a "no internet" error page.
+    // Chromium's offline error page contains the text "ERR_INTERNET_DISCONNECTED" or
+    // "No internet" — if this text is present, the service worker cache failed.
+    const pageContent = await page.content();
+    const hasNetworkError = pageContent.includes('ERR_INTERNET_DISCONNECTED') ||
+      pageContent.includes('ERR_NETWORK_CHANGED') ||
+      pageContent.includes('No internet');
+    expect(hasNetworkError).toBeFalsy();
+
+    // Some navigable content should be visible (the Flutter app shell or at minimum the title)
+    await page.waitForFunction(() => document.title.length > 0, { timeout: 10_000 }).catch(() => {});
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/03-offline-app-visible.png` });
+
+    // --- RESTORE NETWORK ---
+    await context.setOffline(false);
+
+    // Reload to reconnect
+    await page.reload({ timeout: 20_000 });
+    await expect(page.getByText('My Programs')).toBeVisible({ timeout: 20_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/04-reconnected.png` });
+  });
+});

--- a/fittrack/playwright/tests/workout-logging.spec.ts
+++ b/fittrack/playwright/tests/workout-logging.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import { signIn } from '../helpers/sign-in';
+
+const EMAIL = process.env.E2E_TEST_EMAIL ?? 'playwright-e2e@test.com';
+const PASSWORD = process.env.E2E_TEST_PASSWORD ?? 'playwright-test-123';
+
+// Seeded in global-setup
+const PROGRAM_NAME = 'E2E Test Program';
+const WEEK_NAME = 'Week 1';
+const WORKOUT_NAME = 'E2E Workout';
+const EXERCISE_NAME = 'Bench Press';
+
+test.describe('Workout Set Logging', () => {
+  test.beforeEach(async ({ page }) => {
+    await signIn(page, EMAIL, PASSWORD);
+  });
+
+  test('navigates to seeded workout and checks off a set', async ({ page }, testInfo) => {
+    // --- NAVIGATE TO WORKOUT ---
+    // Programs screen shows the seeded E2E Test Program
+    await page.getByText(PROGRAM_NAME).click();
+    await expect(page.getByText(WEEK_NAME)).toBeVisible({ timeout: 10_000 });
+
+    // Navigate into Week 1
+    await page.getByText(WEEK_NAME).click();
+    await expect(page.getByText(WORKOUT_NAME)).toBeVisible({ timeout: 10_000 });
+
+    // Navigate into E2E Workout
+    await page.getByText(WORKOUT_NAME).click();
+    await expect(page.getByText(EXERCISE_NAME)).toBeVisible({ timeout: 10_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/01-workout-open.png` });
+
+    // --- VERIFY EXERCISE IS VISIBLE ---
+    await expect(page.getByText(EXERCISE_NAME)).toBeVisible();
+
+    // --- LOG THE SET ---
+    // The seeded set (reps:5, weight:60) is pre-populated in the set row.
+    // Verify reps and weight fields are visible
+    await expect(page.getByText('Reps *').first()).toBeVisible({ timeout: 5_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/02-exercise-visible.png` });
+
+    // Check off the set using the Checkbox widget (Flutter renders as role="checkbox")
+    const checkbox = page.getByRole('checkbox').first();
+    await expect(checkbox).toBeVisible({ timeout: 5_000 });
+    await expect(checkbox).not.toBeChecked();
+    await checkbox.click();
+
+    // After checking, the set becomes read-only and the checkbox should be checked
+    await expect(checkbox).toBeChecked({ timeout: 5_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/03-set-checked.png` });
+
+    // --- VERIFY PERSISTENCE ---
+    // Reload the page and navigate back to verify the checked state persisted
+    await page.reload();
+    await page.waitForSelector('text=My Programs', { timeout: 20_000 });
+    await page.getByText(PROGRAM_NAME).click();
+    await page.getByText(WEEK_NAME).click();
+    await page.getByText(WORKOUT_NAME).click();
+    await expect(page.getByText(EXERCISE_NAME)).toBeVisible({ timeout: 10_000 });
+
+    // The checkbox should still be checked after reload
+    const reloadedCheckbox = page.getByRole('checkbox').first();
+    await expect(reloadedCheckbox).toBeChecked({ timeout: 10_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/04-persisted-after-reload.png` });
+  });
+});


### PR DESCRIPTION
## Summary
Three test specs covering Stories 2, 3, and 6 from the PRD:

**workout-logging.spec.ts** (Story 2)
- Uses seeded Bench Press exercise from global-setup
- Navigates E2E Test Program → Week 1 → E2E Workout
- Checks off the pre-seeded set; verifies checked state persists after page reload

**analytics.spec.ts** (Story 3)
- Navigates to Analytics via bottom nav tab
- Test user has \`isProOverride:true\` (seeded in global-setup) to bypass Pro gate
- Verifies screen renders with visible tabs (Overview/Exercise/Trends) and no error dialog

**offline-smoke.spec.ts** (Story 6)
- Warms service worker cache by completing a sign-in
- Sets network offline via \`context.setOffline(true)\`
- Reloads and verifies browser does not show ERR_INTERNET_DISCONNECTED
- Restores network and verifies app reconnects

Closes #494, #495, #496. Part of #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)