### PR TITLE
[Task #497] Add playwright-e2e CI job

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -635,6 +635,125 @@ jobs:
         pkill -f "firebase" || true
         pkill -f "java.*firestore" || true
 
+  # Playwright E2E browser tests against compiled Flutter web PWA output.
+  # Non-blocking: continue-on-error:true and NOT in all-tests-passed needs.
+  # Failures create one GitHub issue listing all defects (see playwright/scripts/report-failures.sh).
+  playwright-e2e:
+    name: Playwright E2E (PWA Browser Tests)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Setup Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: 3.35.1
+        cache: true
+
+    - name: Install Flutter dependencies
+      run: |
+        cd fittrack
+        flutter pub get
+
+    - name: Build Flutter web
+      run: |
+        cd fittrack
+        # --web-renderer html was removed in Flutter 3.24+; CanvasKit is the default.
+        # Playwright interacts via Flutter's flt-semantics accessibility overlay.
+        flutter build web --release \
+          --dart-define=USE_EMULATOR=true \
+          --dart-define=SKIP_ONBOARDING=true
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Firebase CLI
+      run: npm install -g firebase-tools
+
+    - name: Install Playwright dependencies
+      run: |
+        cd fittrack/playwright
+        npm ci
+
+    - name: Install Playwright browsers
+      run: |
+        cd fittrack/playwright
+        npx playwright install --with-deps chromium
+
+    - name: Start Firebase emulators
+      run: |
+        cd fittrack
+        firebase emulators:start --only auth,firestore --project fitness-app-8505e &
+        echo $! > emulator.pid
+
+    - name: Wait for Firebase emulators
+      run: |
+        echo "Waiting for Firestore emulator on localhost:8080..."
+        timeout 60 bash -c 'until curl -sf http://localhost:8080 > /dev/null; do sleep 2; done'
+        echo "Waiting for Auth emulator on localhost:9099..."
+        timeout 60 bash -c 'until curl -sf http://localhost:9099 > /dev/null; do sleep 2; done'
+        echo "✅ Firebase emulators ready"
+
+    - name: Start Flutter web server
+      run: |
+        npx serve@14 -s fittrack/build/web -l 3000 &
+        timeout 30 bash -c 'until curl -sf http://localhost:3000 > /dev/null; do sleep 1; done'
+        echo "✅ Flutter web server running on http://localhost:3000"
+
+    - name: Run Playwright E2E tests
+      id: playwright
+      run: |
+        cd fittrack/playwright
+        npx playwright test
+
+    - name: Upload Playwright artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-screenshots
+        path: |
+          fittrack/playwright/test-results/
+          fittrack/playwright/playwright-report/
+        retention-days: 90
+        if-no-files-found: ignore
+
+    - name: Report results to PR
+      if: always() && github.event_name == 'pull_request'
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd fittrack
+        if [ -f playwright/scripts/report-failures.sh ]; then
+          bash playwright/scripts/report-failures.sh \
+            "${{ github.event.number }}" \
+            "${{ github.run_id }}" \
+            "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        else
+          STATUS="${{ steps.playwright.outcome }}"
+          if [ "$STATUS" = "success" ]; then
+            gh pr comment "${{ github.event.number }}" --body "✅ Playwright E2E: all tests passed — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          else
+            gh pr comment "${{ github.event.number }}" --body "⚠️ Playwright E2E: one or more tests failed — [View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+          fi
+        fi
+
+    - name: Stop Firebase emulators
+      if: always()
+      run: |
+        cd fittrack
+        if [ -f emulator.pid ]; then
+          kill $(cat emulator.pid) || true
+          rm emulator.pid
+        fi
+        pkill -f "firebase" || true
+
   # Aggregate results and generate reports
   test-summary:
     name: Test Summary Report

--- a/fittrack/playwright/helpers/sign-in.ts
+++ b/fittrack/playwright/helpers/sign-in.ts
@@ -4,28 +4,38 @@ import { Page } from '@playwright/test';
  * Signs in via the app's sign-in screen using Firebase Auth emulator credentials.
  * Waits for the "My Programs" screen to confirm successful sign-in.
  *
- * Flutter web HTML renderer renders TextFormField as real <input> elements once
- * the field is focused. The email field is the first input; password uses type="password".
+ * Flutter web (CanvasKit, the default renderer since Flutter 3.24) renders UI on canvas
+ * but exposes an accessibility/semantics tree via <flt-semantics> elements. Pressing Tab
+ * activates Flutter's accessibility engine, making role-based locators work.
+ *
+ * Text editing fields: Flutter's text editing host creates real <input> elements in
+ * <flt-text-editing-host> when a field is focused. The password field uses type="password".
  */
 export async function signIn(page: Page, email: string, password: string): Promise<void> {
   await page.goto('/');
 
-  // Wait for sign-in form to render
-  await page.waitForSelector('text=Sign In', { timeout: 20_000 });
+  // Activate Flutter's accessibility semantics tree (required for CanvasKit renderer).
+  // Flutter only enables the flt-semantics overlay when it detects accessibility use;
+  // pressing Tab is the most reliable trigger in headless Chromium.
+  await page.keyboard.press('Tab');
 
-  // Fill email — first text input on the sign-in screen
-  const emailInput = page.locator('input').first();
-  await emailInput.waitFor({ timeout: 10_000 });
-  await emailInput.fill(email);
+  // Wait for the sign-in form to be rendered and accessible
+  await page.waitForSelector('flt-semantics-host', { timeout: 20_000 });
 
-  // Fill password — obscureText:true renders as type="password"
+  // Click the Email field and fill it. Flutter creates a real <input> in the text editing
+  // host when focused. We target by ARIA role since Flutter sets aria-label from labelText.
+  const emailField = page.getByRole('textbox', { name: /email/i });
+  await emailField.waitFor({ timeout: 10_000 });
+  await emailField.fill(email);
+
+  // Fill password field — obscureText:true renders the editing input as type="password"
   const passwordInput = page.locator('input[type="password"]');
   await passwordInput.waitFor({ timeout: 10_000 });
   await passwordInput.fill(password);
 
-  // Click the Sign In button
-  await page.getByText('Sign In', { exact: true }).click();
+  // Click the Sign In button (exposed via flt-semantics role="button")
+  await page.getByRole('button', { name: /sign in/i }).click();
 
-  // Wait for the home screen to confirm sign-in succeeded
-  await page.waitForSelector('text=My Programs', { timeout: 20_000 });
+  // Wait for the home screen — "My Programs" text confirms successful sign-in
+  await page.waitForSelector('flt-semantics:has-text("My Programs")', { timeout: 25_000 });
 }


### PR DESCRIPTION
## Summary
- Adds \`playwright-e2e\` job to \`fittrack_test_suite.yml\` — runs on every PR, non-blocking
- Builds Flutter web with \`USE_EMULATOR=true\` + \`SKIP_ONBOARDING=true\` dart-define flags
- Starts Firebase Auth/Firestore emulators, serves build on port 3000, runs Playwright
- Uploads \`playwright-screenshots\` artifact (90 days); posts PR comment pass/fail
- \`continue-on-error: true\` and absent from \`all-tests-passed\` needs — fully non-blocking
- Updates \`helpers/sign-in.ts\` for Flutter CanvasKit semantics (\`--web-renderer html\` was removed in Flutter 3.24+; now uses Tab keypress to activate \`flt-semantics\` overlay)

## Why no --web-renderer html
Flutter 3.24 removed the HTML renderer. CanvasKit (the default) renders to canvas but exposes an accessibility semantics tree via \`flt-semantics\` elements. Pressing Tab in the browser activates Flutter's accessibility engine, making \`getByRole()\` locators work.

Part of #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)