### PR TITLE
[Task] Refactor SubscriptionService + update pricing UI (#518, #519)

### DIFF
--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -95,7 +95,7 @@ class ProfileScreen extends StatelessWidget {
                     onTap: () => PaywallScreen.show(
                       context,
                       headline: 'Unlock Overload Pro',
-                      subtext: 'Unlimited programs. Full analytics. \$39.99/year.',
+                      subtext: 'Unlimited programs. Full analytics. \$49.99/year.',
                     ),
                   );
                 },

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -119,9 +119,9 @@ class PaywallScreen extends StatelessWidget {
                   _PlanCard(
                     label: 'Annual',
                     badge: 'RECOMMENDED',
-                    savings: 'Save 52% vs monthly',
-                    price: '\$39.99/year',
-                    detail: 'Billed annually · 14-day free trial',
+                    savings: 'Save 40% vs monthly',
+                    price: '\$49.99/year',
+                    detail: 'Billed annually',
                     isRecommended: true,
                     onTap: () {
                       Navigator.of(context).pop();
@@ -141,7 +141,7 @@ class PaywallScreen extends StatelessWidget {
                   _PlanCard(
                     label: 'Monthly',
                     price: '\$6.99/month',
-                    detail: '14-day free trial',
+                    detail: 'Billed monthly',
                     isRecommended: false,
                     onTap: () {
                       Navigator.of(context).pop();
@@ -152,26 +152,6 @@ class PaywallScreen extends StatelessWidget {
                             .read<SubscriptionProvider>()
                             .startCheckout(
                                 userId, SubscriptionService.monthlyPriceId);
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Lifetime plan card
-                  _PlanCard(
-                    label: 'Lifetime',
-                    price: '\$59.99',
-                    detail: 'One-time purchase · No recurring fees',
-                    isRecommended: false,
-                    onTap: () {
-                      Navigator.of(context).pop();
-                      final userId =
-                          context.read<AuthProvider>().user?.uid;
-                      if (userId != null) {
-                        context
-                            .read<SubscriptionProvider>()
-                            .startCheckout(
-                                userId, SubscriptionService.lifetimePriceId);
                       }
                     },
                   ),

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -1,13 +1,15 @@
+import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import '../models/subscription.dart';
 
-/// Manages subscription billing via the Firebase Stripe Extension.
+/// Manages subscription billing via a Cloudflare Worker that proxies Stripe.
 ///
-/// The Firebase Stripe Extension syncs Stripe subscription state to Firestore
-/// under `customers/{userId}/subscriptions`. Checkout sessions are created by
-/// writing to `customers/{userId}/checkout_sessions`; the extension populates
-/// the Stripe Checkout URL asynchronously.
+/// Checkout sessions are created by calling the Worker's
+/// /create-checkout-session endpoint directly. Subscription state is written
+/// to `customers/{userId}/subscriptions` by the Worker's webhook handler and
+/// read back via a real-time Firestore stream.
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
 
@@ -15,7 +17,10 @@ class SubscriptionService {
   // Format: price_XXXXXXXXXXXXXXXXXXXXXXXX
   static const String monthlyPriceId = 'price_monthly_placeholder';
   static const String annualPriceId = 'price_annual_placeholder';
-  static const String lifetimePriceId = 'price_lifetime_placeholder';
+
+  // Cloudflare Worker base URL — set after deploying the Worker via `wrangler deploy`.
+  // Format: https://fittrack-stripe-worker.<account>.workers.dev
+  static const String _workerBaseUrl = 'https://fittrack-stripe-worker.placeholder.workers.dev';
 
   // Stripe Customer Portal shareable link — configured in Stripe Dashboard →
   // Settings → Billing → Customer Portal.
@@ -23,14 +28,23 @@ class SubscriptionService {
       'https://billing.stripe.com/p/login/placeholder';
 
   final FirebaseFirestore? _injectedFirestore;
+  final http.Client? _injectedHttpClient;
+
   FirebaseFirestore get _firestore =>
       _injectedFirestore ?? FirebaseFirestore.instance;
 
-  SubscriptionService._() : _injectedFirestore = null;
+  http.Client get _httpClient => _injectedHttpClient ?? http.Client();
+
+  SubscriptionService._()
+      : _injectedFirestore = null,
+        _injectedHttpClient = null;
 
   @visibleForTesting
-  SubscriptionService.forTest(FirebaseFirestore firestore)
-      : _injectedFirestore = firestore;
+  SubscriptionService.forTest(
+    FirebaseFirestore firestore,
+    http.Client httpClient,
+  )   : _injectedFirestore = firestore,
+        _injectedHttpClient = httpClient;
 
   /// Real-time stream of active Stripe subscriptions for [userId].
   /// Emits [SubscriptionInfo.free] when no active/trialing subscriptions exist.
@@ -63,39 +77,30 @@ class SubscriptionService {
     return SubscriptionInfo.fromStripeFirestore(snapshot.docs.first.data());
   }
 
-  /// Creates a Stripe Checkout session and returns the hosted Checkout URL.
-  ///
-  /// Writes a session document to `customers/{userId}/checkout_sessions`;
-  /// the Firebase Stripe Extension creates the Stripe session and writes back
-  /// the `url` field. Throws if the extension returns an error or times out.
+  /// Creates a Stripe Checkout session via the Cloudflare Worker and returns
+  /// the hosted Checkout URL. Throws if the Worker returns a non-200 response.
   Future<String> createCheckoutSession({
     required String userId,
     required String priceId,
     required String successUrl,
     required String cancelUrl,
   }) async {
-    final sessionRef = await _firestore
-        .collection('customers')
-        .doc(userId)
-        .collection('checkout_sessions')
-        .add({
-      'price': priceId,
-      'success_url': successUrl,
-      'cancel_url': cancelUrl,
-      'mode': priceId == lifetimePriceId ? 'payment' : 'subscription',
-      'allow_promotion_codes': true,
-    });
+    final response = await _httpClient.post(
+      Uri.parse('$_workerBaseUrl/create-checkout-session'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'uid': userId,
+        'priceId': priceId,
+        'successUrl': successUrl,
+        'cancelUrl': cancelUrl,
+      }),
+    );
 
-    // Extension populates 'url' (or 'error') asynchronously — wait up to 10s.
-    final snapshot = await sessionRef
-        .snapshots()
-        .firstWhere((snap) =>
-            snap.data()?['url'] != null || snap.data()?['error'] != null)
-        .timeout(const Duration(seconds: 10));
+    if (response.statusCode != 200) {
+      throw Exception('Checkout failed: ${response.statusCode}');
+    }
 
-    final error = snapshot.data()?['error'] as String?;
-    if (error != null) throw Exception('Stripe checkout error: $error');
-
-    return snapshot.data()!['url'] as String;
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return data['url'] as String;
   }
 }

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # URL launcher
   url_launcher: ^6.2.0
 
+  # HTTP client for Cloudflare Worker API calls
+  http: ^1.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -45,7 +48,6 @@ dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.7
   test: ^1.24.0
-  http: ^1.1.0
   fake_cloud_firestore: ^4.0.1
 flutter:
   uses-material-design: true

--- a/fittrack/test/screens/subscription/paywall_screen_test.dart
+++ b/fittrack/test/screens/subscription/paywall_screen_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(find.text('You have reached the free plan limit.'), findsNothing);
     });
 
-    testWidgets('renders Annual, Monthly and Lifetime plan labels', (tester) async {
+    testWidgets('renders Annual and Monthly plan labels', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -86,7 +86,7 @@ void main() {
 
       expect(find.text('Annual'), findsOneWidget);
       expect(find.text('Monthly'), findsOneWidget);
-      expect(find.text('Lifetime'), findsOneWidget);
+      expect(find.text('Lifetime'), findsNothing);
     });
 
     testWidgets('renders RECOMMENDED badge on annual plan', (tester) async {
@@ -100,7 +100,7 @@ void main() {
       expect(find.text('RECOMMENDED'), findsOneWidget);
     });
 
-    testWidgets('renders Lifetime plan with one-time purchase detail', (tester) async {
+    testWidgets('does not render Lifetime plan (out of scope)', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -108,8 +108,8 @@ void main() {
         ),
       );
 
-      expect(find.text('Lifetime'), findsOneWidget);
-      expect(find.text('One-time purchase · No recurring fees'), findsOneWidget);
+      expect(find.text('Lifetime'), findsNothing);
+      expect(find.text('One-time purchase · No recurring fees'), findsNothing);
     });
 
     testWidgets('renders benefits list', (tester) async {
@@ -186,7 +186,7 @@ void main() {
   });
 
   group('PaywallScreen - plan prices', () {
-    testWidgets('renders hardcoded Stripe prices', (tester) async {
+    testWidgets('renders updated Stripe prices', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -194,9 +194,9 @@ void main() {
         ),
       );
 
-      expect(find.text(r'$39.99/year'), findsOneWidget);
+      expect(find.text(r'$49.99/year'), findsOneWidget);
       expect(find.text(r'$6.99/month'), findsOneWidget);
-      expect(find.text(r'$59.99'), findsOneWidget);
+      expect(find.text(r'$59.99'), findsNothing);
     });
   });
 

--- a/fittrack/test/services/subscription_service_integration_test.dart
+++ b/fittrack/test/services/subscription_service_integration_test.dart
@@ -1,17 +1,29 @@
 /// Integration tests for SubscriptionService.
 ///
-/// Tests the full Stripe-via-Firestore subscription lifecycle using
-/// FakeFirebaseFirestore, verifying that subscription reads, stream emissions,
-/// and checkout session creation all behave correctly end-to-end.
+/// Tests the subscription read/stream lifecycle using FakeFirebaseFirestore,
+/// verifying that subscription reads and stream emissions behave correctly.
+/// Checkout session creation is tested in subscription_service_test.dart
+/// via MockClient.
 
 @Timeout(Duration(seconds: 30))
 library;
 
+import 'dart:convert';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:fittrack/models/subscription.dart';
 import 'package:fittrack/services/subscription_service.dart';
+
+SubscriptionService _makeService(FakeFirebaseFirestore firestore, {http.Client? httpClient}) {
+  return SubscriptionService.forTest(
+    firestore,
+    httpClient ?? MockClient((_) async => http.Response('', 200)),
+  );
+}
 
 void main() {
   late FakeFirebaseFirestore fakeFirestore;
@@ -19,7 +31,7 @@ void main() {
 
   setUp(() {
     fakeFirestore = FakeFirebaseFirestore();
-    service = SubscriptionService.forTest(fakeFirestore);
+    service = _makeService(fakeFirestore);
   });
 
   group('SubscriptionService - subscription read lifecycle', () {
@@ -100,25 +112,16 @@ void main() {
     });
   });
 
-  group('SubscriptionService - checkout session lifecycle', () {
-    test('checkout session document is written with required fields', () async {
-      // Simulate extension: write url when session created
-      fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          final data = doc.data();
-          if (data['price'] != null && data['url'] == null && data['error'] == null) {
-            await doc.reference
-                .update({'url': 'https://checkout.stripe.com/session-xyz'});
-          }
-        }
-      });
+  group('SubscriptionService - checkout session via Cloudflare Worker', () {
+    test('createCheckoutSession returns url from Worker response', () async {
+      final mockClient = MockClient((_) async => http.Response(
+            jsonEncode({'url': 'https://checkout.stripe.com/session-xyz'}),
+            200,
+            headers: {'content-type': 'application/json'},
+          ));
+      final svc = _makeService(fakeFirestore, httpClient: mockClient);
 
-      final url = await service.createCheckoutSession(
+      final url = await svc.createCheckoutSession(
         userId: 'user-checkout',
         priceId: SubscriptionService.annualPriceId,
         successUrl: 'https://fittrack-app.web.app/?checkout=success',
@@ -126,51 +129,21 @@ void main() {
       );
 
       expect(url, 'https://checkout.stripe.com/session-xyz');
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .get();
-
-      final data = sessions.docs.first.data();
-      expect(data['price'], SubscriptionService.annualPriceId);
-      expect(data['success_url'],
-          'https://fittrack-app.web.app/?checkout=success');
-      expect(data['cancel_url'],
-          'https://fittrack-app.web.app/?checkout=cancelled');
-      expect(data['mode'], 'subscription');
-      expect(data['allow_promotion_codes'], isTrue);
     });
 
-    test('lifetime plan uses payment mode', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          final data = doc.data();
-          if (data['price'] != null && data['url'] == null && data['error'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
-          }
-        }
-      });
+    test('throws Exception when Worker returns non-200', () async {
+      final mockClient = MockClient((_) async => http.Response('server error', 500));
+      final svc = _makeService(fakeFirestore, httpClient: mockClient);
 
-      await service.createCheckoutSession(
-        userId: 'user-lifetime',
-        priceId: SubscriptionService.lifetimePriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      await expectLater(
+        svc.createCheckoutSession(
+          userId: 'user-error',
+          priceId: SubscriptionService.annualPriceId,
+          successUrl: 'https://fittrack-app.web.app/?checkout=success',
+          cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+        ),
+        throwsA(isA<Exception>()),
       );
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.first.data()['mode'], 'payment');
     });
   });
 

--- a/fittrack/test/services/subscription_service_test.dart
+++ b/fittrack/test/services/subscription_service_test.dart
@@ -1,19 +1,21 @@
 @Timeout(Duration(seconds: 30))
 library;
 
+import 'dart:convert';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:fittrack/models/subscription.dart';
 import 'package:fittrack/services/subscription_service.dart';
 
 void main() {
   late FakeFirebaseFirestore fakeFirestore;
-  late SubscriptionService service;
 
   setUp(() {
     fakeFirestore = FakeFirebaseFirestore();
-    service = SubscriptionService.forTest(fakeFirestore);
   });
 
   group('SubscriptionService - Stripe Price ID constants', () {
@@ -25,16 +27,18 @@ void main() {
       expect(SubscriptionService.annualPriceId, isNotEmpty);
     });
 
-    test('lifetimePriceId is set', () {
-      expect(SubscriptionService.lifetimePriceId, isNotEmpty);
-    });
-
     test('stripePortalUrl starts with https', () {
       expect(SubscriptionService.stripePortalUrl, startsWith('https://'));
     });
   });
 
   group('SubscriptionService - loadFromFirestore', () {
+    late SubscriptionService service;
+
+    setUp(() {
+      service = SubscriptionService.forTest(fakeFirestore, MockClient((_) async => http.Response('', 200)));
+    });
+
     test('returns SubscriptionInfo.free when no subscriptions exist', () async {
       final result = await service.loadFromFirestore('user-1');
       expect(result.isPro, isFalse);
@@ -106,6 +110,12 @@ void main() {
   });
 
   group('SubscriptionService - subscriptionStream', () {
+    late SubscriptionService service;
+
+    setUp(() {
+      service = SubscriptionService.forTest(fakeFirestore, MockClient((_) async => http.Response('', 200)));
+    });
+
     test('emits SubscriptionInfo.free when no subscriptions', () async {
       final stream = service.subscriptionStream('user-stream');
       final info = await stream.first;
@@ -136,95 +146,72 @@ void main() {
   });
 
   group('SubscriptionService - createCheckoutSession', () {
-    test('writes checkout session document with correct fields', () async {
-      // Simulate extension responding with a url immediately
-      fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['url'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/test'});
-          }
-        }
+    test('POSTs correct JSON body to Worker and returns url', () async {
+      final capturedRequests = <http.Request>[];
+      final mockClient = MockClient((request) async {
+        capturedRequests.add(request);
+        return http.Response(
+          jsonEncode({'url': 'https://checkout.stripe.com/test123'}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
       });
 
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
       final url = await service.createCheckoutSession(
         userId: 'user-checkout',
         priceId: SubscriptionService.annualPriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+        successUrl: 'https://app.test/?checkout=success',
+        cancelUrl: 'https://app.test/?checkout=cancelled',
       );
 
-      expect(url, 'https://checkout.stripe.com/test');
+      expect(url, 'https://checkout.stripe.com/test123');
+      expect(capturedRequests.length, 1);
 
-      // Verify session document was written with correct fields
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.length, 1);
-      final data = sessions.docs.first.data();
-      expect(data['price'], SubscriptionService.annualPriceId);
-      expect(data['mode'], 'subscription');
-      expect(data['allow_promotion_codes'], isTrue);
+      final body = jsonDecode(capturedRequests.first.body) as Map<String, dynamic>;
+      expect(body['uid'], 'user-checkout');
+      expect(body['priceId'], SubscriptionService.annualPriceId);
+      expect(body['successUrl'], 'https://app.test/?checkout=success');
+      expect(body['cancelUrl'], 'https://app.test/?checkout=cancelled');
     });
 
-    test('uses payment mode for lifetime price ID', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['url'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
-          }
-        }
-      });
-
-      await service.createCheckoutSession(
-        userId: 'user-lifetime',
-        priceId: SubscriptionService.lifetimePriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
-      );
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.first.data()['mode'], 'payment');
-    });
-
-    test('throws when extension returns error', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-error')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['error'] == null) {
-            await doc.reference
-                .update({'error': 'No such price: bad_price_id'});
-          }
-        }
-      });
+    test('throws Exception when Worker returns non-200', () async {
+      final mockClient = MockClient((_) async => http.Response('error', 502));
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
 
       expect(
         () => service.createCheckoutSession(
           userId: 'user-error',
-          priceId: 'bad_price_id',
-          successUrl: 'https://fittrack-app.web.app/?checkout=success',
-          cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+          priceId: SubscriptionService.annualPriceId,
+          successUrl: 'https://app.test/?checkout=success',
+          cancelUrl: 'https://app.test/?checkout=cancelled',
         ),
         throwsA(isA<Exception>()),
+      );
+    });
+
+    test('sets Content-Type header to application/json', () async {
+      final capturedRequests = <http.Request>[];
+      final mockClient = MockClient((request) async {
+        capturedRequests.add(request);
+        return http.Response(
+          jsonEncode({'url': 'https://checkout.stripe.com/test'}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
+      await service.createCheckoutSession(
+        userId: 'u1',
+        priceId: SubscriptionService.monthlyPriceId,
+        successUrl: 'https://app.test/?checkout=success',
+        cancelUrl: 'https://app.test/?checkout=cancelled',
+      );
+
+      expect(
+        capturedRequests.first.headers['content-type'],
+        'application/json',
       );
     });
   });

--- a/fittrack/test/services/subscription_service_test.dart
+++ b/fittrack/test/services/subscription_service_test.dart
@@ -211,7 +211,7 @@ void main() {
 
       expect(
         capturedRequests.first.headers['content-type'],
-        'application/json',
+        contains('application/json'),
       );
     });
   });


### PR DESCRIPTION
## Summary

**Task #518 — SubscriptionService HTTP refactor:**
- Moves `http: ^1.1.0` from `dev_dependencies` to `dependencies`
- Replaces `createCheckoutSession()` Firestore write/poll with HTTP POST to Cloudflare Worker
- Removes `lifetimePriceId` constant (Lifetime plan is out of scope per PRD)
- Adds injected `http.Client` to `SubscriptionService.forTest()` for unit testability
- Updates tests to use `MockClient` from `package:http/testing.dart`

**Task #519 — PaywallScreen + ProfileScreen pricing update (bundled with #518):**
> Bundled here because removing `lifetimePriceId` from the service causes a compile error if the PaywallScreen reference is not removed in the same build.
- Removes Lifetime `_PlanCard` (Lifetime plan out of scope per PRD)
- Removes all "14-day free trial" copy
- Updates Annual plan: `$39.99/year` → `$49.99/year`, `Save 52%` → `Save 40% vs monthly`
- Updates `profile_screen.dart` subtext to `$49.99/year`
- Updates `paywall_screen_test.dart` to reflect new plan structure

## Test plan
- [ ] CI unit tests pass (subscription service + paywall widget tests)
- [ ] CI integration tests pass
- [ ] `createCheckoutSession` sends correct JSON body with `uid`, `priceId`, `successUrl`, `cancelUrl`
- [ ] Non-200 Worker response throws `Exception`
- [ ] PaywallScreen shows only Annual and Monthly cards (no Lifetime)
- [ ] Annual price shows `$49.99/year`

Part of #515
Closes #518
Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)