### PR TITLE
feat: Stripe payment integration via Cloudflare Worker (#515)

### DIFF
--- a/Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md
+++ b/Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md
@@ -1,0 +1,171 @@
+# PRD: Stripe Payment Integration via Cloudflare Worker
+
+**Status:** Requirements Complete
+**Priority:** High
+**Platform:** Web (PWA)
+**GitHub Issue:** [#515](https://github.com/justbuildstuff-dev/Fitness-App/issues/515)
+**Author:** BA Agent
+**Date:** 2026-07-10
+
+---
+
+## Problem Statement
+
+Overload Pro's paywall is built but non-functional. The existing checkout flow depends on the Firebase Stripe Extension, which requires the Firebase Blaze (pay-as-you-go) plan. Upgrading introduces unbounded GCP billing risk.
+
+This feature replaces the Firebase Extension dependency with a Cloudflare Worker — a permanently-free serverless function that handles Stripe Checkout session creation and webhook fulfilment, writing subscription status directly to Firestore via the Admin REST API.
+
+---
+
+## Goals
+
+- Make Pro subscriptions purchasable on the web PWA
+- Eliminate the Firebase Blaze plan requirement
+- Keep the Flutter app changes minimal (primarily a service layer swap)
+- Update pricing to reflect market positioning
+
+---
+
+## Out of Scope
+
+- iOS App Store IAP and Android Play Billing (future feature)
+- Lifetime plan (future feature)
+- Free trials (deferred — can be reintroduced as a growth lever later)
+- Info site / marketing page pricing update (separate task — note for SA to flag as a dependency)
+- Stripe Customer Portal configuration (manual one-time setup, not a code task)
+
+---
+
+## Pricing
+
+| Plan | Price | Saving vs monthly | Notes |
+|------|-------|-------------------|-------|
+| Monthly | $6.99/month | — | No change |
+| Annual | $49.99/year | ~40% | Updated from $39.99 |
+
+Free trial copy ("14-day free trial") must be removed from the paywall UI.
+
+---
+
+## Architecture Overview
+
+```
+User taps plan in PaywallScreen
+  → SubscriptionService calls Cloudflare Worker POST /create-checkout-session
+  → Worker creates Stripe Checkout Session via Stripe API
+  → Worker returns { url }
+  → App opens url via url_launcher (LaunchMode.externalApplication)
+  → User completes payment on Stripe hosted page
+  → Stripe fires webhook → Worker POST /stripe-webhook
+      → verifies Stripe-Signature header
+      → handles checkout.session.completed → writes subscription doc to Firestore
+      → handles customer.subscription.updated → updates subscription doc
+      → handles customer.subscription.deleted → marks subscription cancelled
+  → SubscriptionProvider real-time listener picks up Firestore change
+  → User lands back on app with ?checkout=success in URL
+  → App detects param → shows "Welcome to Pro" banner
+```
+
+---
+
+## User Stories
+
+### US-1: Purchase a subscription
+
+**As a free user**, I want to tap a plan on the paywall and be taken directly to a Stripe payment page, so that I can subscribe to Overload Pro without leaving the app ecosystem.
+
+**Acceptance Criteria:**
+- Tapping Monthly or Annual on the paywall opens the Stripe hosted Checkout page in the browser
+- The Checkout page is pre-populated with the correct plan price and currency
+- Tapping "Cancel" on the Stripe page returns the user to the app (cancel URL)
+- The checkout flow works on both mobile and desktop web browsers
+- No Firebase Extension or Blaze plan is required for checkout to function
+
+### US-2: Pro access activates after payment
+
+**As a user who has just paid**, I want my Pro features to unlock automatically, so that I do not have to sign out and back in or manually refresh.
+
+**Acceptance Criteria:**
+- Within 30 seconds of payment completing, `SubscriptionProvider.isPro` returns `true` for the user
+- The real-time Firestore listener (`customers/{uid}/subscriptions`) fires when the Worker writes the subscription document
+- Feature gates (program limit, analytics, custom exercises) lift without any user action
+- If the Firestore write is delayed, the UI does not show an error — it waits silently for the listener to fire
+
+### US-3: Welcome confirmation on return
+
+**As a user returning to the app after payment**, I want to see a clear confirmation that my subscription is active, so that I know the purchase worked and I don't pay twice.
+
+**Acceptance Criteria:**
+- When the app loads with `?checkout=success` in the URL, a "Welcome to Pro" banner or dialog is displayed
+- The banner is shown once per successful checkout (not on every subsequent app load)
+- The banner is dismissible
+- The banner is not shown when `?checkout=cancelled` is in the URL
+
+### US-4: Manage or cancel subscription
+
+**As an active Pro subscriber**, I want to tap a button in the app to manage my subscription, so that I can change my plan or cancel without contacting support.
+
+**Acceptance Criteria:**
+- The "Manage subscription" button in the Subscription screen opens the Stripe Customer Portal in the browser
+- The button is only shown to users with an active subscription (not `isProOverride` admin users)
+- The Stripe Customer Portal URL is configurable without a code change (stored as a constant, not hardcoded in logic)
+- After cancelling in the Portal and returning, the subscription status updates automatically via the real-time listener
+
+### US-5: Subscription expiry revokes Pro access
+
+**As the system**, I want Pro access to be revoked automatically when a subscription is cancelled or expires, so that users who cancel do not continue to access paid features.
+
+**Acceptance Criteria:**
+- When Stripe fires `customer.subscription.deleted`, the Worker updates the Firestore subscription document with `status: 'canceled'`
+- `SubscriptionProvider.isPro` returns `false` once the Firestore update is received by the real-time listener
+- Feature gates re-engage immediately — the user is downgraded to free tier limits
+- Existing data (programs, exercises, sets) is not deleted on downgrade
+
+### US-6: Webhook security
+
+**As the system**, I want all Stripe webhook calls to be cryptographically verified, so that malicious actors cannot fake payment events to grant themselves Pro access.
+
+**Acceptance Criteria:**
+- The Cloudflare Worker verifies the `Stripe-Signature` header on every webhook request using the webhook signing secret
+- Requests with an invalid or missing signature return HTTP 400 and are not processed
+- The webhook signing secret is stored as a Cloudflare Worker secret (environment variable), never in source code
+- The Firebase service account key used to write to Firestore is also stored as a Cloudflare Worker secret
+
+---
+
+## Non-Functional Requirements
+
+- **Latency:** Checkout session URL returned within 3 seconds under normal conditions
+- **Webhook reliability:** Worker returns HTTP 200 within 5 seconds (Stripe retries on non-200)
+- **Idempotency:** Processing the same webhook event twice must not create duplicate subscription documents
+- **No Blaze plan:** The solution must function entirely on the Firebase Spark (free) plan — no Cloud Functions, no Firebase Extensions
+- **Security:** No secrets committed to the repository; all credentials stored as Cloudflare Worker secrets
+
+---
+
+## Existing Code to Modify
+
+| File | Change |
+|------|--------|
+| `lib/services/subscription_service.dart` | Replace `createCheckoutSession()` (currently writes to Firestore and polls) with HTTP POST to Cloudflare Worker endpoint; remove `lifetimePriceId` |
+| `lib/screens/subscription/paywall_screen.dart` | Remove Lifetime plan card; remove trial copy ("14-day free trial"); update annual price to $49.99 |
+| `fittrack/firestore.rules` | Review `customers/{userId}/checkout_sessions` rules — the Worker does not use this subcollection; keep or clean up |
+
+## New Code
+
+| Artifact | Description |
+|----------|-------------|
+| `cloudflare-worker/src/index.ts` | Worker with two routes: `POST /create-checkout-session` and `POST /stripe-webhook` |
+| `cloudflare-worker/package.json` | Wrangler + Stripe SDK dependencies |
+| `cloudflare-worker/wrangler.toml` | Worker name, routes, compatibility date |
+| `lib/main.dart` or router | Detect `?checkout=success` on startup and trigger welcome banner |
+
+---
+
+## Dependencies
+
+- Stripe account with two products created (Monthly $6.99, Annual $49.99) and price IDs recorded
+- Stripe webhook endpoint registered pointing to the deployed Cloudflare Worker URL
+- Firebase service account key (JSON) generated and stored as Cloudflare Worker secret
+- Stripe Customer Portal configured in the Stripe Dashboard with the correct return URL
+- **`fittrack/public/index.html`** — the PWA landing/info page pricing has already been updated by the developer. The Deployment Agent should redeploy Firebase Hosting as part of this feature's release (`firebase deploy --only hosting`).

--- a/Docs/Technical_Designs/Stripe_Cloudflare_Worker_Technical_Design.md
+++ b/Docs/Technical_Designs/Stripe_Cloudflare_Worker_Technical_Design.md
@@ -1,0 +1,356 @@
+# Technical Design: Stripe Payment Integration via Cloudflare Worker
+
+**Feature:** Stripe Payment Integration via Cloudflare Worker
+**GitHub Issue:** [#515](https://github.com/justbuildstuff-dev/Fitness-App/issues/515)
+**PRD:** [Docs/PRDs/Stripe_Cloudflare_Worker_PRD.md](../PRDs/Stripe_Cloudflare_Worker_PRD.md)
+**Author:** SA Agent
+**Date:** 2026-07-10
+**Status:** Design Approved
+
+---
+
+## Current Architecture Analysis
+
+**State Management:** Provider pattern (`ChangeNotifier` + `ChangeNotifierProxyProvider`). `SubscriptionProvider` is a `ChangeNotifierProxyProvider<AuthProvider, SubscriptionProvider>` registered in `main.dart`. Services are singletons (`SubscriptionService.instance`).
+
+**File Structure Discovered:**
+- `lib/services/` — singleton services (e.g. `SubscriptionService`, `FirestoreService`)
+- `lib/providers/` — ChangeNotifier providers
+- `lib/screens/subscription/` — `paywall_screen.dart`, `subscription_management_screen.dart`
+- `lib/widgets/` — reusable widgets (e.g. `returning_user_banner.dart` — banner pattern reference)
+
+**Similar Feature (Banner Pattern):** `lib/widgets/returning_user_banner.dart` — `StatefulWidget` with `_dismissed` bool, static service check, `SizedBox.shrink()` when inactive, `Card` with `primaryContainer` colour. `CheckoutSuccessBanner` follows this exactly.
+
+**URL Param Detection:** No routing library (direct `Navigator.push` only). `Uri.base.queryParameters` is available from `dart:core` on Flutter web — no `dart:html` import needed. Read in widget's `initState` or as a static pre-computed flag.
+
+**HTTP package:** `http: ^1.1.0` is currently in `dev_dependencies` only. It must be moved to `dependencies` for the refactored `SubscriptionService` to use it in production.
+
+**Firestore Customers Rules:** `customers/{userId}/checkout_sessions` currently allows client read/write (used by the Firebase Extension to receive the checkout URL). This subcollection is unused in the new flow — the Worker creates sessions directly via the Stripe API. The rule will be updated to remove write access and add a legacy comment.
+
+**Testing Approach:** Unit tests use `mockito` (`.mocks.dart` generated files). Widget tests use `flutter_test`. The `SubscriptionService` should expose the Worker base URL as a configurable constant (or injectable for tests).
+
+---
+
+## Architecture Overview
+
+The Firebase Stripe Extension is replaced entirely by a Cloudflare Worker. The Worker handles two concerns:
+
+1. **Checkout session creation** — the Flutter app POSTs to the Worker with the user's UID and price ID; the Worker calls the Stripe API and returns the hosted Checkout URL directly. No Firestore writes involved in this path.
+
+2. **Webhook fulfilment** — Stripe fires webhook events to the Worker; the Worker verifies the `Stripe-Signature` header, then writes subscription documents directly to Firestore via the Firebase Admin REST API using a service account JWT. Security rules are bypassed (as with any Admin SDK call).
+
+The existing `SubscriptionProvider` real-time listener on `customers/{uid}/subscriptions` is unchanged — it picks up documents written by the Worker automatically.
+
+```
+┌─────────────────────────┐
+│   Flutter Web (PWA)      │
+│                          │
+│  PaywallScreen           │
+│    → SubscriptionService │
+│       .createCheckout()  │──── POST /create-checkout-session ──▶ Cloudflare Worker
+│                          │◀─── { url: "https://checkout.stripe..." } ──────────────┘
+│    url_launcher opens    │
+│    Stripe Checkout page  │
+└─────────────────────────┘
+                                   Stripe fires webhook
+                                       │
+                          POST /stripe-webhook ──▶ Cloudflare Worker
+                                                        │ verify Stripe-Signature
+                                                        │ build Firestore Admin JWT
+                                                        ▼
+                                              Firestore REST API
+                                          customers/{uid}/subscriptions/{subId}
+                                                        │
+                                   SubscriptionProvider listener fires
+                                          │
+                              Flutter app isPro = true
+```
+
+---
+
+## Component Design
+
+### New: Cloudflare Worker (`cloudflare-worker/`)
+
+A standalone TypeScript project using Wrangler. Lives outside `fittrack/` at the repo root.
+
+```
+cloudflare-worker/
+├── src/
+│   ├── index.ts          # Entry: routes requests to handlers
+│   ├── checkout.ts       # POST /create-checkout-session handler
+│   ├── webhook.ts        # POST /stripe-webhook handler
+│   └── firestore.ts      # Firestore Admin REST API helper (JWT + PATCH)
+├── wrangler.toml
+├── package.json
+└── tsconfig.json
+```
+
+**Environment variables (Cloudflare secrets — never committed):**
+| Secret | Description |
+|--------|-------------|
+| `STRIPE_SECRET_KEY` | Stripe secret key (`sk_live_...`) |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret (`whsec_...`) |
+| `FIREBASE_SERVICE_ACCOUNT_JSON` | Full service account JSON as a string |
+
+**`src/checkout.ts`** — `POST /create-checkout-session`
+
+Input (JSON body):
+```json
+{ "uid": "firebase-auth-uid", "priceId": "price_xxx", "successUrl": "...", "cancelUrl": "..." }
+```
+
+Steps:
+1. Validate required fields present
+2. Call Stripe API: `POST https://api.stripe.com/v1/checkout/sessions` with `mode: subscription`, `client_reference_id: uid`, `line_items: [{ price: priceId, quantity: 1 }]`, `success_url`, `cancel_url`
+3. Return `{ url: session.url }`
+
+CORS headers: `Access-Control-Allow-Origin: *` (Stripe Checkout opens in a separate tab; the POST itself comes from the Flutter app's origin)
+
+**`src/webhook.ts`** — `POST /stripe-webhook`
+
+Steps:
+1. Read raw request body (required for Stripe signature verification)
+2. Verify `Stripe-Signature` header using `STRIPE_WEBHOOK_SECRET` — return 400 on failure
+3. Route by `event.type`:
+   - `checkout.session.completed`: extract `client_reference_id` (uid), look up subscription ID via Stripe API, write subscription doc
+   - `customer.subscription.updated`: update subscription doc
+   - `customer.subscription.deleted`: write `status: 'canceled'` to subscription doc
+4. Return HTTP 200 immediately (Stripe retries on non-200)
+
+Idempotency: the Stripe subscription ID is used as the Firestore document ID. Firestore PATCH (merge) is naturally idempotent — replaying the same event produces the same document state.
+
+**`src/firestore.ts`** — Firestore Admin REST API helper
+
+The Worker calls Firestore's REST endpoint using a service account JWT — this bypasses Firestore security rules (same behaviour as the Admin SDK).
+
+JWT flow:
+1. Parse `FIREBASE_SERVICE_ACCOUNT_JSON` → extract `private_key` (PEM), `client_email`
+2. Build JWT payload: `{ iss: client_email, sub: client_email, aud: 'https://oauth2.googleapis.com/token', scope: 'https://www.googleapis.com/auth/datastore', iat, exp: iat+3600 }`
+3. Sign with `crypto.subtle.sign('RSASSA-PKCS1-v1_5', privateKey, headerPayload)` (Workers have full `crypto.subtle` support)
+4. Exchange JWT for access token: `POST https://oauth2.googleapis.com/token`
+5. PATCH to `https://firestore.googleapis.com/v1/projects/{projectId}/databases/(default)/documents/customers/{uid}/subscriptions/{subscriptionId}`
+
+**Subscription document shape** (what the Worker writes, in Firestore REST API format):
+```json
+{
+  "fields": {
+    "status":              { "stringValue": "active" },
+    "items":               { "arrayValue": { "values": [
+                               { "mapValue": { "fields": {
+                                   "price": { "mapValue": { "fields": {
+                                     "id": { "stringValue": "price_xxx" }
+                                   }}}
+                               }}}
+                             ]}},
+    "current_period_end":  { "timestampValue": "2027-07-10T00:00:00Z" }
+  }
+}
+```
+
+When the Flutter `cloud_firestore` SDK reads this document, the typed values are automatically deserialised to Dart types (`String`, `List`, `Timestamp`), matching what `SubscriptionInfo.fromStripeFirestore()` already expects. No Flutter-side changes are needed for subscription reading.
+
+---
+
+### Modified: `lib/services/subscription_service.dart`
+
+Replace the `createCheckoutSession()` Firestore write/poll with a direct HTTP POST to the Worker.
+
+**Key changes:**
+- Add `static const String _workerBaseUrl = 'https://[worker-name].[account].workers.dev'` (set during deployment)
+- Remove `lifetimePriceId` constant
+- Replace `createCheckoutSession()` body: write to `customers/{userId}/checkout_sessions` + poll → `http.post(_workerBaseUrl/create-checkout-session, body: json)` → parse `url` from response
+- Keep all other methods unchanged (`subscriptionStream`, `loadFromFirestore`, `openCustomerPortal`)
+
+**Error handling:** If the Worker returns non-200, throw `Exception('Checkout failed: $statusCode')`. `SubscriptionProvider.startCheckout()` already catches and surfaces this as `_error`.
+
+---
+
+### Modified: `pubspec.yaml`
+
+Move `http` from `dev_dependencies` to `dependencies`:
+```yaml
+dependencies:
+  # ...existing...
+  http: ^1.1.0   # moved from dev_dependencies
+```
+
+---
+
+### Modified: `lib/screens/subscription/paywall_screen.dart`
+
+- Remove the `_PlanCard` for 'Lifetime' (`\$59.99`, one-time)
+- Remove `'14-day free trial'` from `detail` fields on Monthly and Annual cards
+- Update Annual `price` from `'\$39.99/year'` to `'\$49.99/year'`
+- Update Annual `savings` from `'Save 52% vs monthly'` to `'Save 40% vs monthly'`
+- Update Annual `detail` from `'Billed annually · 14-day free trial'` to `'Billed annually'`
+- Update Monthly `detail` from `'14-day free trial'` to `''` (or remove the field)
+- Remove the `onTap` for the Lifetime card and its `startCheckout` call with `lifetimePriceId`
+
+---
+
+### Modified: `lib/screens/profile/profile_screen.dart`
+
+Line 98: Update subtitle from `'Unlock Overload Pro'` / subtext `'\$39.99/year.'` to `'\$49.99/year.'`
+
+---
+
+### New: `lib/widgets/checkout_success_banner.dart`
+
+Follows the `ReturningUserBanner` pattern exactly (`lib/widgets/returning_user_banner.dart`).
+
+```
+CheckoutSuccessBanner (StatefulWidget)
+  └── _CheckoutSuccessBannerState
+        bool _dismissed = false
+        build():
+          if (_dismissed || !_shouldShow) → SizedBox.shrink()
+          else → Card(primaryContainer) with:
+            - "Welcome to Overload Pro!" title + workspace_premium icon
+            - "Your subscription is now active." body
+            - X dismiss button
+```
+
+`_shouldShow` is a static bool computed once at app startup in `main.dart`:
+```dart
+// In main() before runApp(), web only:
+final bool _checkoutSuccess = kIsWeb
+    ? Uri.base.queryParameters['checkout'] == 'success'
+    : false;
+```
+
+This is passed into `OverloadApp` and stored on a simple `CheckoutSuccessService` static (mirrors `ReturningUserService.shouldShowPrompt` pattern):
+```dart
+class CheckoutSuccessService {
+  static bool pendingWelcome = false;
+  static void dismiss() => pendingWelcome = false;
+}
+```
+
+Set `CheckoutSuccessService.pendingWelcome = _checkoutSuccess` in `main()` before `runApp()`.
+
+On dismiss, the banner calls `CheckoutSuccessService.dismiss()` + `setState(() => _dismissed = true)`. This is in-memory only — refreshing the page after the first view re-shows the banner if the URL still contains `?checkout=success`. To prevent this, after showing the banner, also call:
+```dart
+// Cleans URL without a page reload (web only)
+if (kIsWeb) {
+  // Use dart:html (deprecated) or package:web
+  // Or: rely on the in-memory flag being cleared on dismiss
+}
+```
+
+**Decision:** Do NOT clean the URL programmatically to avoid `dart:html` / `package:web` dependency. The in-memory `pendingWelcome = false` on dismiss is sufficient — once dismissed, it won't re-appear in the same session. A hard refresh re-shows it, which is acceptable (the user paid, seeing "Welcome to Pro" twice is benign).
+
+---
+
+### Modified: `lib/screens/programs/programs_screen.dart`
+
+Add `CheckoutSuccessBanner()` as the first item in the programs list, above `ReturningUserBanner()` (the existing banner).
+
+---
+
+### Modified: `fittrack/firestore.rules`
+
+Update the `checkout_sessions` subcollection comment and remove client write access (no longer used):
+
+```
+match /customers/{userId} {
+  allow read: if request.auth != null && request.auth.uid == userId;
+  allow write: if false; // Cloudflare Worker writes via service account (Admin REST API)
+
+  // Legacy: was used by Firebase Stripe Extension for checkout session polling.
+  // Not used in current Cloudflare Worker flow — retained for historical compatibility.
+  match /checkout_sessions/{sessionId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false; // no longer written by client
+  }
+
+  match /subscriptions/{subscriptionId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false; // Cloudflare Worker writes via service account
+  }
+
+  match /payments/{paymentId} {
+    allow read: if request.auth != null && request.auth.uid == userId;
+    allow write: if false;
+  }
+}
+```
+
+---
+
+## Implementation Tasks
+
+| # | Task | Files | Effort |
+|---|------|-------|--------|
+| 516 | Cloudflare Worker: project setup + /create-checkout-session endpoint | `cloudflare-worker/**` (new) | 1.5 days |
+| 517 | Cloudflare Worker: /stripe-webhook handler + Firestore write | `cloudflare-worker/src/webhook.ts`, `firestore.ts` | 2 days |
+| 518 | Flutter: move http dependency + refactor SubscriptionService | `pubspec.yaml`, `lib/services/subscription_service.dart` | 0.5 days |
+| 519 | Flutter: update PaywallScreen + ProfileScreen pricing UI | `lib/screens/subscription/paywall_screen.dart`, `lib/screens/profile/profile_screen.dart` | 0.5 days |
+| 520 | Flutter: CheckoutSuccessBanner + ProgramsScreen integration | `lib/widgets/checkout_success_banner.dart` (new), `lib/main.dart`, `lib/screens/programs/programs_screen.dart` | 1 day |
+| 521 | Firestore rules: update customers collection comments + remove legacy write access | `fittrack/firestore.rules` | 0.5 days |
+
+**Total estimated effort:** ~6 days
+
+**Dependency order:**
+- Task 516 first (Worker foundation — checkout endpoint needed to get Worker URL for Task 518)
+- Task 517 after 516 (same Worker project)
+- Tasks 518, 519, 520, 521 can be done in parallel after 516 is deployed
+
+---
+
+## Testing Strategy
+
+### Cloudflare Worker (Tasks 516–517)
+- Unit tests using Vitest (Wrangler's test harness) or manual testing via `wrangler dev`
+- Test `POST /create-checkout-session` with valid/missing fields
+- Test `POST /stripe-webhook` with valid and invalid Stripe signatures
+- Test idempotency: processing the same webhook event twice produces the same Firestore document
+- Use Stripe CLI (`stripe listen --forward-to localhost:8787`) for local webhook testing
+
+### Flutter (Tasks 518–520)
+- **Unit:** `SubscriptionService` — mock `http.Client`, assert correct Worker URL + JSON body, assert URL returned correctly
+- **Unit:** `CheckoutSuccessService` — assert `pendingWelcome` set correctly based on URL param
+- **Widget:** `CheckoutSuccessBanner` — `pendingWelcome = true` → banner visible; dismiss → `SizedBox.shrink()`; `pendingWelcome = false` → `SizedBox.shrink()`
+- **Widget:** `PaywallScreen` — assert no Lifetime card, no "free trial" text, correct prices
+- Follow existing test patterns: `mockito` for service mocks, `WidgetTester` for widget tests
+
+### Firestore Rules (Task 521)
+- Verify `customers/{userId}/checkout_sessions` write blocked for clients
+- Verify `customers/{userId}/subscriptions` read allowed for owner
+
+---
+
+## Deployment Notes
+
+1. **Manual setup required before implementation can be tested end-to-end:**
+   - Create Stripe products: Monthly ($6.99) and Annual ($49.99) — note the Price IDs
+   - Create Cloudflare Worker (`wrangler deploy`) and note the Worker URL
+   - Register Stripe webhook endpoint pointing to `https://[worker].workers.dev/stripe-webhook`
+   - Store secrets via `wrangler secret put`
+   - Configure Stripe Customer Portal return URL in Stripe Dashboard
+   - Update `_workerBaseUrl` and `monthlyPriceId`/`annualPriceId` constants in `SubscriptionService`
+
+2. **Firebase Hosting:** `firebase deploy --only hosting` — `fittrack/public/index.html` already updated; redeploy as part of this release.
+
+3. **No Firebase Blaze plan required.** The Firebase Spark plan is sufficient.
+
+---
+
+## Security Notes
+
+- Stripe webhook signature verification is mandatory — without it, any HTTP client could forge a `checkout.session.completed` event and grant Pro access to arbitrary users
+- Service account JSON must never be committed — store in Cloudflare Worker secrets only
+- The service account should be scoped to Firestore only (`roles/datastore.user`) — not a project owner
+- The Worker's `POST /create-checkout-session` endpoint does not require auth (Stripe Checkout handles payment auth). CORS is restricted to the app's production domain in the Worker config (not `*`)
+
+---
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Worker cold-start latency on first request | Low | Workers typically < 5ms cold start; acceptable |
+| Stripe webhook delivery delay | Low | Stripe retries for 3 days; real-time listener shows Pro once doc is written |
+| JWT expiry mid-webhook | Low | Tokens are generated per-request with 1hr expiry; not reused |
+| `client_reference_id` missing on session | Low | Worker validates field presence before writing to Firestore; Stripe returns it on all checkout events |
+| Checkout success URL reloads banner on refresh | Accepted | In-memory flag cleared on dismiss; re-show on refresh is benign (user paid, Welcome to Pro is harmless) |

--- a/cloudflare-worker/package.json
+++ b/cloudflare-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "fittrack-stripe-worker",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240725.0",
+    "@vitest/coverage-v8": "^2.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0",
+    "wrangler": "^3.78.0"
+  }
+}

--- a/cloudflare-worker/src/checkout.ts
+++ b/cloudflare-worker/src/checkout.ts
@@ -1,0 +1,65 @@
+export interface CheckoutRequest {
+  uid: string;
+  priceId: string;
+  successUrl: string;
+  cancelUrl: string;
+}
+
+export async function handleCreateCheckoutSession(
+  request: Request,
+  env: Env,
+): Promise<Response> {
+  let body: CheckoutRequest;
+  try {
+    body = await request.json<CheckoutRequest>();
+  } catch {
+    return jsonResponse({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const { uid, priceId, successUrl, cancelUrl } = body;
+  if (!uid || !priceId || !successUrl || !cancelUrl) {
+    return jsonResponse(
+      { error: 'Missing required fields: uid, priceId, successUrl, cancelUrl' },
+      400,
+    );
+  }
+
+  const params = new URLSearchParams();
+  params.append('mode', 'subscription');
+  params.append('client_reference_id', uid);
+  params.append('line_items[0][price]', priceId);
+  params.append('line_items[0][quantity]', '1');
+  params.append('success_url', successUrl);
+  params.append('cancel_url', cancelUrl);
+  // Store Firebase UID in subscription metadata so it's available on all
+  // future subscription webhook events (updated, deleted).
+  params.append('subscription_data[metadata][uid]', uid);
+
+  const stripeResponse = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${env.STRIPE_SECRET_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params.toString(),
+  });
+
+  if (!stripeResponse.ok) {
+    const errorBody = await stripeResponse.text();
+    console.error('Stripe API error:', stripeResponse.status, errorBody);
+    return jsonResponse({ error: 'Failed to create checkout session' }, 502);
+  }
+
+  const session = await stripeResponse.json<{ url: string }>();
+  return jsonResponse({ url: session.url }, 200);
+}
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': '*',
+    },
+  });
+}

--- a/cloudflare-worker/src/firestore.ts
+++ b/cloudflare-worker/src/firestore.ts
@@ -1,0 +1,153 @@
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+}
+
+interface FirestoreField {
+  stringValue?: string;
+  timestampValue?: string;
+  arrayValue?: { values: FirestoreField[] };
+  mapValue?: { fields: Record<string, FirestoreField> };
+}
+
+interface FirestoreDocument {
+  fields: Record<string, FirestoreField>;
+}
+
+// Builds a Firestore REST API subscription document from primitive values.
+function buildSubscriptionDocument(
+  status: string,
+  priceId: string,
+  currentPeriodEnd: number,
+): FirestoreDocument {
+  const endDate = new Date(currentPeriodEnd * 1000).toISOString();
+  return {
+    fields: {
+      status: { stringValue: status },
+      items: {
+        arrayValue: {
+          values: [
+            {
+              mapValue: {
+                fields: {
+                  price: {
+                    mapValue: {
+                      fields: {
+                        id: { stringValue: priceId },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      current_period_end: { timestampValue: endDate },
+    },
+  };
+}
+
+// Converts a PEM private key string to a CryptoKey for RSASSA-PKCS1-v1_5 signing.
+async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  const pemContent = pem
+    .replace('-----BEGIN PRIVATE KEY-----', '')
+    .replace('-----END PRIVATE KEY-----', '')
+    .replace(/\s/g, '');
+  const der = Uint8Array.from(atob(pemContent), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    'pkcs8',
+    der,
+    { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+}
+
+function base64url(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+// Builds a signed JWT and exchanges it for a Google OAuth2 access token.
+async function getAccessToken(env: Env): Promise<string> {
+  const sa = JSON.parse(env.FIREBASE_SERVICE_ACCOUNT_JSON) as ServiceAccount;
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const payload = {
+    iss: sa.client_email,
+    sub: sa.client_email,
+    aud: 'https://oauth2.googleapis.com/token',
+    scope: 'https://www.googleapis.com/auth/datastore',
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const encodedHeader = base64url(new TextEncoder().encode(JSON.stringify(header)));
+  const encodedPayload = base64url(new TextEncoder().encode(JSON.stringify(payload)));
+  const signingInput = `${encodedHeader}.${encodedPayload}`;
+
+  const privateKey = await importPrivateKey(sa.private_key);
+  const signature = await crypto.subtle.sign(
+    'RSASSA-PKCS1-v1_5',
+    privateKey,
+    new TextEncoder().encode(signingInput),
+  );
+
+  const jwt = `${signingInput}.${base64url(signature)}`;
+
+  const tokenResponse = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: jwt,
+    }).toString(),
+  });
+
+  if (!tokenResponse.ok) {
+    throw new Error(`Failed to get access token: ${tokenResponse.status}`);
+  }
+
+  const tokenData = await tokenResponse.json<{ access_token: string }>();
+  return tokenData.access_token;
+}
+
+// Writes or updates a subscription document in Firestore via the Admin REST API.
+// Uses updateMask to avoid overwriting fields not owned by this worker.
+export async function writeSubscription(
+  env: Env,
+  uid: string,
+  subscriptionId: string,
+  status: string,
+  priceId: string,
+  currentPeriodEnd: number,
+): Promise<void> {
+  const accessToken = await getAccessToken(env);
+  const projectId = env.FIREBASE_PROJECT_ID;
+
+  const docPath = `customers/${uid}/subscriptions/${subscriptionId}`;
+  const url =
+    `https://firestore.googleapis.com/v1/projects/${projectId}/databases/(default)/documents/${docPath}` +
+    '?updateMask.fieldPaths=status&updateMask.fieldPaths=items&updateMask.fieldPaths=current_period_end';
+
+  const body = buildSubscriptionDocument(status, priceId, currentPeriodEnd);
+
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Firestore PATCH failed (${response.status}): ${errorText}`);
+  }
+}

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1,0 +1,29 @@
+import { handleCreateCheckoutSession } from './checkout';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: corsHeaders(),
+      });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/create-checkout-session') {
+      return handleCreateCheckoutSession(request, env);
+    }
+
+    return new Response('Not Found', { status: 404 });
+  },
+} satisfies ExportedHandler<Env>;
+
+function corsHeaders(): HeadersInit {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+}

--- a/cloudflare-worker/src/index.ts
+++ b/cloudflare-worker/src/index.ts
@@ -1,4 +1,5 @@
 import { handleCreateCheckoutSession } from './checkout';
+import { handleStripeWebhook } from './webhook';
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -14,6 +15,10 @@ export default {
 
     if (request.method === 'POST' && url.pathname === '/create-checkout-session') {
       return handleCreateCheckoutSession(request, env);
+    }
+
+    if (request.method === 'POST' && url.pathname === '/stripe-webhook') {
+      return handleStripeWebhook(request, env);
     }
 
     return new Response('Not Found', { status: 404 });

--- a/cloudflare-worker/src/types.ts
+++ b/cloudflare-worker/src/types.ts
@@ -1,0 +1,8 @@
+// Cloudflare Worker environment bindings.
+// Secrets are set via `wrangler secret put` — never committed.
+interface Env {
+  FIREBASE_PROJECT_ID: string;
+  STRIPE_SECRET_KEY: string;
+  STRIPE_WEBHOOK_SECRET: string;
+  FIREBASE_SERVICE_ACCOUNT_JSON: string;
+}

--- a/cloudflare-worker/src/webhook.ts
+++ b/cloudflare-worker/src/webhook.ts
@@ -1,0 +1,143 @@
+import { writeSubscription } from './firestore';
+
+interface StripeSubscription {
+  id: string;
+  status: string;
+  current_period_end: number;
+  metadata: { uid?: string };
+  items: { data: Array<{ price: { id: string } }> };
+}
+
+interface StripeCheckoutSession {
+  client_reference_id: string;
+  subscription: string;
+}
+
+interface StripeEvent {
+  type: string;
+  data: { object: StripeSubscription | StripeCheckoutSession };
+}
+
+// Verifies a Stripe webhook signature using HMAC-SHA256.
+// Returns true if valid, false if the signature doesn't match or is malformed.
+async function verifyStripeSignature(
+  body: string,
+  signatureHeader: string,
+  secret: string,
+): Promise<boolean> {
+  const parts = Object.fromEntries(
+    signatureHeader.split(',').map((p) => p.split('=')),
+  ) as Record<string, string>;
+
+  const timestamp = parts['t'];
+  const expectedSig = parts['v1'];
+  if (!timestamp || !expectedSig) return false;
+
+  const signingPayload = `${timestamp}.${body}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+
+  const signatureBytes = await crypto.subtle.sign(
+    'HMAC',
+    key,
+    new TextEncoder().encode(signingPayload),
+  );
+
+  const computedSig = Array.from(new Uint8Array(signatureBytes))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  // Constant-time comparison to prevent timing attacks.
+  if (computedSig.length !== expectedSig.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < computedSig.length; i++) {
+    mismatch |= computedSig.charCodeAt(i) ^ expectedSig.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+async function fetchStripeSubscription(
+  subscriptionId: string,
+  secretKey: string,
+): Promise<StripeSubscription> {
+  const response = await fetch(`https://api.stripe.com/v1/subscriptions/${subscriptionId}`, {
+    headers: { Authorization: `Bearer ${secretKey}` },
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch subscription ${subscriptionId}: ${response.status}`);
+  }
+  return response.json<StripeSubscription>();
+}
+
+export async function handleStripeWebhook(request: Request, env: Env): Promise<Response> {
+  const body = await request.text();
+  const signatureHeader = request.headers.get('Stripe-Signature') ?? '';
+
+  const isValid = await verifyStripeSignature(body, signatureHeader, env.STRIPE_WEBHOOK_SECRET);
+  if (!isValid) {
+    return new Response('Invalid signature', { status: 400 });
+  }
+
+  let event: StripeEvent;
+  try {
+    event = JSON.parse(body) as StripeEvent;
+  } catch {
+    return new Response('Invalid JSON', { status: 400 });
+  }
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object as StripeCheckoutSession;
+        const uid = session.client_reference_id;
+        if (!uid) {
+          console.error('checkout.session.completed missing client_reference_id');
+          break;
+        }
+        const sub = await fetchStripeSubscription(session.subscription, env.STRIPE_SECRET_KEY);
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, sub.status, priceId, sub.current_period_end);
+        break;
+      }
+
+      case 'customer.subscription.updated': {
+        const sub = event.data.object as StripeSubscription;
+        const uid = sub.metadata?.uid;
+        if (!uid) {
+          console.error('customer.subscription.updated missing metadata.uid');
+          break;
+        }
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, sub.status, priceId, sub.current_period_end);
+        break;
+      }
+
+      case 'customer.subscription.deleted': {
+        const sub = event.data.object as StripeSubscription;
+        const uid = sub.metadata?.uid;
+        if (!uid) {
+          console.error('customer.subscription.deleted missing metadata.uid');
+          break;
+        }
+        const priceId = sub.items.data[0]?.price.id ?? '';
+        await writeSubscription(env, uid, sub.id, 'canceled', priceId, sub.current_period_end);
+        break;
+      }
+
+      default:
+        // Unhandled event types are silently ignored; Stripe doesn't need a retry.
+        break;
+    }
+  } catch (err) {
+    console.error('Webhook handler error:', err);
+    // Return 500 so Stripe retries the event.
+    return new Response('Internal error', { status: 500 });
+  }
+
+  return new Response('OK', { status: 200 });
+}

--- a/cloudflare-worker/test/checkout.test.ts
+++ b/cloudflare-worker/test/checkout.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateCheckoutSession } from '../src/checkout';
+
+const mockEnv: Env = {
+  FIREBASE_PROJECT_ID: 'test-project',
+  STRIPE_SECRET_KEY: 'sk_test_mock',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test_mock',
+  FIREBASE_SERVICE_ACCOUNT_JSON: '{}',
+};
+
+function makeRequest(body: unknown): Request {
+  return new Request('https://worker.test/create-checkout-session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('handleCreateCheckoutSession', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const req = new Request('https://worker.test/create-checkout-session', {
+      method: 'POST',
+      body: 'not-json',
+    });
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(400);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Invalid JSON');
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const req = makeRequest({ uid: 'user123' });
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(400);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Missing required fields');
+  });
+
+  it('calls Stripe API with correct params and returns url', async () => {
+    const mockSession = { url: 'https://checkout.stripe.com/test123' };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(mockSession),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const req = makeRequest({
+      uid: 'user123',
+      priceId: 'price_monthly',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(200);
+
+    const json = await res.json<{ url: string }>();
+    expect(json.url).toBe('https://checkout.stripe.com/test123');
+
+    // Verify Stripe was called with correct params
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const [stripeUrl, stripeInit] = fetchCall as [string, RequestInit];
+    expect(stripeUrl).toBe('https://api.stripe.com/v1/checkout/sessions');
+    expect(stripeInit.headers).toMatchObject({
+      Authorization: `Bearer sk_test_mock`,
+    });
+
+    const body = new URLSearchParams(stripeInit.body as string);
+    expect(body.get('mode')).toBe('subscription');
+    expect(body.get('client_reference_id')).toBe('user123');
+    expect(body.get('line_items[0][price]')).toBe('price_monthly');
+    expect(body.get('subscription_data[metadata][uid]')).toBe('user123');
+  });
+
+  it('returns 502 when Stripe API returns an error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ error: { message: 'Invalid API key' } }),
+      { status: 401 },
+    )));
+
+    const req = makeRequest({
+      uid: 'user123',
+      priceId: 'price_monthly',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.status).toBe(502);
+    const json = await res.json<{ error: string }>();
+    expect(json.error).toContain('Failed to create checkout session');
+  });
+
+  it('sets CORS header on response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ url: 'https://checkout.stripe.com/test' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const req = makeRequest({
+      uid: 'u1',
+      priceId: 'price_annual',
+      successUrl: 'https://app.test/?checkout=success',
+      cancelUrl: 'https://app.test/?checkout=cancelled',
+    });
+
+    const res = await handleCreateCheckoutSession(req, mockEnv);
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+});

--- a/cloudflare-worker/test/webhook.test.ts
+++ b/cloudflare-worker/test/webhook.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleStripeWebhook } from '../src/webhook';
+
+// Mock writeSubscription to avoid real Firestore calls.
+vi.mock('../src/firestore', () => ({
+  writeSubscription: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { writeSubscription } from '../src/firestore';
+
+const mockEnv: Env = {
+  FIREBASE_PROJECT_ID: 'test-project',
+  STRIPE_SECRET_KEY: 'sk_test_mock',
+  STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
+  FIREBASE_SERVICE_ACCOUNT_JSON: '{}',
+};
+
+// Builds a valid Stripe-Signature header using HMAC-SHA256.
+async function buildSignatureHeader(body: string, secret: string, timestamp = Math.floor(Date.now() / 1000)): Promise<string> {
+  const signingPayload = `${timestamp}.${body}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sigBytes = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(signingPayload));
+  const sig = Array.from(new Uint8Array(sigBytes))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return `t=${timestamp},v1=${sig}`;
+}
+
+function makeWebhookRequest(body: string, signatureHeader: string): Request {
+  return new Request('https://worker.test/stripe-webhook', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Stripe-Signature': signatureHeader,
+    },
+    body,
+  });
+}
+
+const mockSub = {
+  id: 'sub_123',
+  status: 'active',
+  current_period_end: 1800000000,
+  metadata: { uid: 'user123' },
+  items: { data: [{ price: { id: 'price_annual' } }] },
+};
+
+describe('handleStripeWebhook', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 400 for invalid signature', async () => {
+    const body = JSON.stringify({ type: 'checkout.session.completed', data: { object: {} } });
+    const req = makeWebhookRequest(body, 't=12345,v1=invalidsig');
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing signature header', async () => {
+    const body = '{}';
+    const req = new Request('https://worker.test/stripe-webhook', {
+      method: 'POST',
+      body,
+    });
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(400);
+  });
+
+  it('handles customer.subscription.updated and writes to Firestore', async () => {
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'active',
+      'price_annual',
+      1800000000,
+    );
+  });
+
+  it('handles customer.subscription.deleted and writes canceled status', async () => {
+    const deletedSub = { ...mockSub, status: 'canceled' };
+    const event = { type: 'customer.subscription.deleted', data: { object: deletedSub } };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'canceled',
+      'price_annual',
+      1800000000,
+    );
+  });
+
+  it('handles checkout.session.completed by fetching subscription from Stripe', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(
+      JSON.stringify(mockSub),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    )));
+
+    const event = {
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          client_reference_id: 'user123',
+          subscription: 'sub_123',
+        },
+      },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledWith(
+      mockEnv,
+      'user123',
+      'sub_123',
+      'active',
+      'price_annual',
+      1800000000,
+    );
+    vi.unstubAllGlobals();
+  });
+
+  it('returns 500 when writeSubscription throws (triggers Stripe retry)', async () => {
+    vi.mocked(writeSubscription).mockRejectedValueOnce(new Error('Firestore error'));
+
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 200 for unhandled event types (no retry needed)', async () => {
+    const event = { type: 'payment_intent.created', data: { object: {} } };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+    const req = makeWebhookRequest(body, sig);
+
+    const res = await handleStripeWebhook(req, mockEnv);
+    expect(res.status).toBe(200);
+    expect(writeSubscription).not.toHaveBeenCalled();
+  });
+
+  it('idempotent: processing the same event twice calls writeSubscription twice with same args', async () => {
+    const event = {
+      type: 'customer.subscription.updated',
+      data: { object: mockSub },
+    };
+    const body = JSON.stringify(event);
+    const sig = await buildSignatureHeader(body, mockEnv.STRIPE_WEBHOOK_SECRET);
+
+    const res1 = await handleStripeWebhook(makeWebhookRequest(body, sig), mockEnv);
+    const res2 = await handleStripeWebhook(makeWebhookRequest(body, sig), mockEnv);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(writeSubscription).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(writeSubscription).mock.calls[0]).toEqual(
+      vi.mocked(writeSubscription).mock.calls[1],
+    );
+  });
+});

--- a/cloudflare-worker/tsconfig.json
+++ b/cloudflare-worker/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/cloudflare-worker/vitest.config.ts
+++ b/cloudflare-worker/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+    },
+  },
+});

--- a/cloudflare-worker/wrangler.toml
+++ b/cloudflare-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "fittrack-stripe-worker"
+main = "src/index.ts"
+compatibility_date = "2024-07-25"
+compatibility_flags = ["nodejs_compat"]
+
+[vars]
+FIREBASE_PROJECT_ID = "fitness-app-8505e"
+
+# Secrets (set via `wrangler secret put`, never committed):
+# STRIPE_SECRET_KEY
+# STRIPE_WEBHOOK_SECRET
+# FIREBASE_SERVICE_ACCOUNT_JSON

--- a/fittrack/firestore.rules
+++ b/fittrack/firestore.rules
@@ -393,26 +393,31 @@ service cloud.firestore {
     }
 
     // -----------------------
-    // Stripe Extension — customers collection
-    // Written by the Firebase Stripe Extension (admin SDK / webhooks).
-    // Clients may read their own subscription data and create checkout sessions.
+    // Stripe — customers collection
+    // Written by the Cloudflare Worker via Firebase Admin REST API (service account).
+    // Clients may only read their own subscription data.
     // -----------------------
     match /customers/{userId} {
       allow read: if request.auth != null && request.auth.uid == userId;
-      allow write: if false; // Extension writes via admin SDK
+      allow write: if false; // Cloudflare Worker writes via service account (Admin REST API)
 
+      // Legacy: was used by the Firebase Stripe Extension for checkout session
+      // URL polling. Not used in the current Cloudflare Worker flow — the Worker
+      // creates Stripe sessions directly via the Stripe API without touching
+      // Firestore. Retained for historical compatibility; client write removed.
       match /checkout_sessions/{sessionId} {
-        allow read, write: if request.auth != null && request.auth.uid == userId;
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if false; // no longer written by client
       }
 
       match /subscriptions/{subscriptionId} {
         allow read: if request.auth != null && request.auth.uid == userId;
-        allow write: if false; // Extension writes via admin SDK
+        allow write: if false; // Cloudflare Worker writes via service account
       }
 
       match /payments/{paymentId} {
         allow read: if request.auth != null && request.auth.uid == userId;
-        allow write: if false; // Extension writes via admin SDK
+        allow write: if false; // Cloudflare Worker writes via service account
       }
     }
 

--- a/fittrack/lib/main.dart
+++ b/fittrack/lib/main.dart
@@ -26,6 +26,7 @@ import 'services/lifecycle_notification_service.dart';
 import 'services/notification_service.dart';
 import 'services/onboarding_service.dart';
 import 'services/returning_user_service.dart';
+import 'widgets/checkout_success_banner.dart';
 
 const bool _kUseEmulator = bool.fromEnvironment('USE_EMULATOR', defaultValue: false);
 const bool _kForceSemantics = bool.fromEnvironment('FORCE_SEMANTICS', defaultValue: false);
@@ -120,6 +121,13 @@ void main() async {
 
   // Initialize returning user service — detects 30+ day inactivity on home screen
   ReturningUserService.initialize(prefs);
+
+  // Detect Stripe Checkout success return URL — set once before runApp so the
+  // flag is available synchronously when ProgramsScreen first builds.
+  if (kIsWeb) {
+    CheckoutSuccessService.pendingWelcome =
+        Uri.base.queryParameters['checkout'] == 'success';
+  }
 
   runZonedGuarded(
     () => runApp(OverloadApp(prefs: prefs)),

--- a/fittrack/lib/screens/profile/profile_screen.dart
+++ b/fittrack/lib/screens/profile/profile_screen.dart
@@ -95,7 +95,7 @@ class ProfileScreen extends StatelessWidget {
                     onTap: () => PaywallScreen.show(
                       context,
                       headline: 'Unlock Overload Pro',
-                      subtext: 'Unlimited programs. Full analytics. \$39.99/year.',
+                      subtext: 'Unlimited programs. Full analytics. \$49.99/year.',
                     ),
                   );
                 },

--- a/fittrack/lib/screens/programs/programs_screen.dart
+++ b/fittrack/lib/screens/programs/programs_screen.dart
@@ -11,6 +11,7 @@ import '../../widgets/global_bottom_nav_bar.dart';
 import '../../widgets/create_options_sheet.dart';
 import '../templates/template_picker_screen.dart';
 import '../templates/template_preview_sheet.dart';
+import '../../widgets/checkout_success_banner.dart';
 import '../../widgets/returning_user_banner.dart';
 import '../../providers/subscription_provider.dart';
 import '../subscription/paywall_screen.dart';
@@ -93,6 +94,7 @@ class ProgramsScreen extends StatelessWidget {
 
           return Column(
             children: [
+              const CheckoutSuccessBanner(),
               const ReturningUserBanner(),
               Expanded(
                 child: RefreshIndicator(

--- a/fittrack/lib/screens/subscription/paywall_screen.dart
+++ b/fittrack/lib/screens/subscription/paywall_screen.dart
@@ -119,9 +119,9 @@ class PaywallScreen extends StatelessWidget {
                   _PlanCard(
                     label: 'Annual',
                     badge: 'RECOMMENDED',
-                    savings: 'Save 52% vs monthly',
-                    price: '\$39.99/year',
-                    detail: 'Billed annually · 14-day free trial',
+                    savings: 'Save 40% vs monthly',
+                    price: '\$49.99/year',
+                    detail: 'Billed annually',
                     isRecommended: true,
                     onTap: () {
                       Navigator.of(context).pop();
@@ -141,7 +141,7 @@ class PaywallScreen extends StatelessWidget {
                   _PlanCard(
                     label: 'Monthly',
                     price: '\$6.99/month',
-                    detail: '14-day free trial',
+                    detail: 'Billed monthly',
                     isRecommended: false,
                     onTap: () {
                       Navigator.of(context).pop();
@@ -152,26 +152,6 @@ class PaywallScreen extends StatelessWidget {
                             .read<SubscriptionProvider>()
                             .startCheckout(
                                 userId, SubscriptionService.monthlyPriceId);
-                      }
-                    },
-                  ),
-                  const SizedBox(height: 12),
-
-                  // Lifetime plan card
-                  _PlanCard(
-                    label: 'Lifetime',
-                    price: '\$59.99',
-                    detail: 'One-time purchase · No recurring fees',
-                    isRecommended: false,
-                    onTap: () {
-                      Navigator.of(context).pop();
-                      final userId =
-                          context.read<AuthProvider>().user?.uid;
-                      if (userId != null) {
-                        context
-                            .read<SubscriptionProvider>()
-                            .startCheckout(
-                                userId, SubscriptionService.lifetimePriceId);
                       }
                     },
                   ),

--- a/fittrack/lib/services/subscription_service.dart
+++ b/fittrack/lib/services/subscription_service.dart
@@ -1,13 +1,15 @@
+import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import '../models/subscription.dart';
 
-/// Manages subscription billing via the Firebase Stripe Extension.
+/// Manages subscription billing via a Cloudflare Worker that proxies Stripe.
 ///
-/// The Firebase Stripe Extension syncs Stripe subscription state to Firestore
-/// under `customers/{userId}/subscriptions`. Checkout sessions are created by
-/// writing to `customers/{userId}/checkout_sessions`; the extension populates
-/// the Stripe Checkout URL asynchronously.
+/// Checkout sessions are created by calling the Worker's
+/// /create-checkout-session endpoint directly. Subscription state is written
+/// to `customers/{userId}/subscriptions` by the Worker's webhook handler and
+/// read back via a real-time Firestore stream.
 class SubscriptionService {
   static final SubscriptionService instance = SubscriptionService._();
 
@@ -15,7 +17,10 @@ class SubscriptionService {
   // Format: price_XXXXXXXXXXXXXXXXXXXXXXXX
   static const String monthlyPriceId = 'price_monthly_placeholder';
   static const String annualPriceId = 'price_annual_placeholder';
-  static const String lifetimePriceId = 'price_lifetime_placeholder';
+
+  // Cloudflare Worker base URL — set after deploying the Worker via `wrangler deploy`.
+  // Format: https://fittrack-stripe-worker.<account>.workers.dev
+  static const String _workerBaseUrl = 'https://fittrack-stripe-worker.placeholder.workers.dev';
 
   // Stripe Customer Portal shareable link — configured in Stripe Dashboard →
   // Settings → Billing → Customer Portal.
@@ -23,14 +28,23 @@ class SubscriptionService {
       'https://billing.stripe.com/p/login/placeholder';
 
   final FirebaseFirestore? _injectedFirestore;
+  final http.Client? _injectedHttpClient;
+
   FirebaseFirestore get _firestore =>
       _injectedFirestore ?? FirebaseFirestore.instance;
 
-  SubscriptionService._() : _injectedFirestore = null;
+  http.Client get _httpClient => _injectedHttpClient ?? http.Client();
+
+  SubscriptionService._()
+      : _injectedFirestore = null,
+        _injectedHttpClient = null;
 
   @visibleForTesting
-  SubscriptionService.forTest(FirebaseFirestore firestore)
-      : _injectedFirestore = firestore;
+  SubscriptionService.forTest(
+    FirebaseFirestore firestore,
+    http.Client httpClient,
+  )   : _injectedFirestore = firestore,
+        _injectedHttpClient = httpClient;
 
   /// Real-time stream of active Stripe subscriptions for [userId].
   /// Emits [SubscriptionInfo.free] when no active/trialing subscriptions exist.
@@ -63,39 +77,30 @@ class SubscriptionService {
     return SubscriptionInfo.fromStripeFirestore(snapshot.docs.first.data());
   }
 
-  /// Creates a Stripe Checkout session and returns the hosted Checkout URL.
-  ///
-  /// Writes a session document to `customers/{userId}/checkout_sessions`;
-  /// the Firebase Stripe Extension creates the Stripe session and writes back
-  /// the `url` field. Throws if the extension returns an error or times out.
+  /// Creates a Stripe Checkout session via the Cloudflare Worker and returns
+  /// the hosted Checkout URL. Throws if the Worker returns a non-200 response.
   Future<String> createCheckoutSession({
     required String userId,
     required String priceId,
     required String successUrl,
     required String cancelUrl,
   }) async {
-    final sessionRef = await _firestore
-        .collection('customers')
-        .doc(userId)
-        .collection('checkout_sessions')
-        .add({
-      'price': priceId,
-      'success_url': successUrl,
-      'cancel_url': cancelUrl,
-      'mode': priceId == lifetimePriceId ? 'payment' : 'subscription',
-      'allow_promotion_codes': true,
-    });
+    final response = await _httpClient.post(
+      Uri.parse('$_workerBaseUrl/create-checkout-session'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'uid': userId,
+        'priceId': priceId,
+        'successUrl': successUrl,
+        'cancelUrl': cancelUrl,
+      }),
+    );
 
-    // Extension populates 'url' (or 'error') asynchronously — wait up to 10s.
-    final snapshot = await sessionRef
-        .snapshots()
-        .firstWhere((snap) =>
-            snap.data()?['url'] != null || snap.data()?['error'] != null)
-        .timeout(const Duration(seconds: 10));
+    if (response.statusCode != 200) {
+      throw Exception('Checkout failed: ${response.statusCode}');
+    }
 
-    final error = snapshot.data()?['error'] as String?;
-    if (error != null) throw Exception('Stripe checkout error: $error');
-
-    return snapshot.data()!['url'] as String;
+    final data = jsonDecode(response.body) as Map<String, dynamic>;
+    return data['url'] as String;
   }
 }

--- a/fittrack/lib/widgets/checkout_success_banner.dart
+++ b/fittrack/lib/widgets/checkout_success_banner.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+/// In-memory flag set once at app startup when `?checkout=success` is detected
+/// in the URL. Cleared on dismiss so the banner never re-appears in the same
+/// session (though a hard refresh that retains the URL will re-show it, which
+/// is benign — the user paid and "Welcome to Pro" is harmless to see twice).
+class CheckoutSuccessService {
+  static bool pendingWelcome = false;
+  static void dismiss() => pendingWelcome = false;
+}
+
+/// Shown at the top of the programs list when the user returns to the app
+/// after a successful Stripe Checkout (`?checkout=success` in the URL).
+///
+/// Invisible (SizedBox.shrink) when conditions are not met.
+class CheckoutSuccessBanner extends StatefulWidget {
+  const CheckoutSuccessBanner({super.key});
+
+  @override
+  State<CheckoutSuccessBanner> createState() => _CheckoutSuccessBannerState();
+}
+
+class _CheckoutSuccessBannerState extends State<CheckoutSuccessBanner> {
+  bool _dismissed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (_dismissed || !CheckoutSuccessService.pendingWelcome) {
+      return const SizedBox.shrink();
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Card(
+      margin: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      color: colorScheme.primaryContainer,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.workspace_premium,
+                    color: colorScheme.onPrimaryContainer, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'Welcome to Overload Pro!',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          color: colorScheme.onPrimaryContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  color: colorScheme.onPrimaryContainer.withValues(alpha: 0.7),
+                  visualDensity: VisualDensity.compact,
+                  tooltip: 'Dismiss',
+                  onPressed: _dismiss,
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Your subscription is now active. All Pro features are unlocked.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer.withValues(alpha: 0.85),
+                  ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _dismiss() {
+    CheckoutSuccessService.dismiss();
+    setState(() => _dismissed = true);
+  }
+}

--- a/fittrack/public/index.html
+++ b/fittrack/public/index.html
@@ -276,7 +276,7 @@
       <div class="pricing-col">
         <span class="pricing-tier-label">Pro</span>
         <p class="pricing-price">$6.99 <sub>/ month</sub></p>
-        <p class="pricing-alt">or $39.99/year — <strong>save 52%</strong></p>
+        <p class="pricing-alt">or $49.99/year — <strong>save 40%</strong></p>
         <ul class="pricing-items">
           <li>Everything in Free</li>
           <li>Unlimited programs</li>

--- a/fittrack/pubspec.yaml
+++ b/fittrack/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # URL launcher
   url_launcher: ^6.2.0
 
+  # HTTP client for Cloudflare Worker API calls
+  http: ^1.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -45,7 +48,6 @@ dev_dependencies:
   mockito: ^5.4.4
   build_runner: ^2.4.7
   test: ^1.24.0
-  http: ^1.1.0
   fake_cloud_firestore: ^4.0.1
 flutter:
   uses-material-design: true

--- a/fittrack/test/screens/subscription/paywall_screen_test.dart
+++ b/fittrack/test/screens/subscription/paywall_screen_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(find.text('You have reached the free plan limit.'), findsNothing);
     });
 
-    testWidgets('renders Annual, Monthly and Lifetime plan labels', (tester) async {
+    testWidgets('renders Annual and Monthly plan labels', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -86,7 +86,7 @@ void main() {
 
       expect(find.text('Annual'), findsOneWidget);
       expect(find.text('Monthly'), findsOneWidget);
-      expect(find.text('Lifetime'), findsOneWidget);
+      expect(find.text('Lifetime'), findsNothing);
     });
 
     testWidgets('renders RECOMMENDED badge on annual plan', (tester) async {
@@ -100,7 +100,7 @@ void main() {
       expect(find.text('RECOMMENDED'), findsOneWidget);
     });
 
-    testWidgets('renders Lifetime plan with one-time purchase detail', (tester) async {
+    testWidgets('does not render Lifetime plan (out of scope)', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -108,8 +108,8 @@ void main() {
         ),
       );
 
-      expect(find.text('Lifetime'), findsOneWidget);
-      expect(find.text('One-time purchase · No recurring fees'), findsOneWidget);
+      expect(find.text('Lifetime'), findsNothing);
+      expect(find.text('One-time purchase · No recurring fees'), findsNothing);
     });
 
     testWidgets('renders benefits list', (tester) async {
@@ -186,7 +186,7 @@ void main() {
   });
 
   group('PaywallScreen - plan prices', () {
-    testWidgets('renders hardcoded Stripe prices', (tester) async {
+    testWidgets('renders updated Stripe prices', (tester) async {
       await tester.pumpWidget(
         _buildSubject(
           sub: sub,
@@ -194,9 +194,9 @@ void main() {
         ),
       );
 
-      expect(find.text(r'$39.99/year'), findsOneWidget);
+      expect(find.text(r'$49.99/year'), findsOneWidget);
       expect(find.text(r'$6.99/month'), findsOneWidget);
-      expect(find.text(r'$59.99'), findsOneWidget);
+      expect(find.text(r'$59.99'), findsNothing);
     });
   });
 

--- a/fittrack/test/services/subscription_service_integration_test.dart
+++ b/fittrack/test/services/subscription_service_integration_test.dart
@@ -1,17 +1,29 @@
 /// Integration tests for SubscriptionService.
 ///
-/// Tests the full Stripe-via-Firestore subscription lifecycle using
-/// FakeFirebaseFirestore, verifying that subscription reads, stream emissions,
-/// and checkout session creation all behave correctly end-to-end.
+/// Tests the subscription read/stream lifecycle using FakeFirebaseFirestore,
+/// verifying that subscription reads and stream emissions behave correctly.
+/// Checkout session creation is tested in subscription_service_test.dart
+/// via MockClient.
 
 @Timeout(Duration(seconds: 30))
 library;
 
+import 'dart:convert';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:fittrack/models/subscription.dart';
 import 'package:fittrack/services/subscription_service.dart';
+
+SubscriptionService _makeService(FakeFirebaseFirestore firestore, {http.Client? httpClient}) {
+  return SubscriptionService.forTest(
+    firestore,
+    httpClient ?? MockClient((_) async => http.Response('', 200)),
+  );
+}
 
 void main() {
   late FakeFirebaseFirestore fakeFirestore;
@@ -19,7 +31,7 @@ void main() {
 
   setUp(() {
     fakeFirestore = FakeFirebaseFirestore();
-    service = SubscriptionService.forTest(fakeFirestore);
+    service = _makeService(fakeFirestore);
   });
 
   group('SubscriptionService - subscription read lifecycle', () {
@@ -100,25 +112,16 @@ void main() {
     });
   });
 
-  group('SubscriptionService - checkout session lifecycle', () {
-    test('checkout session document is written with required fields', () async {
-      // Simulate extension: write url when session created
-      fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          final data = doc.data();
-          if (data['price'] != null && data['url'] == null && data['error'] == null) {
-            await doc.reference
-                .update({'url': 'https://checkout.stripe.com/session-xyz'});
-          }
-        }
-      });
+  group('SubscriptionService - checkout session via Cloudflare Worker', () {
+    test('createCheckoutSession returns url from Worker response', () async {
+      final mockClient = MockClient((_) async => http.Response(
+            jsonEncode({'url': 'https://checkout.stripe.com/session-xyz'}),
+            200,
+            headers: {'content-type': 'application/json'},
+          ));
+      final svc = _makeService(fakeFirestore, httpClient: mockClient);
 
-      final url = await service.createCheckoutSession(
+      final url = await svc.createCheckoutSession(
         userId: 'user-checkout',
         priceId: SubscriptionService.annualPriceId,
         successUrl: 'https://fittrack-app.web.app/?checkout=success',
@@ -126,51 +129,21 @@ void main() {
       );
 
       expect(url, 'https://checkout.stripe.com/session-xyz');
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .get();
-
-      final data = sessions.docs.first.data();
-      expect(data['price'], SubscriptionService.annualPriceId);
-      expect(data['success_url'],
-          'https://fittrack-app.web.app/?checkout=success');
-      expect(data['cancel_url'],
-          'https://fittrack-app.web.app/?checkout=cancelled');
-      expect(data['mode'], 'subscription');
-      expect(data['allow_promotion_codes'], isTrue);
     });
 
-    test('lifetime plan uses payment mode', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          final data = doc.data();
-          if (data['price'] != null && data['url'] == null && data['error'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
-          }
-        }
-      });
+    test('throws Exception when Worker returns non-200', () async {
+      final mockClient = MockClient((_) async => http.Response('server error', 500));
+      final svc = _makeService(fakeFirestore, httpClient: mockClient);
 
-      await service.createCheckoutSession(
-        userId: 'user-lifetime',
-        priceId: SubscriptionService.lifetimePriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+      await expectLater(
+        svc.createCheckoutSession(
+          userId: 'user-error',
+          priceId: SubscriptionService.annualPriceId,
+          successUrl: 'https://fittrack-app.web.app/?checkout=success',
+          cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+        ),
+        throwsA(isA<Exception>()),
       );
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.first.data()['mode'], 'payment');
     });
   });
 

--- a/fittrack/test/services/subscription_service_test.dart
+++ b/fittrack/test/services/subscription_service_test.dart
@@ -1,19 +1,21 @@
 @Timeout(Duration(seconds: 30))
 library;
 
+import 'dart:convert';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:fittrack/models/subscription.dart';
 import 'package:fittrack/services/subscription_service.dart';
 
 void main() {
   late FakeFirebaseFirestore fakeFirestore;
-  late SubscriptionService service;
 
   setUp(() {
     fakeFirestore = FakeFirebaseFirestore();
-    service = SubscriptionService.forTest(fakeFirestore);
   });
 
   group('SubscriptionService - Stripe Price ID constants', () {
@@ -25,16 +27,18 @@ void main() {
       expect(SubscriptionService.annualPriceId, isNotEmpty);
     });
 
-    test('lifetimePriceId is set', () {
-      expect(SubscriptionService.lifetimePriceId, isNotEmpty);
-    });
-
     test('stripePortalUrl starts with https', () {
       expect(SubscriptionService.stripePortalUrl, startsWith('https://'));
     });
   });
 
   group('SubscriptionService - loadFromFirestore', () {
+    late SubscriptionService service;
+
+    setUp(() {
+      service = SubscriptionService.forTest(fakeFirestore, MockClient((_) async => http.Response('', 200)));
+    });
+
     test('returns SubscriptionInfo.free when no subscriptions exist', () async {
       final result = await service.loadFromFirestore('user-1');
       expect(result.isPro, isFalse);
@@ -106,6 +110,12 @@ void main() {
   });
 
   group('SubscriptionService - subscriptionStream', () {
+    late SubscriptionService service;
+
+    setUp(() {
+      service = SubscriptionService.forTest(fakeFirestore, MockClient((_) async => http.Response('', 200)));
+    });
+
     test('emits SubscriptionInfo.free when no subscriptions', () async {
       final stream = service.subscriptionStream('user-stream');
       final info = await stream.first;
@@ -136,95 +146,72 @@ void main() {
   });
 
   group('SubscriptionService - createCheckoutSession', () {
-    test('writes checkout session document with correct fields', () async {
-      // Simulate extension responding with a url immediately
-      fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['url'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/test'});
-          }
-        }
+    test('POSTs correct JSON body to Worker and returns url', () async {
+      final capturedRequests = <http.Request>[];
+      final mockClient = MockClient((request) async {
+        capturedRequests.add(request);
+        return http.Response(
+          jsonEncode({'url': 'https://checkout.stripe.com/test123'}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
       });
 
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
       final url = await service.createCheckoutSession(
         userId: 'user-checkout',
         priceId: SubscriptionService.annualPriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+        successUrl: 'https://app.test/?checkout=success',
+        cancelUrl: 'https://app.test/?checkout=cancelled',
       );
 
-      expect(url, 'https://checkout.stripe.com/test');
+      expect(url, 'https://checkout.stripe.com/test123');
+      expect(capturedRequests.length, 1);
 
-      // Verify session document was written with correct fields
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-checkout')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.length, 1);
-      final data = sessions.docs.first.data();
-      expect(data['price'], SubscriptionService.annualPriceId);
-      expect(data['mode'], 'subscription');
-      expect(data['allow_promotion_codes'], isTrue);
+      final body = jsonDecode(capturedRequests.first.body) as Map<String, dynamic>;
+      expect(body['uid'], 'user-checkout');
+      expect(body['priceId'], SubscriptionService.annualPriceId);
+      expect(body['successUrl'], 'https://app.test/?checkout=success');
+      expect(body['cancelUrl'], 'https://app.test/?checkout=cancelled');
     });
 
-    test('uses payment mode for lifetime price ID', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['url'] == null) {
-            await doc.reference.update({'url': 'https://checkout.stripe.com/lifetime'});
-          }
-        }
-      });
-
-      await service.createCheckoutSession(
-        userId: 'user-lifetime',
-        priceId: SubscriptionService.lifetimePriceId,
-        successUrl: 'https://fittrack-app.web.app/?checkout=success',
-        cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
-      );
-
-      final sessions = await fakeFirestore
-          .collection('customers')
-          .doc('user-lifetime')
-          .collection('checkout_sessions')
-          .get();
-      expect(sessions.docs.first.data()['mode'], 'payment');
-    });
-
-    test('throws when extension returns error', () async {
-      fakeFirestore
-          .collection('customers')
-          .doc('user-error')
-          .collection('checkout_sessions')
-          .snapshots()
-          .listen((snap) async {
-        for (final doc in snap.docs) {
-          if (doc.data()['price'] != null && doc.data()['error'] == null) {
-            await doc.reference
-                .update({'error': 'No such price: bad_price_id'});
-          }
-        }
-      });
+    test('throws Exception when Worker returns non-200', () async {
+      final mockClient = MockClient((_) async => http.Response('error', 502));
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
 
       expect(
         () => service.createCheckoutSession(
           userId: 'user-error',
-          priceId: 'bad_price_id',
-          successUrl: 'https://fittrack-app.web.app/?checkout=success',
-          cancelUrl: 'https://fittrack-app.web.app/?checkout=cancelled',
+          priceId: SubscriptionService.annualPriceId,
+          successUrl: 'https://app.test/?checkout=success',
+          cancelUrl: 'https://app.test/?checkout=cancelled',
         ),
         throwsA(isA<Exception>()),
+      );
+    });
+
+    test('sets Content-Type header to application/json', () async {
+      final capturedRequests = <http.Request>[];
+      final mockClient = MockClient((request) async {
+        capturedRequests.add(request);
+        return http.Response(
+          jsonEncode({'url': 'https://checkout.stripe.com/test'}),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final service = SubscriptionService.forTest(fakeFirestore, mockClient);
+      await service.createCheckoutSession(
+        userId: 'u1',
+        priceId: SubscriptionService.monthlyPriceId,
+        successUrl: 'https://app.test/?checkout=success',
+        cancelUrl: 'https://app.test/?checkout=cancelled',
+      );
+
+      expect(
+        capturedRequests.first.headers['content-type'],
+        contains('application/json'),
       );
     });
   });

--- a/fittrack/test/widgets/checkout_success_banner_test.dart
+++ b/fittrack/test/widgets/checkout_success_banner_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fittrack/widgets/checkout_success_banner.dart';
+
+Widget _buildSubject() {
+  return const MaterialApp(
+    home: Scaffold(body: CheckoutSuccessBanner()),
+  );
+}
+
+void main() {
+  setUp(() {
+    CheckoutSuccessService.pendingWelcome = false;
+  });
+
+  group('CheckoutSuccessBanner', () {
+    testWidgets('is invisible when pendingWelcome is false', (tester) async {
+      CheckoutSuccessService.pendingWelcome = false;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+      expect(find.byType(Card), findsNothing);
+    });
+
+    testWidgets('shows banner when pendingWelcome is true', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.text('Welcome to Overload Pro!'), findsOneWidget);
+      expect(
+        find.text('Your subscription is now active. All Pro features are unlocked.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('shows workspace_premium icon when visible', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      expect(find.byIcon(Icons.workspace_premium), findsOneWidget);
+    });
+
+    testWidgets('dismisses banner on close tap', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      expect(find.text('Welcome to Overload Pro!'), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+    });
+
+    testWidgets('dismiss clears pendingWelcome flag', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+
+    testWidgets('does not re-appear after dismiss even if pendingWelcome re-set', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      // Even if the flag is re-set (e.g., by a test), the _dismissed bool
+      // on the widget state keeps it invisible within the same widget lifecycle.
+      CheckoutSuccessService.pendingWelcome = true;
+      await tester.pump();
+
+      expect(find.text('Welcome to Overload Pro!'), findsNothing);
+    });
+
+    testWidgets('uses primaryContainer card color', (tester) async {
+      CheckoutSuccessService.pendingWelcome = true;
+
+      await tester.pumpWidget(_buildSubject());
+
+      final card = tester.widget<Card>(find.byType(Card));
+      final colorScheme = Theme.of(tester.element(find.byType(Card))).colorScheme;
+      expect(card.color, colorScheme.primaryContainer);
+    });
+  });
+
+  group('CheckoutSuccessService', () {
+    test('pendingWelcome defaults to false', () {
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+
+    test('dismiss() sets pendingWelcome to false', () {
+      CheckoutSuccessService.pendingWelcome = true;
+      CheckoutSuccessService.dismiss();
+      expect(CheckoutSuccessService.pendingWelcome, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a Cloudflare Worker (`cloudflare-worker/`) with `/create-checkout-session` and `/stripe-webhook` endpoints — no Firebase Blaze plan required
- Refactors `SubscriptionService.createCheckoutSession()` to POST to the Worker instead of writing a Firestore checkout_sessions document
- Updates PaywallScreen: removes Lifetime plan, removes free trial copy, updates annual pricing to $49.99/year
- Adds `CheckoutSuccessBanner` shown once after returning from Stripe Checkout with `?checkout=success`
- Tightens Firestore security rules: removes client write access to `checkout_sessions` subcollection (Worker writes via Admin REST API)

## Tasks completed

- #516 Cloudflare Worker: project setup + /create-checkout-session endpoint (PR #522)
- #517 Cloudflare Worker: /stripe-webhook handler + Firestore Admin REST write helper (PR #523)
- #518 Flutter: move http dependency + refactor SubscriptionService (PR #524)
- #519 Flutter: update PaywallScreen + ProfileScreen pricing UI (PR #524)
- #520 Flutter: CheckoutSuccessBanner + ProgramsScreen integration (PR #525)
- #521 Firestore rules: update customers collection for Cloudflare Worker flow (PR #526)

## Security notes

- No Stripe keys, webhook secrets, or service account JSON committed
- Worker secrets stored via `wrangler secret put` only
- `_workerBaseUrl` is a placeholder constant safe for a public repo

## Test plan

- [ ] All unit, widget, integration, and E2E tests pass on the feature branch CI run
- [ ] Verify Cloudflare Worker deploys correctly in staging (`wrangler deploy`)
- [ ] Test Stripe Checkout flow end-to-end with test keys
- [ ] Verify `?checkout=success` triggers the welcome banner on Programs screen
- [ ] Verify webhook correctly updates Firestore subscription document

Closes #515

Generated with Claude Code
