### PR TITLE
[Bug #510] Add Java 21 setup to playwright-e2e CI job

### DIFF
--- a/.github/workflows/fittrack_test_suite.yml
+++ b/.github/workflows/fittrack_test_suite.yml
@@ -674,6 +674,12 @@ jobs:
       with:
         node-version: '20'
 
+    - name: Setup Java 21 for Firebase emulators
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
     - name: Install Firebase CLI
       run: npm install -g firebase-tools
 


### PR DESCRIPTION
## Fix

Adds \`actions/setup-java@v4\` (Temurin, Java 21) to the \`playwright-e2e\` CI job, before the Firebase CLI install step.

## Root Cause

The latest version of \`firebase-tools\` (installed via \`npm install -g firebase-tools\`) dropped support for Java <21. The \`ubuntu-latest\` runner defaults to Java 17. Without an explicit Java setup step, Firebase emulators fail to start with:

\`\`\`
Error: firebase-tools no longer supports Java version before 21.
\`\`\`

The \`enhanced-tests\` job avoided this because it uses \`node-version: '18'\`, which happens to install an older firebase-tools. The \`playwright-e2e\` job uses \`node-version: '20'\`, which pulls the latest firebase-tools.

## Change

Added before the \`Install Firebase CLI\` step:
\`\`\`yaml
- name: Setup Java 21 for Firebase emulators
  uses: actions/setup-java@v4
  with:
    distribution: 'temurin'
    java-version: '21'
\`\`\`

Fixes #510. Part of #490.

🤖 Generated with [Claude Code](https://claude.com/claude-code)