### PR TITLE
[Diagnostic] Capture console/pageerror during offline-smoke reconnect (#533)

### DIFF
--- a/fittrack/playwright/tests/offline-smoke.spec.ts
+++ b/fittrack/playwright/tests/offline-smoke.spec.ts
@@ -176,4 +176,41 @@ test.describe('PWA Offline Smoke', () => {
       new Promise<void>(resolve => setTimeout(resolve, 3_000)),
     ]);
   });
+
+  // DIAGNOSTIC (#533): isolates whether auth persistence loss requires the offline
+  // navigation, or happens on any reload. No context.setOffline() involved here at
+  // all — just sign in, confirm HomeScreen, plain reload, check whether the session
+  // is still there. If this also lands on Sign In screen, persistence loss is not
+  // offline/service-worker specific; if it survives, the offline sequence itself is
+  // implicated. Not a permanent test — remove once #533's root cause is confirmed.
+  test('DIAGNOSTIC: auth session survives a plain reload (no offline)', async ({ page }, testInfo) => {
+    test.setTimeout(60_000);
+
+    page.on('console', msg => {
+      const text = msg.text();
+      if (text.includes('[AuthProvider]') || text.includes('firebase') || text.includes('Firebase')) {
+        console.log(`[E2E][browser-console] ${text}`);
+      }
+    });
+    page.on('pageerror', err => {
+      console.log(`[E2E][browser-pageerror] ${err.message}`);
+    });
+
+    await signIn(page, EMAIL, PASSWORD);
+    await expect(
+      page.locator('[aria-current="true"]').or(page.getByText('My Programs')).first()
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/01-before-plain-reload.png` }).catch(() => {});
+
+    console.log('[E2E] --- plain reload starting (no offline) ---');
+    await page.reload({ timeout: 20_000 });
+    console.log('[E2E] --- plain reload complete; watching for AuthProvider state ---');
+
+    await expect(
+      page.locator('[aria-current="true"]').or(page.getByText('My Programs')).first()
+    ).toBeVisible({ timeout: 20_000 });
+
+    await page.screenshot({ path: `test-results/${testInfo.title}/02-after-plain-reload.png` }).catch(() => {});
+  });
 });

--- a/fittrack/playwright/tests/offline-smoke.spec.ts
+++ b/fittrack/playwright/tests/offline-smoke.spec.ts
@@ -22,6 +22,23 @@ test.describe('PWA Offline Smoke', () => {
     // 200s gives ample headroom for CI variability.
     test.setTimeout(200_000);
 
+    // DIAGNOSTIC (#533): surface AuthProvider's existing debugPrint output and any
+    // uncaught page errors. AuthProvider already logs `[AuthProvider] Auth state
+    // changed - userId: ...` on every authStateChanges emission (auth_provider.dart:37)
+    // but nothing was listening to the browser console, so this signal was invisible
+    // in CI. This tells us directly whether authStateChanges fires with a null user
+    // after the reconnect reload, or doesn't fire at all — narrowing down whether
+    // Firebase Auth persistence is being lost vs. the app just failing to re-render.
+    page.on('console', msg => {
+      const text = msg.text();
+      if (text.includes('[AuthProvider]') || text.includes('firebase') || text.includes('Firebase')) {
+        console.log(`[E2E][browser-console] ${text}`);
+      }
+    });
+    page.on('pageerror', err => {
+      console.log(`[E2E][browser-pageerror] ${err.message}`);
+    });
+
     // --- WARM THE SERVICE WORKER CACHE ---
     // Sign in first to ensure the service worker has cached the app shell.
     await signIn(page, EMAIL, PASSWORD);
@@ -147,7 +164,9 @@ test.describe('PWA Offline Smoke', () => {
     // Reload to reconnect. Unlike the offline-phase reload above, we do NOT
     // swallow errors here — a failure to reconnect is the actual regression
     // this test exists to catch (#514), so it must fail the test, not just log.
+    console.log('[E2E] --- reconnect reload starting ---');
     await page.reload({ timeout: 20_000 });
+    console.log('[E2E] --- reconnect reload complete; watching for AuthProvider state ---');
     await expect(
       page.locator('[aria-current="true"]').or(page.getByText('My Programs')).first()
     ).toBeVisible({ timeout: 20_000 });


### PR DESCRIPTION
## Summary
- Diagnostic-only change to gather direct evidence for #533 (offline-smoke reconnect regression).
- Adds a `page.on('console', ...)` listener to surface `AuthProvider`'s existing `[AuthProvider] Auth state changed - userId: ...` debugPrint output, which nothing was previously listening to in CI.
- Adds `page.on('pageerror', ...)` to catch any uncaught JS exceptions during the reconnect reload.
- Brackets the reconnect reload with `[E2E] --- reconnect reload starting/complete ---` markers so the console output can be attributed to that specific window.

## Why
Investigation of #533 found that after the offline→reload→reconnect cycle, zero Firebase Auth network requests occur (see issue comment) — meaning `authStateChanges()` likely never fires with a user. This change surfaces the app's own auth-state logging to confirm that directly, without needing local Flutter reproduction.

## Test plan
- [ ] Let CI run `offline-smoke.spec.ts` on both projects
- [ ] Inspect `[E2E][browser-console]` and `[E2E][browser-pageerror]` lines around the reconnect reload markers
- [ ] Report findings back to #533; revert this diagnostic PR without merging once root cause is understood (not intended to merge to main as-is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)