### PR TITLE
[Task] Stripe webhook handler + Firestore Admin REST write helper (#517)

### DIFF
--- a/cloudflare-worker/src/firestore.ts
+++ b/cloudflare-worker/src/firestore.ts
@@ -1,0 +1,153 @@
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+}
+
+interface FirestoreField {
+  stringValue?: string;
+  timestampValue?: string;
+  arrayValue?: { values: FirestoreField[] };
+  mapValue?: { fields: Record<string, FirestoreField> };
+}
+
+interface FirestoreDocument {
+  fields: Record<string, FirestoreField>;
+}
+
+// Builds a Firestore REST API subscription document from primitive values.
+function buildSubscriptionDocument(
+  status: string,
+  priceId: string,
+  currentPeriodEnd: number,
+): FirestoreDocument {
+  const endDate = new Date(currentPeriodEnd * 1000).toISOString();
+  return {
+    fields: {
+      status: { stringValue: status },
+      items: {
+        arrayValue: {
+          values: [
+            {
+              mapValue: {
+                fields: {
+                  price: {
+                    mapValue: {
+                      fields: {
+                        id: { stringValue: priceId },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      current_period_end: { timestampValue: endDate },
+    },
+  };
+}
+
+// Converts a PEM private key string to a CryptoKey for RSASSA-PKCS1-v1_5 signing.
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemContent = pem
+    .replace('-----BEGIN PRIVATE KEY-----', '')
+    .replace('-----END PRIVATE KEY-----', '')
+    .replace(/\s/g, '');
+  const der = Uint8Array.from(atob(pemContent), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    'pkcs8',
+    der,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function base64url(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+// Builds a signed JWT and exchanges it for a Google OAuth2 access token.
+async function getAccessToken(env: Env): Promise<string> {
+  const sa = JSON.parse(env.FIREBASE_SERVICE_ACCOUNT_JSON) as ServiceAccount;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: sa.client_email,
+    sub: sa.client_email,
+    aud: 'https://oauth2.googleapis.com/token',
+    scope: 'https://www.googleapis.com/auth/datastore',
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const encodedHeader = base64url(new TextEncoder().encode(JSON.stringify(header)));
+  const encodedPayload = base64url(new TextEncoder().encode(JSON.stringify(payload)));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const privateKey = await importPrivateKey(sa.private_key);
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+
+  const jwt = `${signingInput}.${base64url(signature)}`;
+
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    throw new Error(`Failed to get access token: ${tokenResponse.status}`);
+  }
+
+  const tokenData = await tokenResponse.json<{ access_token: string }>();
+  return tokenData.access_token;
+}
+
+// Writes or updates a subscription document in Firestore via the Admin REST API.
+// Uses updateMask to avoid overwriting fields not owned by this worker.
+export async function writeSubscription(
+  env: Env,
+  uid: string,
+  subscriptionId: string,
+  status: string,
+  priceId: string,
+  currentPeriodEnd: number,
+): Promise<void> {
+  const accessToken = await getAccessToken(env);
+  const projectId = env.FIREBASE_PROJECT_ID;
+
+  const docPath = `customers/${uid}/subscriptions/${subscriptionId}`;
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents/${docPath}` +
+    '?updateMask.fieldPaths=status&updateMask.fieldPaths=items&updateMask.fieldPaths=current_period_end';
+
+  const body = buildSubscriptionDocument(status, priceId, currentPeriodEnd);
+
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Firestore PATCH failed (${response.status}): ${errorText}`);
+  }
+}

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1,4 +1,5 @@
 import { handleCreateCheckoutSession } from './checkout';
+import { handleStripeWebhook } from './webhook';
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -14,6 +15,10 @@ export default {
 
     if (request.method === 'POST' && url.pathname === '/create-checkout-session') {
       return handleCreateCheckoutSession(request, env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/stripe-webhook') {
+      return handleStripeWebhook(request, env);
     }
 
     return new Response('Not Found', { status: 404 });

--- a/cloudflare-worker/src/webhook.ts
+++ b/cloudflare-worker/src/webhook.ts
@@ -1,0 +1,143 @@
+import { writeSubscription } from './firestore';
+
+interface StripeSubscription {
+  id: string;
+  status: string;
+  current_period_end: number;
+  metadata: { uid?: string };
+  items: { data: Array<{ price: { id: string } }> };
+}
+
+interface StripeCheckoutSession {
+  client_reference_id: string;
+  subscription: string;
+}
+
+interface StripeEvent {
+  type: string;
+  data: { object: StripeSubscription | StripeCheckoutSession };
+}
+
+// Verifies a Stripe webhook signature using HMAC-SHA256.
+// Returns true if valid, false if the signature doesn't match or is malformed.
+async function verifyStripeSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string,
+): Promise<boolean> {
+  const parts = Object.fromEntries(
+    signatureHeader.split(',').map((p) => p.split('=')),
+  ) as Record<string, string>;
+
+  const timestamp = parts['t'];
+  const expectedSig = parts['v1'];
+  if (!timestamp || !expectedSig) return false;
+
+  const signingPayload = `${timestamp}.${body}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signatureBytes = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(signingPayload),
+  );
+
+  const computedSig = Array.from(new Uint8Array(signatureBytes))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  // Constant-time comparison to prevent timing attacks.
+  if (computedSig.length !== expectedSig.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < computedSig.length; i++) {
+    mismatch |= computedSig.charCodeAt(i) ^ expectedSig.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+async function fetchStripeSubscription(
+  subscriptionId: string,
+  secretKey: string,
+): Promise<StripeSubscription> {
+  const response = await fetch(`https://api.stripe.com/v1/subscriptions/${subscriptionId}`, {
+    headers: { Authorization: `Bearer ${secretKey}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch subscription ${subscriptionId}: ${response.status}`);
+  }
+  return response.json<StripeSubscription>();
+}
+
+export async function handleStripeWebhook(request: Request, env: Env): Promise<Response> {
+  const body = await request.text();
+  const signatureHeader = request.headers.get('Stripe-Signature') ?? '';
+
+  const isValid = await verifyStripeSignature(body, signatureHeader, env.STRIPE_WEBHOOK_SECRET);
+  if (!isValid) {
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(body) as StripeEvent;
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as StripeCheckoutSession;
+        const uid = session.client_reference_id;
+        if (!uid) {
+          console.error('checkout.session.completed missing client_reference_id');
+          break;
+        }
+        const sub = await fetchStripeSubscription(session.subscription, env.STRIPE_SECRET_KEY);
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, sub.status, priceId, sub.current_period_end);
+        break;
+      }
+
+      case 'customer.subscription.updated': {
+        const sub = event.data.object as StripeSubscription;
+        const uid = sub.metadata?.uid;
+        if (!uid) {
+          console.error('customer.subscription.updated missing metadata.uid');
+          break;
+        }
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, sub.status, priceId, sub.current_period_end);
+        break;
+      }
+
+      case 'customer.subscription.deleted': {
+        const sub = event.data.object as StripeSubscription;
+        const uid = sub.metadata?.uid;
+        if (!uid) {
+          console.error('customer.subscription.deleted missing metadata.uid');
+          break;
+        }
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, 'canceled', priceId, sub.current_period_end);
+        break;
+      }
+
+      default:
+        // Unhandled event types are silently ignored; Stripe doesn't need a retry.
+        break;
+    }
+  } catch (err) {
+    console.error('Webhook handler error:', err);
+    // Return 500 so Stripe retries the event.
+    return new Response('Internal error', { status: 500 });
+  }
+
+  return new Response('OK', { status: 200 });
+}

--- a/cloudflare-worker/test/webhook.test.ts
+++ b/cloudflare-worker/test/webhook.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleStripeWebhook } from '../src/webhook';
+
+// Mock writeSubscription to avoid real Firestore calls.
+vi.mock('../src/firestore', () => ({
+  writeSubscription: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { writeSubscription } from '../src/firestore';
+
+const mockEnv: Env = {
+  FIREBASE_PROJECT_ID: 'test-project',
+  STRIPE_SECRET_KEY: 'sk_test_mock',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
+  FIREBASE_SERVICE_ACCOUNT_JSON: '{}',
+};
+
+// Builds a valid Stripe-Signature header using HMAC-SHA256.
+async function buildSignatureHeader(body: string, secret: string, timestamp = Math.floor(Date.now() / 1000)): Promise<string> {
+  const signingPayload = `${timestamp}.${body}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sigBytes = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingPayload));
+  const sig = Array.from(new Uint8Array(sigBytes))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `t=${timestamp},v1=${sig}`;
+}
+
+function makeWebhookRequest(body: string, signatureHeader: string): Request {
+  return new Request('https://worker.test/stripe-webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Stripe-Signature': signatureHeader,
+    },
+    body,
+  });
+}
+
+const mockSub = {
+  id: 'sub_123',
+  status: 'active',
+  current_period_end: 1800000000,
+  metadata: { uid: 'user123' },
+  items: { data: [{ price: { id: 'price_annual' } }] },
+};
+
+describe('handleStripeWebhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for invalid signature', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed', data: { object: {} } });
+    const req = makeWebhookRequest(body, 't=12345,v1=invalidsig');
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing signature header', async () => {
+    const body = '{}';
+    const req = new Request('https://worker.test/stripe-webhook', {
+      method: 'POST',
+      body,
+    });
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(400);
+  });
+
+  it('handles customer.subscription.updated and writes to Firestore', async () => {
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'active',
+      'price_annual',
+      1800000000,
+    );
+  });
+
+  it('handles customer.subscription.deleted and writes canceled status', async () => {
+    const deletedSub = { ...mockSub, status: 'canceled' };
+    const event = { type: 'customer.subscription.deleted', data: { object: deletedSub } };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'canceled',
+      'price_annual',
+      1800000000,
+    );
+  });
+
+  it('handles checkout.session.completed by fetching subscription from Stripe', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(mockSub),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          client_reference_id: 'user123',
+          subscription: 'sub_123',
+        },
+      },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'active',
+      'price_annual',
+      1800000000,
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 500 when writeSubscription throws (triggers Stripe retry)', async () => {
+    vi.mocked(writeSubscription).mockRejectedValueOnce(new Error('Firestore error'));
+
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 for unhandled event types (no retry needed)', async () => {
+    const event = { type: 'payment_intent.created', data: { object: {} } };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).not.toHaveBeenCalled();
+  });
+
+  it('idempotent: processing the same event twice calls writeSubscription twice with same args', async () => {
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+
+    const res1 = await handleStripeWebhook(makeWebhookRequest(body, sig), mockEnv);
+    const res2 = await handleStripeWebhook(makeWebhookRequest(body, sig), mockEnv);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(writeSubscription).mock.calls[0]).toEqual(
+      vi.mocked(writeSubscription).mock.calls[1],
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Implements `POST /stripe-webhook` with Stripe-Signature verification (HMAC-SHA256 via `crypto.subtle`, constant-time comparison)
- Routes `checkout.session.completed`, `customer.subscription.updated`, `customer.subscription.deleted` to Firestore writes
- Returns HTTP 400 on invalid signature, HTTP 500 on Firestore failure (triggers Stripe retry), HTTP 200 on success
- Implements `src/firestore.ts`: JWT signing with `crypto.subtle.sign('RSASSA-PKCS1-v1_5')`, OAuth2 token exchange, Firestore REST PATCH with `updateMask`
- Writes `customers/{uid}/subscriptions/{subscriptionId}` in typed format matching `SubscriptionInfo.fromStripeFirestore()`
- Includes Vitest tests: invalid signature, subscription events, idempotency, Firestore error → 500, unhandled events → 200

## Test plan
- [ ] CI Vitest tests pass
- [ ] Invalid `Stripe-Signature` → HTTP 400
- [ ] Valid webhook for `customer.subscription.updated` → Firestore PATCH called
- [ ] Valid webhook for `customer.subscription.deleted` → `status: canceled`
- [ ] Replaying same event → same Firestore document (idempotent via PATCH)
- [ ] Firestore failure → HTTP 500

Part of #515
Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)