### PR TITLE
[Bug #508] Fix playwright-e2e CI: use npm install instead of npm ci

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -680,7 +680,10 @@ jobs:
     - name: Install Playwright dependencies
       run: |
         cd fittrack/playwright
-        npm ci
+        # npm install used instead of npm ci because no package-lock.json is committed.
+        # package-lock.json is gitignored (Windows SSL prevents local generation);
+        # version is pinned in package.json via ^semver so installs are stable.
+        npm install
 
     - name: Install Playwright browsers
       run: |


### PR DESCRIPTION
## Fix

Replaces \`npm ci\` with \`npm install\` in the \`playwright-e2e\` CI job's **Install Playwright dependencies** step.

## Root Cause

\`npm ci\` requires a committed \`package-lock.json\`. None was committed because generating one locally fails on Windows due to an SSL certificate verification error (\`UNABLE_TO_VERIFY_LEAF_SIGNATURE\` when reaching npmjs.org). The lockfile cannot be committed without generating it first.

## Why npm install is acceptable

- \`package.json\` pins \`@playwright/test\` at \`^1.47.0\` — only patch/minor upgrades can be picked up
- Playwright's Chromium binary is separately pinned by \`npx playwright install --with-deps chromium\`
- CI runs on a fresh Ubuntu runner each time, so caching is not a concern
- If lockfile pinning is required in the future, it can be generated in CI and committed as an artifact

Fixes #508. Part of #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)