### PR TITLE
[Task] Remove checkout_sessions client write + update Cloudflare Worker comments (#521)

### DIFF
--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -393,26 +393,31 @@ service cloud.firestore {
     }
 
     // -----------------------
-    // Stripe Extension — customers collection
-    // Written by the Firebase Stripe Extension (admin SDK / webhooks).
-    // Clients may read their own subscription data and create checkout sessions.
+    // Stripe — customers collection
+    // Written by the Cloudflare Worker via Firebase Admin REST API (service account).
+    // Clients may only read their own subscription data.
     // -----------------------
     match /customers/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
-      allow write: if false; // Extension writes via admin SDK
+      allow write: if false; // Cloudflare Worker writes via service account (Admin REST API)
 
+      // Legacy: was used by the Firebase Stripe Extension for checkout session
+      // URL polling. Not used in the current Cloudflare Worker flow — the Worker
+      // creates Stripe sessions directly via the Stripe API without touching
+      // Firestore. Retained for historical compatibility; client write removed.
       match /checkout_sessions/{sessionId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if false; // no longer written by client
       }
 
       match /subscriptions/{subscriptionId} {
         allow read: if request.auth != null && request.auth.uid == userId;
-        allow write: if false; // Extension writes via admin SDK
+        allow write: if false; // Cloudflare Worker writes via service account
       }
 
       match /payments/{paymentId} {
         allow read: if request.auth != null && request.auth.uid == userId;
-        allow write: if false; // Extension writes via admin SDK
+        allow write: if false; // Cloudflare Worker writes via service account
       }
     }
 


### PR DESCRIPTION
## Summary

- Removes `allow write` from `customers/{userId}/checkout_sessions` — client no longer writes checkout sessions (the Cloudflare Worker calls the Stripe API directly)
- Updates all comments in the `customers/{userId}` block to reference "Cloudflare Worker via service account (Admin REST API)" instead of "Firebase Stripe Extension"
- Adds legacy comment on `checkout_sessions` explaining why the subcollection rule is retained (historical compatibility)

## Test plan
- [ ] CI security checks pass
- [ ] `customers/{userId}/checkout_sessions` write from client is blocked (HTTP 403)
- [ ] `customers/{userId}/subscriptions` read from owner returns data
- [ ] `customers/{userId}/subscriptions` write from client is blocked

Part of #515
Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)