### PR TITLE
[Task] Cloudflare Worker setup + /create-checkout-session endpoint (#516)

### DIFF
--- a/Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md
+++ b/Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md
@@ -1,0 +1,171 @@
+# PRD: Stripe Payment Integration via Cloudflare Worker
+
+**Status:** Requirements Complete
+**Priority:** High
+**Platform:** Web (PWA)
+**GitHub Issue:** [#515](https://github.com/justbuildstuff-dev/Fitness-App/issues/515)
+**Author:** BA Agent
+**Date:** 2026-07-10
+
+---
+
+## Problem Statement
+
+Overload Pro's paywall is built but non-functional. The existing checkout flow depends on the Firebase Stripe Extension, which requires the Firebase Blaze (pay-as-you-go) plan. Upgrading introduces unbounded GCP billing risk.
+
+This feature replaces the Firebase Extension dependency with a Cloudflare Worker — a permanently-free serverless function that handles Stripe Checkout session creation and webhook fulfilment, writing subscription status directly to Firestore via the Admin REST API.
+
+---
+
+## Goals
+
+- Make Pro subscriptions purchasable on the web PWA
+- Eliminate the Firebase Blaze plan requirement
+- Keep the Flutter app changes minimal (primarily a service layer swap)
+- Update pricing to reflect market positioning
+
+---
+
+## Out of Scope
+
+- iOS App Store IAP and Android Play Billing (future feature)
+- Lifetime plan (future feature)
+- Free trials (deferred — can be reintroduced as a growth lever later)
+- Info site / marketing page pricing update (separate task — note for SA to flag as a dependency)
+- Stripe Customer Portal configuration (manual one-time setup, not a code task)
+
+---
+
+## Pricing
+
+| Plan | Price | Saving vs monthly | Notes |
+|------|-------|-------------------|-------|
+| Monthly | $6.99/month | — | No change |
+| Annual | $49.99/year | ~40% | Updated from $39.99 |
+
+Free trial copy ("14-day free trial") must be removed from the paywall UI.
+
+---
+
+## Architecture Overview
+
+```
+User taps plan in PaywallScreen
+  → SubscriptionService calls Cloudflare Worker POST /create-checkout-session
+  → Worker creates Stripe Checkout Session via Stripe API
+  → Worker returns { url }
+  → App opens url via url_launcher (LaunchMode.externalApplication)
+  → User completes payment on Stripe hosted page
+  → Stripe fires webhook → Worker POST /stripe-webhook
+      → verifies Stripe-Signature header
+      → handles checkout.session.completed → writes subscription doc to Firestore
+      → handles customer.subscription.updated → updates subscription doc
+      → handles customer.subscription.deleted → marks subscription cancelled
+  → SubscriptionProvider real-time listener picks up Firestore change
+  → User lands back on app with ?checkout=success in URL
+  → App detects param → shows "Welcome to Pro" banner
+```
+
+---
+
+## User Stories
+
+### US-1: Purchase a subscription
+
+**As a free user**, I want to tap a plan on the paywall and be taken directly to a Stripe payment page, so that I can subscribe to Overload Pro without leaving the app ecosystem.
+
+**Acceptance Criteria:**
+- Tapping Monthly or Annual on the paywall opens the Stripe hosted Checkout page in the browser
+- The Checkout page is pre-populated with the correct plan price and currency
+- Tapping "Cancel" on the Stripe page returns the user to the app (cancel URL)
+- The checkout flow works on both mobile and desktop web browsers
+- No Firebase Extension or Blaze plan is required for checkout to function
+
+### US-2: Pro access activates after payment
+
+**As a user who has just paid**, I want my Pro features to unlock automatically, so that I do not have to sign out and back in or manually refresh.
+
+**Acceptance Criteria:**
+- Within 30 seconds of payment completing, `SubscriptionProvider.isPro` returns `true` for the user
+- The real-time Firestore listener (`customers/{uid}/subscriptions`) fires when the Worker writes the subscription document
+- Feature gates (program limit, analytics, custom exercises) lift without any user action
+- If the Firestore write is delayed, the UI does not show an error — it waits silently for the listener to fire
+
+### US-3: Welcome confirmation on return
+
+**As a user returning to the app after payment**, I want to see a clear confirmation that my subscription is active, so that I know the purchase worked and I don't pay twice.
+
+**Acceptance Criteria:**
+- When the app loads with `?checkout=success` in the URL, a "Welcome to Pro" banner or dialog is displayed
+- The banner is shown once per successful checkout (not on every subsequent app load)
+- The banner is dismissible
+- The banner is not shown when `?checkout=cancelled` is in the URL
+
+### US-4: Manage or cancel subscription
+
+**As an active Pro subscriber**, I want to tap a button in the app to manage my subscription, so that I can change my plan or cancel without contacting support.
+
+**Acceptance Criteria:**
+- The "Manage subscription" button in the Subscription screen opens the Stripe Customer Portal in the browser
+- The button is only shown to users with an active subscription (not `isProOverride` admin users)
+- The Stripe Customer Portal URL is configurable without a code change (stored as a constant, not hardcoded in logic)
+- After cancelling in the Portal and returning, the subscription status updates automatically via the real-time listener
+
+### US-5: Subscription expiry revokes Pro access
+
+**As the system**, I want Pro access to be revoked automatically when a subscription is cancelled or expires, so that users who cancel do not continue to access paid features.
+
+**Acceptance Criteria:**
+- When Stripe fires `customer.subscription.deleted`, the Worker updates the Firestore subscription document with `status: 'canceled'`
+- `SubscriptionProvider.isPro` returns `false` once the Firestore update is received by the real-time listener
+- Feature gates re-engage immediately — the user is downgraded to free tier limits
+- Existing data (programs, exercises, sets) is not deleted on downgrade
+
+### US-6: Webhook security
+
+**As the system**, I want all Stripe webhook calls to be cryptographically verified, so that malicious actors cannot fake payment events to grant themselves Pro access.
+
+**Acceptance Criteria:**
+- The Cloudflare Worker verifies the `Stripe-Signature` header on every webhook request using the webhook signing secret
+- Requests with an invalid or missing signature return HTTP 400 and are not processed
+- The webhook signing secret is stored as a Cloudflare Worker secret (environment variable), never in source code
+- The Firebase service account key used to write to Firestore is also stored as a Cloudflare Worker secret
+
+---
+
+## Non-Functional Requirements
+
+- **Latency:** Checkout session URL returned within 3 seconds under normal conditions
+- **Webhook reliability:** Worker returns HTTP 200 within 5 seconds (Stripe retries on non-200)
+- **Idempotency:** Processing the same webhook event twice must not create duplicate subscription documents
+- **No Blaze plan:** The solution must function entirely on the Firebase Spark (free) plan — no Cloud Functions, no Firebase Extensions
+- **Security:** No secrets committed to the repository; all credentials stored as Cloudflare Worker secrets
+
+---
+
+## Existing Code to Modify
+
+| File | Change |
+|------|--------|
+| `lib/services/subscription_service.dart` | Replace `createCheckoutSession()` (currently writes to Firestore and polls) with HTTP POST to Cloudflare Worker endpoint; remove `lifetimePriceId` |
+| `lib/screens/subscription/paywall_screen.dart` | Remove Lifetime plan card; remove trial copy ("14-day free trial"); update annual price to $49.99 |
+| `fittrack/firestore.rules` | Review `customers/{userId}/checkout_sessions` rules — the Worker does not use this subcollection; keep or clean up |
+
+## New Code
+
+| Artifact | Description |
+|----------|-------------|
+| `cloudflare-worker/src/index.ts` | Worker with two routes: `POST /create-checkout-session` and `POST /stripe-webhook` |
+| `cloudflare-worker/package.json` | Wrangler + Stripe SDK dependencies |
+| `cloudflare-worker/wrangler.toml` | Worker name, routes, compatibility date |
+| `lib/main.dart` or router | Detect `?checkout=success` on startup and trigger welcome banner |
+
+---
+
+## Dependencies
+
+- Stripe account with two products created (Monthly $6.99, Annual $49.99) and price IDs recorded
+- Stripe webhook endpoint registered pointing to the deployed Cloudflare Worker URL
+- Firebase service account key (JSON) generated and stored as Cloudflare Worker secret
+- Stripe Customer Portal configured in the Stripe Dashboard with the correct return URL
+- **`fittrack/public/index.html`** — the PWA landing/info page pricing has already been updated by the developer. The Deployment Agent should redeploy Firebase Hosting as part of this feature's release (`firebase deploy --only hosting`).

--- a/Docs/Technical_Designs/Stripe_Cloudflare_Worker_Technical_Design.md
+++ b/Docs/Technical_Designs/Stripe_Cloudflare_Worker_Technical_Design.md
@@ -1,0 +1,356 @@
+# Technical Design: Stripe Payment Integration via Cloudflare Worker
+
+**Feature:** Stripe Payment Integration via Cloudflare Worker
+**GitHub Issue:** [#515](https://github.com/justbuildstuff-dev/Fitness-App/issues/515)
+**PRD:** [Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md](../PRDs/Stripe_Cloudflare_Worker_PRD.md)
+**Author:** SA Agent
+**Date:** 2026-07-10
+**Status:** Design Approved
+
+---
+
+## Current Architecture Analysis
+
+**State Management:** Provider pattern (`ChangeNotifier` + `ChangeNotifierProxyProvider`). `SubscriptionProvider` is a `ChangeNotifierProxyProvider<AuthProvider, SubscriptionProvider>` registered in `main.dart`. Services are singletons (`SubscriptionService.instance`).
+
+**File Structure Discovered:**
+- `lib/services/` — singleton services (e.g. `SubscriptionService`, `FirestoreService`)
+- `lib/providers/` — ChangeNotifier providers
+- `lib/screens/subscription/` — `paywall_screen.dart`, `subscription_management_screen.dart`
+- `lib/widgets/` — reusable widgets (e.g. `returning_user_banner.dart` — banner pattern reference)
+
+**Similar Feature (Banner Pattern):** `lib/widgets/returning_user_banner.dart` — `StatefulWidget` with `_dismissed` bool, static service check, `SizedBox.shrink()` when inactive, `Card` with `primaryContainer` colour. `CheckoutSuccessBanner` follows this exactly.
+
+**URL Param Detection:** No routing library (direct `Navigator.push` only). `Uri.base.queryParameters` is available from `dart:core` on Flutter web — no `dart:html` import needed. Read in widget's `initState` or as a static pre-computed flag.
+
+**HTTP package:** `http: ^1.1.0` is currently in `dev_dependencies` only. It must be moved to `dependencies` for the refactored `SubscriptionService` to use it in production.
+
+**Firestore Customers Rules:** `customers/{userId}/checkout_sessions` currently allows client read/write (used by the Firebase Extension to receive the checkout URL). This subcollection is unused in the new flow — the Worker creates sessions directly via the Stripe API. The rule will be updated to remove write access and add a legacy comment.
+
+**Testing Approach:** Unit tests use `mockito` (`.mocks.dart` generated files). Widget tests use `flutter_test`. The `SubscriptionService` should expose the Worker base URL as a configurable constant (or injectable for tests).
+
+---
+
+## Architecture Overview
+
+The Firebase Stripe Extension is replaced entirely by a Cloudflare Worker. The Worker handles two concerns:
+
+1. **Checkout session creation** — the Flutter app POSTs to the Worker with the user's UID and price ID; the Worker calls the Stripe API and returns the hosted Checkout URL directly. No Firestore writes involved in this path.
+
+2. **Webhook fulfilment** — Stripe fires webhook events to the Worker; the Worker verifies the `Stripe-Signature` header, then writes subscription documents directly to Firestore via the Firebase Admin REST API using a service account JWT. Security rules are bypassed (as with any Admin SDK call).
+
+The existing `SubscriptionProvider` real-time listener on `customers/{uid}/subscriptions` is unchanged — it picks up documents written by the Worker automatically.
+
+```
+┌─────────────────────────┐
+│   Flutter Web (PWA)      │
+│                          │
+│  PaywallScreen           │
+│    → SubscriptionService │
+│       .createCheckout()  │──── POST /create-checkout-session ──▶ Cloudflare Worker
+│                          │◀─── { url: "https://checkout.stripe..." } ──────────────┘
+│    url_launcher opens    │
+│    Stripe Checkout page  │
+└─────────────────────────┘
+                                   Stripe fires webhook
+                                       │
+                          POST /stripe-webhook ──▶ Cloudflare Worker
+                                                        │ verify Stripe-Signature
+                                                        │ build Firestore Admin JWT
+                                                        ▼
+                                              Firestore REST API
+                                          customers/{uid}/subscriptions/{subId}
+                                                        │
+                                   SubscriptionProvider listener fires
+                                          │
+                              Flutter app isPro = true
+```
+
+---
+
+## Component Design
+
+### New: Cloudflare Worker (`cloudflare-worker/`)
+
+A standalone TypeScript project using Wrangler. Lives outside `fittrack/` at the repo root.
+
+```
+cloudflare-worker/
+├── src/
+│   ├── index.ts          # Entry: routes requests to handlers
+│   ├── checkout.ts       # POST /create-checkout-session handler
+│   ├── webhook.ts        # POST /stripe-webhook handler
+│   └── firestore.ts      # Firestore Admin REST API helper (JWT + PATCH)
+├── wrangler.toml
+├── package.json
+└── tsconfig.json
+```
+
+**Environment variables (Cloudflare secrets — never committed):**
+| Secret | Description |
+|--------|-------------|
+| `STRIPE_SECRET_KEY` | Stripe secret key (`sk_live_...`) |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret (`whsec_...`) |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | Full service account JSON as a string |
+
+**`src/checkout.ts`** — `POST /create-checkout-session`
+
+Input (JSON body):
+```json
+{ "uid": "firebase-auth-uid", "priceId": "price_xxx", "successUrl": "...", "cancelUrl": "..." }
+```
+
+Steps:
+1. Validate required fields present
+2. Call Stripe API: `POST https://api.stripe.com/v1/checkout/sessions` with `mode: subscription`, `client_reference_id: uid`, `line_items: [{ price: priceId, quantity: 1 }]`, `success_url`, `cancel_url`
+3. Return `{ url: session.url }`
+
+CORS headers: `Access-Control-Allow-Origin: *` (Stripe Checkout opens in a separate tab; the POST itself comes from the Flutter app's origin)
+
+**`src/webhook.ts`** — `POST /stripe-webhook`
+
+Steps:
+1. Read raw request body (required for Stripe signature verification)
+2. Verify `Stripe-Signature` header using `STRIPE_WEBHOOK_SECRET` — return 400 on failure
+3. Route by `event.type`:
+   - `checkout.session.completed`: extract `client_reference_id` (uid), look up subscription ID via Stripe API, write subscription doc
+   - `customer.subscription.updated`: update subscription doc
+   - `customer.subscription.deleted`: write `status: 'canceled'` to subscription doc
+4. Return HTTP 200 immediately (Stripe retries on non-200)
+
+Idempotency: the Stripe subscription ID is used as the Firestore document ID. Firestore PATCH (merge) is naturally idempotent — replaying the same event produces the same document state.
+
+**`src/firestore.ts`** — Firestore Admin REST API helper
+
+The Worker calls Firestore's REST endpoint using a service account JWT — this bypasses Firestore security rules (same behaviour as the Admin SDK).
+
+JWT flow:
+1. Parse `FIREBASE_SERVICE_ACCOUNT_JSON` → extract `private_key` (PEM), `client_email`
+2. Build JWT payload: `{ iss: client_email, sub: client_email, aud: 'https://oauth2.googleapis.com/token', scope: 'https://www.googleapis.com/auth/datastore', iat, exp: iat+3600 }`
+3. Sign with `crypto.subtle.sign('RSASSA-PKCS1-v1_5', privateKey, headerPayload)` (Workers have full `crypto.subtle` support)
+4. Exchange JWT for access token: `POST https://oauth2.googleapis.com/token`
+5. PATCH to `https://firestore.googleapis.com/v1/projects/{projectId}/databases/(default)/documents/customers/{uid}/subscriptions/{subscriptionId}`
+
+**Subscription document shape** (what the Worker writes, in Firestore REST API format):
+```json
+{
+  "fields": {
+    "status":              { "stringValue": "active" },
+    "items":               { "arrayValue": { "values": [
+                               { "mapValue": { "fields": {
+                                   "price": { "mapValue": { "fields": {
+                                     "id": { "stringValue": "price_xxx" }
+                                   }}}
+                               }}}
+                             ]}},
+    "current_period_end":  { "timestampValue": "2027-07-10T00:00:00Z" }
+  }
+}
+```
+
+When the Flutter `cloud_firestore` SDK reads this document, the typed values are automatically deserialised to Dart types (`String`, `List`, `Timestamp`), matching what `SubscriptionInfo.fromStripeFirestore()` already expects. No Flutter-side changes are needed for subscription reading.
+
+---
+
+### Modified: `lib/services/subscription_service.dart`
+
+Replace the `createCheckoutSession()` Firestore write/poll with a direct HTTP POST to the Worker.
+
+**Key changes:**
+- Add `static const String _workerBaseUrl = 'https://[worker-name].[account].workers.dev'` (set during deployment)
+- Remove `lifetimePriceId` constant
+- Replace `createCheckoutSession()` body: write to `customers/{userId}/checkout_sessions` + poll → `http.post(_workerBaseUrl/create-checkout-session, body: json)` → parse `url` from response
+- Keep all other methods unchanged (`subscriptionStream`, `loadFromFirestore`, `openCustomerPortal`)
+
+**Error handling:** If the Worker returns non-200, throw `Exception('Checkout failed: $statusCode')`. `SubscriptionProvider.startCheckout()` already catches and surfaces this as `_error`.
+
+---
+
+### Modified: `pubspec.yaml`
+
+Move `http` from `dev_dependencies` to `dependencies`:
+```yaml
+dependencies:
+  # ...existing...
+  http: ^1.1.0   # moved from dev_dependencies
+```
+
+---
+
+### Modified: `lib/screens/subscription/paywall_screen.dart`
+
+- Remove the `_PlanCard` for 'Lifetime' (`\$59.99`, one-time)
+- Remove `'14-day free trial'` from `detail` fields on Monthly and Annual cards
+- Update Annual `price` from `'\$39.99/year'` to `'\$49.99/year'`
+- Update Annual `savings` from `'Save 52% vs monthly'` to `'Save 40% vs monthly'`
+- Update Annual `detail` from `'Billed annually · 14-day free trial'` to `'Billed annually'`
+- Update Monthly `detail` from `'14-day free trial'` to `''` (or remove the field)
+- Remove the `onTap` for the Lifetime card and its `startCheckout` call with `lifetimePriceId`
+
+---
+
+### Modified: `lib/screens/profile/profile_screen.dart`
+
+Line 98: Update subtitle from `'Unlock Overload Pro'` / subtext `'\$39.99/year.'` to `'\$49.99/year.'`
+
+---
+
+### New: `lib/widgets/checkout_success_banner.dart`
+
+Follows the `ReturningUserBanner` pattern exactly (`lib/widgets/returning_user_banner.dart`).
+
+```
+CheckoutSuccessBanner (StatefulWidget)
+  └── _CheckoutSuccessBannerState
+        bool _dismissed = false
+        build():
+          if (_dismissed || !_shouldShow) → SizedBox.shrink()
+          else → Card(primaryContainer) with:
+            - "Welcome to Overload Pro!" title + workspace_premium icon
+            - "Your subscription is now active." body
+            - X dismiss button
+```
+
+`_shouldShow` is a static bool computed once at app startup in `main.dart`:
+```dart
+// In main() before runApp(), web only:
+final bool _checkoutSuccess = kIsWeb
+    ? Uri.base.queryParameters['checkout'] == 'success'
+    : false;
+```
+
+This is passed into `OverloadApp` and stored on a simple `CheckoutSuccessService` static (mirrors `ReturningUserService.shouldShowPrompt` pattern):
+```dart
+class CheckoutSuccessService {
+  static bool pendingWelcome = false;
+  static void dismiss() => pendingWelcome = false;
+}
+```
+
+Set `CheckoutSuccessService.pendingWelcome = _checkoutSuccess` in `main()` before `runApp()`.
+
+On dismiss, the banner calls `CheckoutSuccessService.dismiss()` + `setState(() => _dismissed = true)`. This is in-memory only — refreshing the page after the first view re-shows the banner if the URL still contains `?checkout=success`. To prevent this, after showing the banner, also call:
+```dart
+// Cleans URL without a page reload (web only)
+if (kIsWeb) {
+  // Use dart:html (deprecated) or package:web
+  // Or: rely on the in-memory flag being cleared on dismiss
+}
+```
+
+**Decision:** Do NOT clean the URL programmatically to avoid `dart:html` / `package:web` dependency. The in-memory `pendingWelcome = false` on dismiss is sufficient — once dismissed, it won't re-appear in the same session. A hard refresh re-shows it, which is acceptable (the user paid, seeing "Welcome to Pro" twice is benign).
+
+---
+
+### Modified: `lib/screens/programs/programs_screen.dart`
+
+Add `CheckoutSuccessBanner()` as the first item in the programs list, above `ReturningUserBanner()` (the existing banner).
+
+---
+
+### Modified: `fittrack/firestore.rules`
+
+Update the `checkout_sessions` subcollection comment and remove client write access (no longer used):
+
+```
+match /customers/{userId} {
+  allow read: if request.auth != null && request.auth.uid == userId;
+  allow write: if false; // Cloudflare Worker writes via service account (Admin REST API)
+
+  // Legacy: was used by Firebase Stripe Extension for checkout session polling.
+  // Not used in current Cloudflare Worker flow — retained for historical compatibility.
+  match /checkout_sessions/{sessionId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false; // no longer written by client
+  }
+
+  match /subscriptions/{subscriptionId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false; // Cloudflare Worker writes via service account
+  }
+
+  match /payments/{paymentId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false;
+  }
+}
+```
+
+---
+
+## Implementation Tasks
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| 516 | Cloudflare Worker: project setup + /create-checkout-session endpoint | `cloudflare-worker/**` (new) | 1.5 days |
+| 517 | Cloudflare Worker: /stripe-webhook handler + Firestore write | `cloudflare-worker/src/webhook.ts`, `firestore.ts` | 2 days |
+| 518 | Flutter: move http dependency + refactor SubscriptionService | `pubspec.yaml`, `lib/services/subscription_service.dart` | 0.5 days |
+| 519 | Flutter: update PaywallScreen + ProfileScreen pricing UI | `lib/screens/subscription/paywall_screen.dart`, `lib/screens/profile/profile_screen.dart` | 0.5 days |
+| 520 | Flutter: CheckoutSuccessBanner + ProgramsScreen integration | `lib/widgets/checkout_success_banner.dart` (new), `lib/main.dart`, `lib/screens/programs/programs_screen.dart` | 1 day |
+| 521 | Firestore rules: update customers collection comments + remove legacy write access | `fittrack/firestore.rules` | 0.5 days |
+
+**Total estimated effort:** ~6 days
+
+**Dependency order:**
+- Task 516 first (Worker foundation — checkout endpoint needed to get Worker URL for Task 518)
+- Task 517 after 516 (same Worker project)
+- Tasks 518, 519, 520, 521 can be done in parallel after 516 is deployed
+
+---
+
+## Testing Strategy
+
+### Cloudflare Worker (Tasks 516–517)
+- Unit tests using Vitest (Wrangler's test harness) or manual testing via `wrangler dev`
+- Test `POST /create-checkout-session` with valid/missing fields
+- Test `POST /stripe-webhook` with valid and invalid Stripe signatures
+- Test idempotency: processing the same webhook event twice produces the same Firestore document
+- Use Stripe CLI (`stripe listen --forward-to localhost:8787`) for local webhook testing
+
+### Flutter (Tasks 518–520)
+- **Unit:** `SubscriptionService` — mock `http.Client`, assert correct Worker URL + JSON body, assert URL returned correctly
+- **Unit:** `CheckoutSuccessService` — assert `pendingWelcome` set correctly based on URL param
+- **Widget:** `CheckoutSuccessBanner` — `pendingWelcome = true` → banner visible; dismiss → `SizedBox.shrink()`; `pendingWelcome = false` → `SizedBox.shrink()`
+- **Widget:** `PaywallScreen` — assert no Lifetime card, no "free trial" text, correct prices
+- Follow existing test patterns: `mockito` for service mocks, `WidgetTester` for widget tests
+
+### Firestore Rules (Task 521)
+- Verify `customers/{userId}/checkout_sessions` write blocked for clients
+- Verify `customers/{userId}/subscriptions` read allowed for owner
+
+---
+
+## Deployment Notes
+
+1. **Manual setup required before implementation can be tested end-to-end:**
+   - Create Stripe products: Monthly ($6.99) and Annual ($49.99) — note the Price IDs
+   - Create Cloudflare Worker (`wrangler deploy`) and note the Worker URL
+   - Register Stripe webhook endpoint pointing to `https://[worker].workers.dev/stripe-webhook`
+   - Store secrets via `wrangler secret put`
+   - Configure Stripe Customer Portal return URL in Stripe Dashboard
+   - Update `_workerBaseUrl` and `monthlyPriceId`/`annualPriceId` constants in `SubscriptionService`
+
+2. **Firebase Hosting:** `firebase deploy --only hosting` — `fittrack/public/index.html` already updated; redeploy as part of this release.
+
+3. **No Firebase Blaze plan required.** The Firebase Spark plan is sufficient.
+
+---
+
+## Security Notes
+
+- Stripe webhook signature verification is mandatory — without it, any HTTP client could forge a `checkout.session.completed` event and grant Pro access to arbitrary users
+- Service account JSON must never be committed — store in Cloudflare Worker secrets only
+- The service account should be scoped to Firestore only (`roles/datastore.user`) — not a project owner
+- The Worker's `POST /create-checkout-session` endpoint does not require auth (Stripe Checkout handles payment auth). CORS is restricted to the app's production domain in the Worker config (not `*`)
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Worker cold-start latency on first request | Low | Workers typically < 5ms cold start; acceptable |
+| Stripe webhook delivery delay | Low | Stripe retries for 3 days; real-time listener shows Pro once doc is written |
+| JWT expiry mid-webhook | Low | Tokens are generated per-request with 1hr expiry; not reused |
+| `client_reference_id` missing on session | Low | Worker validates field presence before writing to Firestore; Stripe returns it on all checkout events |
+| Checkout success URL reloads banner on refresh | Accepted | In-memory flag cleared on dismiss; re-show on refresh is benign (user paid, Welcome to Pro is harmless) |

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fittrack-stripe-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240725.0",
+    "@vitest/coverage-v8": "^2.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0",
+    "wrangler": "^3.78.0"
+  }
+}

--- a/cloudflare-worker/src/checkout.ts
+++ b/cloudflare-worker/src/checkout.ts
@@ -1,0 +1,65 @@
+export interface CheckoutRequest {
+  uid: string;
+  priceId: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export async function handleCreateCheckoutSession(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  let body: CheckoutRequest;
+  try {
+    body = await request.json<CheckoutRequest>();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const { uid, priceId, successUrl, cancelUrl } = body;
+  if (!uid || !priceId || !successUrl || !cancelUrl) {
+    return jsonResponse(
+      { error: 'Missing required fields: uid, priceId, successUrl, cancelUrl' },
+      400,
+    );
+  }
+
+  const params = new URLSearchParams();
+  params.append('mode', 'subscription');
+  params.append('client_reference_id', uid);
+  params.append('line_items[0][price]', priceId);
+  params.append('line_items[0][quantity]', '1');
+  params.append('success_url', successUrl);
+  params.append('cancel_url', cancelUrl);
+  // Store Firebase UID in subscription metadata so it's available on all
+  // future subscription webhook events (updated, deleted).
+  params.append('subscription_data[metadata][uid]', uid);
+
+  const stripeResponse = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!stripeResponse.ok) {
+    const errorBody = await stripeResponse.text();
+    console.error('Stripe API error:', stripeResponse.status, errorBody);
+    return jsonResponse({ error: 'Failed to create checkout session' }, 502);
+  }
+
+  const session = await stripeResponse.json<{ url: string }>();
+  return jsonResponse({ url: session.url }, 200);
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1,0 +1,29 @@
+import { handleCreateCheckoutSession } from './checkout';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(),
+      });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/create-checkout-session') {
+      return handleCreateCheckoutSession(request, env);
+    }
+
+    return new Response('Not Found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+
+function corsHeaders(): HeadersInit {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}

--- a/cloudflare-worker/src/types.ts
+++ b/cloudflare-worker/src/types.ts
@@ -1,0 +1,8 @@
+// Cloudflare Worker environment bindings.
+// Secrets are set via `wrangler secret put` — never committed.
+interface Env {
+  FIREBASE_PROJECT_ID: string;
+  STRIPE_SECRET_KEY: string;
+  STRIPE_WEBHOOK_SECRET: string;
+  FIREBASE_SERVICE_ACCOUNT_JSON: string;
+}

--- a/cloudflare-worker/test/checkout.test.ts
+++ b/cloudflare-worker/test/checkout.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateCheckoutSession } from '../src/checkout';
+
+const mockEnv: Env = {
+  FIREBASE_PROJECT_ID: 'test-project',
+  STRIPE_SECRET_KEY: 'sk_test_mock',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test_mock',
+  FIREBASE_SERVICE_ACCOUNT_JSON: '{}',
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request('https://worker.test/create-checkout-session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('handleCreateCheckoutSession', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const req = new Request('https://worker.test/create-checkout-session', {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(400);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Invalid JSON');
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const req = makeRequest({ uid: 'user123' });
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(400);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Missing required fields');
+  });
+
+  it('calls Stripe API with correct params and returns url', async () => {
+    const mockSession = { url: 'https://checkout.stripe.com/test123' };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(mockSession),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const req = makeRequest({
+      uid: 'user123',
+      priceId: 'price_monthly',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(200);
+
+    const json = await res.json<{ url: string }>();
+    expect(json.url).toBe('https://checkout.stripe.com/test123');
+
+    // Verify Stripe was called with correct params
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const [stripeUrl, stripeInit] = fetchCall as [string, RequestInit];
+    expect(stripeUrl).toBe('https://api.stripe.com/v1/checkout/sessions');
+    expect(stripeInit.headers).toMatchObject({
+      Authorization: `Bearer sk_test_mock`,
+    });
+
+    const body = new URLSearchParams(stripeInit.body as string);
+    expect(body.get('mode')).toBe('subscription');
+    expect(body.get('client_reference_id')).toBe('user123');
+    expect(body.get('line_items[0][price]')).toBe('price_monthly');
+    expect(body.get('subscription_data[metadata][uid]')).toBe('user123');
+  });
+
+  it('returns 502 when Stripe API returns an error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: { message: 'Invalid API key' } }),
+      { status: 401 },
+    )));
+
+    const req = makeRequest({
+      uid: 'user123',
+      priceId: 'price_monthly',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(502);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Failed to create checkout session');
+  });
+
+  it('sets CORS header on response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ url: 'https://checkout.stripe.com/test' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const req = makeRequest({
+      uid: 'u1',
+      priceId: 'price_annual',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+});

--- a/cloudflare-worker/tsconfig.json
+++ b/cloudflare-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/cloudflare-worker/vitest.config.ts
+++ b/cloudflare-worker/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+    },
+  },
+});

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "fittrack-stripe-worker"
+main = "src/index.ts"
+compatibility_date = "2024-07-25"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+FIREBASE_PROJECT_ID = "fitness-app-8505e"
+
+# Secrets (set via `wrangler secret put`, never committed):
+# STRIPE_SECRET_KEY
+# STRIPE_WEBHOOK_SECRET
+# FIREBASE_SERVICE_ACCOUNT_JSON


### PR DESCRIPTION
## Summary

- Creates `cloudflare-worker/` TypeScript project using Wrangler (replaces Firebase Stripe Extension entirely)
- Implements `POST /create-checkout-session`: validates request, calls Stripe API, returns `{ url }` for the hosted Checkout page
- Stores Firebase UID in `subscription_data[metadata][uid]` on the Stripe session so it propagates to all future subscription webhook events
- Includes Vitest unit tests covering valid requests, missing fields, Stripe API errors, and CORS headers
- Also commits PRD (`Docs/PRDs/`) and Technical Design (`Docs/Technical_Designs/`) from BA/SA agents

## Secrets required (set via `wrangler secret put` — never committed)
- `STRIPE_SECRET_KEY`
- `STRIPE_WEBHOOK_SECRET`
- `FIREBASE_SERVICE_ACCOUNT_JSON`

## Test plan
- [ ] CI Vitest tests pass (`npm test` in `cloudflare-worker/`)
- [ ] `POST /create-checkout-session` with valid body returns `{ url }` (manual: `wrangler dev`)
- [ ] `POST /create-checkout-session` with missing fields returns HTTP 400
- [ ] CORS preflight (`OPTIONS`) returns 204

Part of #515
Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)