### PR TITLE
[Task] CheckoutSuccessBanner + URL param detection on app startup (#520)

### DIFF
--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -26,6 +26,7 @@ import 'services/lifecycle_notification_service.dart';
 import 'services/notification_service.dart';
 import 'services/onboarding_service.dart';
 import 'services/returning_user_service.dart';
+import 'widgets/checkout_success_banner.dart';
 
 const bool _kUseEmulator = bool.fromEnvironment('USE_EMULATOR', defaultValue: false);
 const bool _kForceSemantics = bool.fromEnvironment('FORCE_SEMANTICS', defaultValue: false);
@@ -120,6 +121,13 @@ void main() async {
 
   // Initialize returning user service — detects 30+ day inactivity on home screen
   ReturningUserService.initialize(prefs);
+
+  // Detect Stripe Checkout success return URL — set once before runApp so the
+  // flag is available synchronously when ProgramsScreen first builds.
+  if (kIsWeb) {
+    CheckoutSuccessService.pendingWelcome =
+        Uri.base.queryParameters['checkout'] == 'success';
+  }
 
   runZonedGuarded(
     () => runApp(OverloadApp(prefs: prefs)),

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -11,6 +11,7 @@ import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/create_options_sheet.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
+import '../../widgets/checkout_success_banner.dart';
 import '../../widgets/returning_user_banner.dart';
 import '../../providers/subscription_provider.dart';
 import '../subscription/paywall_screen.dart';
@@ -93,6 +94,7 @@ class ProgramsScreen extends StatelessWidget {
 
           return Column(
             children: [
+              const CheckoutSuccessBanner(),
               const ReturningUserBanner(),
               Expanded(
                 child: RefreshIndicator(

--- a/fittrack/lib/widgets/checkout_success_banner.dart
+++ b/fittrack/lib/widgets/checkout_success_banner.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// In-memory flag set once at app startup when `?checkout=success` is detected
+/// in the URL. Cleared on dismiss so the banner never re-appears in the same
+/// session (though a hard refresh that retains the URL will re-show it, which
+/// is benign — the user paid and "Welcome to Pro" is harmless to see twice).
+class CheckoutSuccessService {
+  static bool pendingWelcome = false;
+  static void dismiss() => pendingWelcome = false;
+}
+
+/// Shown at the top of the programs list when the user returns to the app
+/// after a successful Stripe Checkout (`?checkout=success` in the URL).
+///
+/// Invisible (SizedBox.shrink) when conditions are not met.
+class CheckoutSuccessBanner extends StatefulWidget {
+  const CheckoutSuccessBanner({super.key});
+
+  @override
+  State<CheckoutSuccessBanner> createState() => _CheckoutSuccessBannerState();
+}
+
+class _CheckoutSuccessBannerState extends State<CheckoutSuccessBanner> {
+  bool _dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed || !CheckoutSuccessService.pendingWelcome) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      color: colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.workspace_premium,
+                    color: colorScheme.onPrimaryContainer, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Welcome to Overload Pro!',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  color: colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
+                  visualDensity: VisualDensity.compact,
+                  tooltip: 'Dismiss',
+                  onPressed: _dismiss,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Your subscription is now active. All Pro features are unlocked.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer.withValues(alpha: 0.85),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _dismiss() {
+    CheckoutSuccessService.dismiss();
+    setState(() => _dismissed = true);
+  }
+}

--- a/fittrack/test/widgets/checkout_success_banner_test.dart
+++ b/fittrack/test/widgets/checkout_success_banner_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/widgets/checkout_success_banner.dart';
+
+Widget _buildSubject() {
+  return const MaterialApp(
+    home: Scaffold(body: CheckoutSuccessBanner()),
+  );
+}
+
+void main() {
+  setUp(() {
+    CheckoutSuccessService.pendingWelcome = false;
+  });
+
+  group('CheckoutSuccessBanner', () {
+    testWidgets('is invisible when pendingWelcome is false', (tester) async {
+      CheckoutSuccessService.pendingWelcome = false;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+      expect(find.byType(Card), findsNothing);
+    });
+
+    testWidgets('shows banner when pendingWelcome is true', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.text('Welcome to Overload Pro!'), findsOneWidget);
+      expect(
+        find.text('Your subscription is now active. All Pro features are unlocked.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows workspace_premium icon when visible', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.byIcon(Icons.workspace_premium), findsOneWidget);
+    });
+
+    testWidgets('dismisses banner on close tap', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      expect(find.text('Welcome to Overload Pro!'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+    });
+
+    testWidgets('dismiss clears pendingWelcome flag', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+
+    testWidgets('does not re-appear after dismiss even if pendingWelcome re-set', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      // Even if the flag is re-set (e.g., by a test), the _dismissed bool
+      // on the widget state keeps it invisible within the same widget lifecycle.
+      CheckoutSuccessService.pendingWelcome = true;
+      await tester.pump();
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+    });
+
+    testWidgets('uses primaryContainer card color', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      final card = tester.widget<Card>(find.byType(Card));
+      final colorScheme = Theme.of(tester.element(find.byType(Card))).colorScheme;
+      expect(card.color, colorScheme.primaryContainer);
+    });
+  });
+
+  group('CheckoutSuccessService', () {
+    test('pendingWelcome defaults to false', () {
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+
+    test('dismiss() sets pendingWelcome to false', () {
+      CheckoutSuccessService.pendingWelcome = true;
+      CheckoutSuccessService.dismiss();
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- New `CheckoutSuccessService` static class (mirrors `ReturningUserService.shouldShowPrompt`)
- New `CheckoutSuccessBanner` `StatefulWidget` following `returning_user_banner.dart` pattern exactly: `Card` with `primaryContainer` colour, `workspace_premium` icon, "Welcome to Overload Pro!" title, dismiss button
- `main.dart`: sets `CheckoutSuccessService.pendingWelcome = true` before `runApp()` when `Uri.base.queryParameters['checkout'] == 'success'` on web builds (`kIsWeb` guard, no `dart:html` import needed)
- `programs_screen.dart`: adds `CheckoutSuccessBanner()` as first widget above `ReturningUserBanner()`
- Widget tests: banner visibility, dismiss behaviour, flag clearing, `_dismissed` state prevents re-show

## Notes
- URL is **not** cleaned after detection (no `dart:html`/`package:web` dependency needed)
- Re-showing on hard page refresh is intentional and benign (user paid; "Welcome to Pro" is harmless)

## Test plan
- [ ] CI widget tests pass
- [ ] `pendingWelcome = false` → `SizedBox.shrink()` (banner invisible)
- [ ] `pendingWelcome = true` → banner shows with correct title and body text
- [ ] Tapping X sets `pendingWelcome = false` and hides banner
- [ ] Banner stays hidden after dismiss even if `pendingWelcome` is re-set

Part of #515
Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)